### PR TITLE
sony-common: update file_contexts

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -41,6 +41,7 @@
 
 # WiFi MAC address
 /sys/devices/fb000000.qcom,wcnss-wlan/wcnss_mac_addr    u:object_r:sysfs_addrsetup:s0
+/sys/devices/platform/bcmdhd_wlan/macaddr               u:object_r:sysfs_addrsetup:s0
 
 # Bluetooth
 /dev/ttyHS0                                             u:object_r:hci_attach_dev:s0


### PR DESCRIPTION
this is needed for SELinux in bcmdhd devices

Signed-off-by: David Viteri <davidteri91@gmail.com>