### PR TITLE
remove system_data_file due to new neverallow rule

### DIFF
--- a/sepolicy/system_app.te
+++ b/sepolicy/system_app.te
@@ -1,2 +1,1 @@
 allow system_app timekeep_prop:property_service set;
-allow system_app system_data_file:dir { add_name create setattr };


### PR DESCRIPTION
In accordance with AOSP's new system/sepolicy repo

Signed-off-by: Adam Farden <adam@farden.cz>