### PR TITLE
Allow gatekeeperd and keystore access to /firmware files

### DIFF
--- a/sepolicy/gatekeeperd.te
+++ b/sepolicy/gatekeeperd.te
@@ -1,0 +1,1 @@
+allow gatekeeperd firmware_file:file r_file_perms;

--- a/sepolicy/keystore.te
+++ b/sepolicy/keystore.te
@@ -1,0 +1,1 @@
+allow keystore firmware_file:file r_file_perms;


### PR DESCRIPTION
Fixes the following on kitakami devices

```
type=1400 audit(220125.139:3): avc: denied { read } for pid=454 comm="gatekeeperd" name="kmota.mdt" dev="mmcblk0p3" ino=28 scontext=u:r:gatekeeperd:s0 tcontext=u:object_r:firmware_file:s0 tclass=file permissive=1
type=1400 audit(220125.149:4): avc: denied { open } for pid=454 comm="gatekeeperd" path="/firmware/image/kmota.mdt" dev="mmcblk0p3" ino=28 scontext=u:r:gatekeeperd:s0 tcontext=u:object_r:firmware_file:s0 tclass=file permissive=1
type=1400 audit(220125.149:5): avc: denied { getattr } for pid=454 comm="gatekeeperd" path="/firmware/image/kmota.mdt" dev="mmcblk0p3" ino=28 scontext=u:r:gatekeeperd:s0 tcontext=u:object_r:firmware_file:s0 tclass=file permissive=1
type=1400 audit(220125.199:6): avc: denied { read } for pid=448 comm="keystore" name="keymaste.mdt" dev="mmcblk0p3" ino=33 scontext=u:r:keystore:s0 tcontext=u:object_r:firmware_file:s0 tclass=file permissive=1
type=1400 audit(220125.199:7): avc: denied { open } for pid=448 comm="keystore" path="/firmware/image/keymaste.mdt" dev="mmcblk0p3" ino=33 scontext=u:r:keystore:s0 tcontext=u:object_r:firmware_file:s0 tclass=file permissive=1
type=1400 audit(220125.199:8): avc: denied { getattr } for pid=448 comm="keystore" path="/firmware/image/keymaste.mdt" dev="mmcblk0p3" ino=33 scontext=u:r:keystore:s0 tcontext=u:object_r:firmware_file:s0 tclass=file permissive=1
```

The gatekeeperd section is already in master branch (this is only relevant to m-mr1)