### PR TITLE
common: sepolicy: Fix init denied

### DIFF
--- a/sepolicy/init.te
+++ b/sepolicy/init.te
@@ -34,4 +34,4 @@ allow init mtp_device:chr_file { getattr };
 allow init block_device:blk_file { write };
 allow init device_latency:chr_file { write };
 allow init wcnss_device:chr_file { write };
-
+allow init tmpfs:file { write };


### PR DESCRIPTION
<5>[   11.241711] type=1400 audit(14553972.809:4): avc:  denied  { write } for  pid=374 comm="init" name="kmsg" dev="tmpfs" ino=11268 scontext=u:r:init:s0 tcontext=u:object_r:tmpfs:s0 tclass=file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I364bed09218789e191ffbe14b3fcbd88b088d690