### PR TITLE
sony-common: add ADBoverWIFI prop

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -159,6 +159,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.data.qmi.adb_logmask=0
 
+# ADBoverWIFI
+PRODUCT_PROPERTY_OVERRIDES += \
+    service.adb.tcp.port=5555
+
 # Enable MultiWindow
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.sys.debug.multi_window=true


### PR DESCRIPTION
david@david-desktop:~$ adb devices
List of devices attached
192.168.1.3:5555         device

HOW TO USE
adb connect target_ip:5555

Signed-off-by: David Viteri <davidteri91@gmail.com>