### PR TITLE
sony-common: Set property for dualmic fluence for voice communication

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -221,6 +221,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Fluencetype can be "fluence" or "fluencepro" or "none"
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.audio.fluence.voicecall=true \
+    persist.audio.fluence.voicecomm=true \
     persist.audio.fluence.voicerec=false \
     persist.audio.fluence.speaker=true \
     media.aac_51_output_enabled=true


### PR DESCRIPTION
needed by https://github.com/sonyxperiadev/device-sony-common/blob/master/rootdir/system/vendor/etc/audio_effects.conf#L211

Signed-off-by: David Viteri <davidteri91@gmail.com>