### PR TITLE
sony-common: move out InCallUI

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -136,7 +136,6 @@ PRODUCT_PACKAGES += \
 
 # AOSP Packages
 PRODUCT_PACKAGES += \
-    InCallUI \
     Launcher3
 
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
This is a package for telephony targets ... not needed to be included in windy devices

Signed-off-by: David Viteri <davidteri91@gmail.com>