### PR TITLE
sony-common: use deep buffer for music stream

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -218,13 +218,15 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     vidc.debug.level=1
 
+# Audio
 # Fluencetype can be "fluence" or "fluencepro" or "none"
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.audio.fluence.voicecall=true \
     persist.audio.fluence.voicecomm=true \
     persist.audio.fluence.voicerec=false \
     persist.audio.fluence.speaker=true \
-    media.aac_51_output_enabled=true
+    media.aac_51_output_enabled=true \
+    audio.deep_buffer.media=1
 
 # Property to enable user to access Google WFD settings.
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
https://android.googlesource.com/platform/frameworks/av/+/439e4ed408c21bd65711d279bd5251cef7e83440

DEEP_BUFFER uses very low latency and as compress_offload (which is better) it can let's help in battery life while using music streams services

Signed-off-by: David Viteri <davidteri91@gmail.com>