### PR TITLE
rhine: Fix wifi with Enforcing SELinux

### DIFF
--- a/sepolicy/init.te
+++ b/sepolicy/init.te
@@ -33,4 +33,5 @@ allow init sysfs_usb_supply:lnk_file { read getattr };
 allow init mtp_device:chr_file { getattr };
 allow init block_device:blk_file { write };
 allow init device_latency:chr_file { write };
+allow init wcnss_device:chr_file { write };
 


### PR DESCRIPTION
Avoid

03-01 18:50:37.286 W/init    (1): type=1400 audit(0.0:4): avc: denied { write } for name=wcnss_wlan dev=tmpfs ino=11360 scontext=u:r:init:s0 tcontext=u:object_r:wcnss_device:s0 tclass=chr_file permissive=0

Signed-off-by: David Viteri <davidteri91@gmail.com>