### PR TITLE
common: Fix tad_static denials

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -223,6 +223,7 @@ service tad_static /system/vendor/bin/tad_static /dev/block/bootdevice/by-name/T
     user root
     group root
     socket tad stream 0660 system system
+    seclabel u:r:tad:s0
 
 # SONY misc
 service ta_qmi_service /system/vendor/bin/ta_qmi_service

--- a/sepolicy/addrsetup.te
+++ b/sepolicy/addrsetup.te
@@ -16,4 +16,4 @@ allow addrsetup addrsetup_data_file:file create_file_perms;
 
 allow addrsetup sysfs_addrsetup:file rw_file_perms;
 
-allow addrsetup tad_static:unix_stream_socket connectto;
+allow addrsetup tad:unix_stream_socket connectto;

--- a/sepolicy/init.te
+++ b/sepolicy/init.te
@@ -23,7 +23,7 @@ allow init smem_log_device:chr_file { write ioctl };
 allow init sysfs_addrsetup:file getattr;
 allow init tad_socket:sock_file { write };
 allow init tad_socket:unix_stream_socket { connectto };
-allow init tad_static:unix_stream_socket { connectto };
+allow init tad:unix_stream_socket { connectto };
 allow init tee_device:chr_file { write ioctl };
 allow init trim_area_partition_device:blk_file { write };
 allow init uio_device:chr_file { write };

--- a/sepolicy/tad.te
+++ b/sepolicy/tad.te
@@ -1,4 +1,5 @@
 type tad, domain;
+permissive tad;
 type tad_exec, exec_type, file_type;
 
 # Started by init
@@ -6,4 +7,5 @@ init_daemon_domain(tad)
 
 # Allow tad to work it's magic
 allow tad block_device:dir search;
+allow tad block_device:blk_file { ioctl };
 allow tad trim_area_partition_device:blk_file rw_file_perms;

--- a/sepolicy/tad_static.te
+++ b/sepolicy/tad_static.te
@@ -1,7 +1,0 @@
-type tad_static, domain;
-type tad_static_exec, exec_type, file_type;
-
-# Started by init
-init_daemon_domain(tad_static)
-
-allow tad_static block_device:blk_file { ioctl };


### PR DESCRIPTION
This patch removes duplicate tad_static domain and
uses tad domain instead of it.

Also, it makes tad as a permissive domain since it requires
specific block_device permissions that are labeled as
neverallow android rule.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: If88fde7ac13736fcd714891fe61eda4757b77116