### PR TITLE
Revert "sony-common: add ADBoverWIFI prop"

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -160,10 +160,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.data.qmi.adb_logmask=0
 
-# ADBoverWIFI
-PRODUCT_PROPERTY_OVERRIDES += \
-    service.adb.tcp.port=5555
-
 # Enable MultiWindow
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.sys.debug.multi_window=true


### PR DESCRIPTION
This commit make adb over wifi persist over reboot , even when disabled in developers option.
Not needed for average users, can be enabled by editing build.prop.