### PR TITLE
sony-common: remove double white spaces

### DIFF
--- a/rootdir/system/vendor/etc/audio_effects.conf
+++ b/rootdir/system/vendor/etc/audio_effects.conf
@@ -63,20 +63,20 @@ effects {
 # Proxy implementation
   #effectname {
     #library proxy
-    #uuid  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    #uuid xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
     # SW implemetation of the effect. Added as a node under the proxy to
     # indicate this as a sub effect.
       #libsw {
          #library libSW
-         #uuid  yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
+         #uuid yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
       #} End of SW effect
 
     # HW implementation of the effect. Added as a node under the proxy to
     # indicate this as a sub effect.
       #libhw {
          #library libHW
-         #uuid  zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz
+         #uuid zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz
       #}End of HW effect
   #} End of effect proxy
 
@@ -188,7 +188,7 @@ effects {
 
     libsw {
       library visualizer_sw
-      uuid  d069d9e0-8329-11df-9168-0002a5d5c51b
+      uuid d069d9e0-8329-11df-9168-0002a5d5c51b
     }
 
     libhw {


### PR DESCRIPTION
Signed-off-by: David Viteri <davidteri91@gmail.com>