### PR TITLE
sony-common: remove TapToWake overlay

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -185,7 +185,4 @@
          format is UMTS|LTE|... -->
     <string translatable="false" name="config_radio_access_family">GSM | WCDMA | LTE</string>
 
-    <!-- Whether device supports double tap to wake -->
-    <bool name="config_supportDoubleTapWake">true</bool>
-
 </resources>


### PR DESCRIPTION
due to only shinano and kitakami have it enabled on powerHAL and Kernel
we do not want see it on unsupported targets

Signed-off-by: David Viteri <davidteri91@gmail.com>