### PR TITLE
Revert "sony-common: enable video offload"

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -228,10 +228,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     media.aac_51_output_enabled=true \
     audio.deep_buffer.media=1
 
-# Media
-PRODUCT_PROPERTY_OVERRIDES += \
-    audio.offload.video=1
-
 # Property to enable user to access Google WFD settings.
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.debug.wfd.enable=1


### PR DESCRIPTION
Reverts sonyxperiadev/device-sony-common#45

If its enabled video playback on chrome is broken on html5 videos 
It stutters all the time here 
It happens on all shinano devices