### PR TITLE
Update init.common.rc

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -390,8 +390,8 @@ on property:ro.boot.baseband=apq
     stop ril-daemon
 
 on property:ro.boot.baseband=msm
-    start qmuxd
-    start netmgrd
+    enable qmuxd
+    enable netmgrd
 
 on property:persist.radio.multisim.config=dsds
     start ril-daemon2

--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -394,7 +394,7 @@ on property:ro.boot.baseband=msm
     enable netmgrd
 
 on property:persist.radio.multisim.config=dsds
-    start ril-daemon2
+    enable ril-daemon2
 
 on property:init.svc.wpa_supplicant=stopped
     stop dhcpcd


### PR DESCRIPTION
When using full disk encryption with a password different from DEFAULT_PASSWORD, the class 'main' is started to prompt for password/pin/pattern and then it is reset. The services qmuxd and netmgrd are declared as class 'main' and 'disabled'. Because they are disabled, they need to be explicitly called to be started. When the class 'main' is reset, these services never go up again. Changing the 'start' to 'enable' solves the issue...