### PR TITLE
sony: common: sepolicy: Fix tad denials

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -1,5 +1,6 @@
 # Trim Area daemon
 /dev/socket/tad                               u:object_r:tad_socket:s0
+/dev/block/mmcblk0p1                          u:object_r:tad_block_device:s0
 
 # NFC
 /dev/pn54x                                    u:object_r:nfc_device:s0

--- a/sepolicy/tad.te
+++ b/sepolicy/tad.te
@@ -1,11 +1,12 @@
 type tad, domain;
-permissive tad;
 type tad_exec, exec_type, file_type;
+type tad_block_device, dev_type;
 
 # Started by init
 init_daemon_domain(tad)
 
 # Allow tad to work it's magic
 allow tad block_device:dir search;
-allow tad block_device:blk_file { ioctl };
+allow tad tad_block_device:dir create_dir_perms;
+allow tad tad_block_device:blk_file rw_file_perms;
 allow tad trim_area_partition_device:blk_file rw_file_perms;


### PR DESCRIPTION
Add TA block device labelled then fix tad denials for generic block_device.

According to Google the better solution here is to just add a specific
label to the block device. Allowing access to the generically
labeled "block_device" (in external/sepolicy) is dangerous.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I4e2f66e9b31c82ee4433f8531529570dd1433667