### PR TITLE
common: sepolicy: Fix kernel denials

### DIFF
--- a/sepolicy/kernel.te
+++ b/sepolicy/kernel.te
@@ -1,0 +1,2 @@
+allow kernel self:capability { net_admin };
+allow kernel tmpfs:file { write };


### PR DESCRIPTION
It is required for touch_fusion

<5>[   11.389866] type=1400 audit(14553972.959:5): avc:  denied  { net_admin } for  pid=375 comm="touch_fusion" capability=12  scontext=u:r:kernel:s0 tcontext=u:r:kernel:s0 tclass=capability permissive=0
<5>[   11.406476] type=1400 audit(14553972.969:6): avc:  denied  { write } for  pid=375 comm="touch_fusion" path="/dev/kmsg" dev="tmpfs" ino=11268 scontext=u:r:kernel:s0 tcontext=u:object_r:tmpfs:s0 tclass=file permissive=0
<5>[   11.425711] type=1400 audit(14553972.999:7): avc:  denied  { write } for  pid=375 comm="touch_fusion" path="/dev/kmsg" dev="tmpfs" ino=11268 scontext=u:r:kernel:s0 tcontext=u:object_r:tmpfs:s0 tclass=file permissive=0
<5>[   11.456219] type=1400 audit(14553973.029:8): avc:  denied  { write } for  pid=375 comm="touch_fusion" path="/dev/kmsg" dev="tmpfs" ino=11268 scontext=u:r:kernel:s0 tcontext=u:object_r:tmpfs:s0 tclass=file permissive=0
<5>[   11.475481] type=1400 audit(14553973.039:9): avc:  denied  { net_admin } for  pid=375 comm="touch_fusion" capability=12  scontext=u:r:kernel:s0 tcontext=u:r:kernel:s0 tclass=capability permissive=0
<5>[   11.493009] type=1400 audit(14553973.069:10): avc:  denied  { write } for  pid=375 comm="touch_fusion" path="/dev/kmsg" dev="tmpfs" ino=11268 scontext=u:r:kernel:s0 tcontext=u:object_r:tmpfs:s0 tclass=file permissive=0

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I5446902be6e75d51b343f0db25acec285a42c20d