### PR TITLE
Fix touchscreen on Z4 when SELinux is enforced in 'user' build

### DIFF
--- a/sepolicy/touchfusion.te
+++ b/sepolicy/touchfusion.te
@@ -46,6 +46,4 @@ allow touchfusion cgroup:dir { create add_name };
 
 allow touchfusion self:capability { setgid setuid };
 
-userdebug_or_eng(`
 allow touchfusion self:capability { sys_nice net_admin };
-')


### PR DESCRIPTION
This fixes those denied:
[   17.038652] touch_fusion: start [/system/vendor/bin/touch_fusion] 4
[   17.038783] type=1400 audit(198323.169:3): avc:  denied  { net_admin } for  pid=478 comm="touch_fusion" capability=12  scontext=u:r:touchfusion:s0 tcontext=u:r:touchfusion:s0 tclass=capability permissive=1
[   17.042344] type=1400 audit(198323.169:4): avc:  denied  { sys_nice } for  pid=478 comm="touch_fusion" capability=23  scontext=u:r:touchfusion:s0 tcontext=u:r:touchfusion:s0 tclass=capability permissive=1

Signed-off-by: Julien Bolard <jbolard@genymobile.com>