### PR TITLE
Add Kitakami fingerprint HAL

### DIFF
--- a/fingerprint/Android.mk
+++ b/fingerprint/Android.mk
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2016 Shane Francis / Jens Andersen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ifeq ($(filter-out satsuki sumire suzuran,$(TARGET_DEVICE)),)
+LOCAL_PATH:= $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := fingerprint.$(TARGET_DEVICE)
+LOCAL_MODULE_RELATIVE_PATH := hw
+LOCAL_SRC_FILES := fingerprint.c \
+		   QSEEComFunc.c \
+		   fpc_imp.c
+
+LOCAL_CFLAGS += -std=c99
+LOCAL_SHARED_LIBRARIES := liblog \
+			libdl \
+			libutils
+LOCAL_MODULE_TAGS := optional
+
+include $(BUILD_SHARED_LIBRARY)
+endif

--- a/fingerprint/QSEEComAPI.h
+++ b/fingerprint/QSEEComAPI.h
@@ -1,0 +1,299 @@
+/*
+ *  Copyright (c) 2012, The Android Open Source Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you
+ *  may not use this file except in compliance with the License.  You may
+ *  obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+#ifndef __QSEECOMAPI_H_
+#define __QSEECOMAPI_H_
+
+
+/*----------------------------------------------------------------------------
+ * Include Files
+* -------------------------------------------------------------------------*/
+#include <stdint.h>
+#include <stdbool.h>
+
+#define QSEECOM_ALIGN_SIZE	0x40
+#define QSEECOM_ALIGN_MASK	(QSEECOM_ALIGN_SIZE - 1)
+#define QSEECOM_ALIGN(x)	\
+	((x + QSEECOM_ALIGN_SIZE) & (~QSEECOM_ALIGN_MASK))
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*----------------------------------------------------------------------------
+ * Preprocessor Definitions and Constants
+ * -------------------------------------------------------------------------*/
+/** The memory is locked and non-pageable */
+#define MEM_LOCKED         0x00000001
+/** The memory is marked non-cacheable */
+#define MEM_NON_CACHED     0x00000002
+
+#define QSEECOM_APP_QUERY_FAILED       -6
+#define QSEECOM_APP_NOT_LOADED         -5
+#define QSEECOM_APP_ALREADY_LOADED     -4
+#define QSEECOM_LISTENER_UNREGISTERED	-3
+#define QSEECOM_LISTENER_ALREADY_REGISTERED	-2
+#define QSEECOM_LISTENER_REGISTER_FAIL		-1
+
+/*----------------------------------------------------------------------------
+ * Type Declarations
+ * -------------------------------------------------------------------------*/
+struct QSEECom_handle {
+	unsigned char *ion_sbuffer;
+};
+
+struct QSEECom_ion_fd_data {
+	int32_t fd;
+	uint32_t cmd_buf_offset;
+};
+
+struct QSEECom_ion_fd_info {
+	struct QSEECom_ion_fd_data data[4];
+};
+
+/*----------------------------------------------------------------------------
+ * Function Declarations and Documentation
+ * -------------------------------------------------------------------------*/
+/**
+ * @brief Open a handle to the  QSEECom device.
+ *
+ * - Load a secure application. The application will be verified that it is
+ *    secure by digital signature verification.
+ * Allocate memory for sending requests to the QSAPP
+ *
+ * Note/Comments:
+ * There is a one-to-one relation for a HLOS client and a QSAPP;
+ * meaning that only one app can communicate to a QSAPP at a time.
+ *
+ * Please note that there is difference between an application and a listener
+ * service. A QSAPP must be loaded at the request of the HLOS,
+ * and all requests are orginated by the HLOS client.
+ * A listener service on the otherhand is started during start-up by a
+ * daemon, qseecomd.
+ *
+ * A HLOS application may create mutiple handles to the QSAPP
+ *
+ * @param[in/out] handle The device handle
+ * @param[in] fname The directory and filename to load.
+ * @param[in] sb_size Size of the shared buffer memory  for sending requests.
+ * @return Zero on success, negative on failure. errno will be set on
+ *  error.
+ */
+int QSEECom_start_app(struct QSEECom_handle **clnt_handle, const char *path,
+			const char *fname, uint32_t sb_size);
+
+/**
+ * @brief Close the application associated with the handle.
+ *
+ * - Unload a secure application. The driver will verify if there exists
+ *   any other applications that are communicating with the QSAPP to which
+ *   the "handle" is tied.
+ * - De-allocate memory for sending requests to QSAPP.
+ *
+ * @param[in] handle The device handle
+ * @return Zero on success, negative on failure. errno will be set on
+ *  error.
+ */
+int QSEECom_shutdown_app(struct QSEECom_handle **handle);
+
+/**
+ * @brief Open a handle to the  QSEECom device.
+ *
+ * - Load an external elf. The elf will be verified that it is
+ *    secure by digital signature verification.
+ *
+ * A HLOS application may create mutiple opens (only one is permitted for the
+ * app, but each listener service can open a unique device in the same HLOS app
+ * /executable.
+ * @param[in/out] handle The device handle
+ * @param[in] fname The directory and filename to load.
+ * @return Zero on success, negative on failure. errno will be set on
+ *  error.
+ */
+int QSEECom_load_external_elf(struct QSEECom_handle **clnt_handle, const char *path,
+			const char *fname);
+
+/**
+ * @brief Close the external elf
+ *
+ * - Unload an external elf.
+ *
+ * @param[in] handle The device handle
+ *
+ * @return Zero on success, negative on failure. errno will be set on
+ *  error.
+ */
+int QSEECom_unload_external_elf(struct QSEECom_handle **handle);
+
+/**
+ * @brief Register an HLOS listener service. This allows messages from QSAPP
+ * to be received.
+ *
+ * @param[in] handle The device handle
+ * @param[in] lstnr_id The listener service identifier. This ID must be uniquely
+ * assigned to avoid any collisions.
+ * @param[in] sb_length Shared memory buffer between OS and QSE.
+ * @param[in] flags Provide the shared memory flags attributes.
+ *
+ * @return Zero on success, negative on failure. errno will be set on
+ *  error.
+ *
+ */
+int QSEECom_register_listener(struct QSEECom_handle **handle,
+			uint32_t lstnr_id, uint32_t sb_length, uint32_t flags);
+
+/**
+ * @brief Unregister a listener service.
+ *
+ * @param[in] handle The device handle
+ *
+ * @return Zero on success, negative on failure. errno will be set on
+ *  error.
+ */
+int QSEECom_unregister_listener(struct QSEECom_handle *handle);
+
+
+/**
+ * @brief Send QSAPP a "user" defined buffer (may contain some message/
+ * command request) and receives a response from QSAPP in receive buffer.
+ * The HLOS client writes to the send_buf, where QSAPP writes to the rcv_buf.
+ * This is a blocking call.
+ *
+ * @param[in] handle    The device handle
+ * @param[in] send_buf  The buffer to be sent.
+ *                      If using ion_sbuffer, ensure this
+ *                      QSEECOM_BUFFER_ALIGN'ed.
+ * @param[in] sbuf_len  The send buffer length
+ *                      If using ion_sbuffer, ensure length is
+ *                      multiple of QSEECOM_BUFFER_ALIGN.
+ * @param[in] rcv_buf   The QSEOS returned buffer.
+ *                      If using ion_sbuffer, ensure this is
+ *                      QSEECOM_BUFFER_ALIGN'ed.
+ * @param[in] rbuf_len  The returned buffer length.
+ *                      If using ion_sbuffer, ensure length is
+ *                      multiple of QSEECOM_BUFFER_ALIGN.
+ * @param[in] rbuf_len  The returned buffer length.
+ *
+ * @return Zero on success, negative on failure. errno will be set on
+ *  error.
+ */
+int QSEECom_send_cmd(struct QSEECom_handle *handle, void *send_buf,
+			uint32_t sbuf_len, void *rcv_buf, uint32_t rbuf_len);
+
+
+/**
+ * @brief Send QSAPP a "user" defined buffer (may contain some message/
+ * command request) and receives a response from QSAPP in receive buffer.
+ * This API is same as send_cmd except it takes in addition parameter,
+ * "ifd_data".  This "ifd_data" holds information (ion fd handle and
+ * cmd_buf_offset) used for modifying data in the message in send_buf
+ * at an offset.  Essentailly, it has the ion fd handle information to
+ * retrieve physical address and modify the message in send_buf at the
+ * mentioned offset.
+ *
+ * The HLOS client writes to the send_buf, where QSAPP writes to the rcv_buf.
+ * This is a blocking call.
+ *
+ * @param[in] handle    The device handle
+ * @param[in] send_buf  The buffer to be sent.
+ *                      If using ion_sbuffer, ensure this
+ *                      QSEECOM_BUFFER_ALIGN'ed.
+ * @param[in] sbuf_len  The send buffer length
+ *                      If using ion_sbuffer, ensure length is
+ *                      multiple of QSEECOM_BUFFER_ALIGN.
+ * @param[in] rcv_buf   The QSEOS returned buffer.
+ *                      If using ion_sbuffer, ensure this is
+ *                      QSEECOM_BUFFER_ALIGN'ed.
+ * @param[in] rbuf_len  The returned buffer length.
+ *                      If using ion_sbuffer, ensure length is
+ *                      multiple of QSEECOM_BUFFER_ALIGN.
+ * @param[in] QSEECom_ion_fd_info  data related to memory allocated by ion.
+ *
+ * @return Zero on success, negative on failure. errno will be set on
+ *  error.
+ */
+int QSEECom_send_modified_cmd(struct QSEECom_handle *handle, void *send_buf,
+			uint32_t sbuf_len, void *resp_buf, uint32_t rbuf_len,
+			struct QSEECom_ion_fd_info  *ifd_data);
+
+/**
+ * @brief Receive a service defined buffer.
+ *
+ * @param[in] handle    The device handle
+ * @param[out] buf      The buffer that is received
+ * @param[in] len       The receive buffer length
+ *
+ * @return Zero on success, negative on failure. errno will be set on
+ *  error.
+ */
+int QSEECom_receive_req(struct QSEECom_handle *handle,
+			void *buf, uint32_t len);
+
+/**
+ * @brief Send a response based on the previous QSEECom_receive_req.
+ *
+ * This allows a listener service to receive a command (e.g. read file abc).
+ * The service can then handle the request from QSEECom_receive_req, and provide
+ * that information back to QSAPP.
+ *
+ * This allows the HLOS to act as the server and QSAPP to behave as the client.
+ *
+ * @param[in] handle    The device handle
+ * @param[out] send_buf  The buffer to be returned back to QSAPP
+ * @param[in] len       The send buffer length
+ *
+ * @return Zero on success, negative on failure. errno will be set on
+ *  error.
+ */
+int QSEECom_send_resp(struct QSEECom_handle *handle,
+			void *send_buf, uint32_t len);
+
+/**
+ * @brief Set the bandwidth for QSEE.
+ *
+ * This API resulst in improving the performance on the Crypto hardware
+ * in QSEE. It should be called before issuing send_cmd/send_modified_cmd
+ * for commands that requires using the crypto hardware on the QSEE.
+ * Typically this API should be called before issuing the send request to
+ * enable high performance mode and after completion of the send_cmd to
+ * resume to low performance and hence to low power mode.
+ *
+ * This allows the clients of QSEECom to set the QSEE cyptpo HW bus
+ * bandwidth to high/low.
+ *
+ * @param[in] high    Set to 1 to enable bandwidth.
+ *
+ * @return Zero on success, negative on failure. errno will be set on
+ *  error.
+ */
+int QSEECom_set_bandwidth(struct QSEECom_handle *handle, bool high);
+
+/**
+ * @brief Query QSEE to check if app is loaded.
+ *
+ * This API queries QSEE to see if the app is loaded or not.
+ *
+ * @param[in] app_name  Name of the app.
+ *
+ * @return QSEECOM_APP_QUERY_FAILED/QSEECOM_APP_NOT_LOADED/QSEECOM_APP_LOADED.
+ */
+int QSEECom_app_load_query(struct QSEECom_handle *handle, char *app_name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/fingerprint/QSEEComFunc.c
+++ b/fingerprint/QSEEComFunc.c
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2016 Shane Francis / Jens Andersen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "QSEEComFunc.h"
+
+#define LOG_TAG "QSEE_WRAPPER"
+#define LOG_NDEBUG 0
+
+//#define USE_QSEE_WRAPPER 1
+
+#include <cutils/log.h>
+
+int open_handle()
+{
+
+#ifdef USE_QSEE_WRAPPER
+    printf("Open Target Lib : libDSEEComAPI\n");
+    mLibHandle = dlopen("libDSEEComAPI.so", RTLD_NOW);
+#else
+    printf("Open Target Lib : libQSEEComAPI\n");
+    mLibHandle = dlopen("libQSEEComAPI.so", RTLD_NOW);
+#endif
+
+    if (!mLibHandle) {
+        printf("Failed to initialize QSEECom API library\n");
+        return -1;
+    } else {
+        printf("Initialized QSEECom API library\n");
+
+        bool hasError = false;
+
+        mStartApp = (start_app_fn) dlsym(mLibHandle, "QSEECom_start_app");
+
+        if (!mStartApp) {
+            printf("Failed to initialize QSEECom_start_app API function\n");
+            hasError = true;
+        }
+
+        mStopApp = (shutdown_app_fn) dlsym(mLibHandle, "QSEECom_shutdown_app");
+
+        if (!mStopApp) {
+            printf("Failed to initialize QSEECom_shutdown_app API function");
+            hasError = true;
+        }
+
+        load_external_elf_fn = (load_external_elf) dlsym(mLibHandle, "QSEECom_load_external_elf");
+
+        if (!load_external_elf_fn) {
+            printf("Failed to initialize QSEECom_load_external_elf API function\n");
+            hasError = true;
+        }
+
+        unload_external_elf_fn = (unload_external_elf) dlsym(mLibHandle, "QSEECom_unload_external_elf");
+
+        if (!unload_external_elf_fn) {
+            printf("Failed to initialize QSEECom_unload_external_elf API function\n");
+            hasError = true;
+        }
+
+        register_listener_fn = (register_listener) dlsym(mLibHandle, "QSEECom_register_listener");
+
+        if (!register_listener_fn) {
+            printf("Failed to initialize QSEECom_register_listener API function\n");
+            hasError = true;
+        }
+
+        unregister_listener_fn = (unregister_listener) dlsym(mLibHandle, "QSEECom_unregister_listener");
+
+        if (!unregister_listener_fn) {
+            printf("Failed to initialize QSEECom_unregister_listener API function\n");
+            hasError = true;
+        }
+
+        send_cmd_fn = (send_cmd) dlsym(mLibHandle, "QSEECom_send_cmd");
+
+        if (!send_cmd_fn) {
+            printf("Failed to initialize QSEECom_send_cmd API function\n");
+            hasError = true;
+        }
+
+        send_modified_cmd_fn = (send_modified_cmd) dlsym(mLibHandle, "QSEECom_send_modified_cmd");
+
+        if (!send_modified_cmd_fn) {
+            printf("Failed to initialize QSEECom_send_modified_cmd API function\n");
+            hasError = true;
+        }
+
+        receive_req_fn = (receive_req) dlsym(mLibHandle, "QSEECom_receive_req");
+
+        if (!receive_req_fn) {
+            printf("Failed to initialize QSEECom_receive_req API function\n");
+            hasError = true;
+        }
+
+        send_resp_fn = (send_resp) dlsym(mLibHandle, "QSEECom_send_resp");
+
+        if (!send_resp_fn) {
+            printf("Failed to initialize QSEECom_send_resp API function\n");
+            hasError = true;
+        }
+
+        set_bandwidth_fn = (set_bandwidth) dlsym(mLibHandle, "QSEECom_set_bandwidth");
+
+        if (!set_bandwidth_fn) {
+            printf("Failed to initialize QSEECom_set_bandwidth API function\n");
+            hasError = true;
+        }
+
+        app_load_query_fn = (app_load_query) dlsym(mLibHandle, "QSEECom_app_load_query");
+
+        if (!app_load_query_fn) {
+            printf("Failed to initialize QSEECom_app_load_query API function\n");
+            hasError = true;
+        }
+
+
+        if (hasError) {
+            printf("Close Target Lib : libQSEEComAPI\n");
+            dlclose(mLibHandle);
+            mLibHandle = NULL;
+            return -1;
+        }
+
+    }
+
+    return 1;
+}
+
+
+int32_t qcom_km_ION_memalloc(struct qcom_km_ion_info_t *handle,
+                             uint32_t size)
+{
+    int32_t ret = 0;
+    int32_t iret = 0;
+    int32_t fd = 0;
+    unsigned char *v_addr;
+    struct ion_allocation_data ion_alloc_data;
+    int32_t ion_fd;
+    int32_t rc;
+    struct ion_fd_data ifd_data;
+    struct ion_handle_data handle_data;
+    /* open ION device for memory management
+     * O_DSYNC -> uncached memory
+    */
+    if(handle == NULL) {
+        ALOGE("Error:: null handle received");
+        return -1;
+    }
+    ion_fd  = open("/dev/ion", O_RDONLY | O_DSYNC);
+    if (ion_fd < 0) {
+        ALOGE("Error::Cannot open ION device");
+        return -1;
+    }
+    handle->ion_sbuffer = NULL;
+    handle->ifd_data_fd = 0;
+    /* Size of allocation */
+    ion_alloc_data.len = (size + 4095) & (~4095);
+    /* 4K aligned */
+    ion_alloc_data.align = 4096;
+    /* memory is allocated from EBI heap */
+    ion_alloc_data.heap_id_mask = ION_HEAP(ION_QSECOM_HEAP_ID);
+    /* Set the memory to be uncached */
+    ion_alloc_data.flags = 0;
+    /* IOCTL call to ION for memory request */
+    rc = ioctl(ion_fd, ION_IOC_ALLOC, &ion_alloc_data);
+    if (rc) {
+        ret = -1;
+        goto alloc_fail;
+    }
+
+    ifd_data.handle = ion_alloc_data.handle;
+
+    /* Call MAP ioctl to retrieve the ifd_data.fd file descriptor */
+    rc = ioctl(ion_fd, ION_IOC_MAP, &ifd_data);
+    if (rc) {
+        ret = -1;
+        goto ioctl_fail;
+    }
+    /* Make the ion mmap call */
+    v_addr = (unsigned char *)mmap(NULL, ion_alloc_data.len,
+                                   PROT_READ | PROT_WRITE,
+                                   MAP_SHARED, ifd_data.fd, 0);
+    if (v_addr == MAP_FAILED) {
+        ALOGE("Error::ION MMAP failed");
+        ret = -1;
+        goto map_fail;
+    }
+    handle->ion_fd = ion_fd;
+    handle->ifd_data_fd = ifd_data.fd;
+    handle->ion_sbuffer = v_addr;
+    handle->ion_alloc_handle.handle = ion_alloc_data.handle;
+    handle->sbuf_len = size;
+    return ret;
+map_fail:
+    if (handle->ion_sbuffer != NULL) {
+        iret = munmap(handle->ion_sbuffer, ion_alloc_data.len);
+        if (iret)
+            ALOGE("Error::Failed to unmap memory for load image. ret = %d", ret);
+    }
+ioctl_fail:
+    handle_data.handle = ion_alloc_data.handle;
+    if (handle->ifd_data_fd)
+        close(handle->ifd_data_fd);
+    iret = ioctl(ion_fd, ION_IOC_FREE, &handle_data);
+    if (iret) {
+        ALOGE("Error::ION FREE ioctl returned error = %d",iret);
+    }
+alloc_fail:
+    if (ion_fd > 0)
+        close(ion_fd);
+    return ret;
+}
+
+
+int32_t qcom_km_ion_dealloc(struct qcom_km_ion_info_t *handle)
+{
+    struct ion_handle_data handle_data;
+    int32_t ret = 0;
+    /* Deallocate the memory for the listener */
+    ret = munmap(handle->ion_sbuffer, (handle->sbuf_len + 4095) & (~4095));
+    if (ret) {
+        ALOGE("Error::Unmapping ION Buffer failed with ret = %d", ret);
+    }
+    handle_data.handle = handle->ion_alloc_handle.handle;
+    close(handle->ifd_data_fd);
+    ret = ioctl(handle->ion_fd, ION_IOC_FREE, &handle_data);
+    if (ret) {
+        ALOGE("Error::ION Memory FREE ioctl failed with ret = %d", ret);
+    }
+    close(handle->ion_fd);
+    return ret;
+}

--- a/fingerprint/QSEEComFunc.h
+++ b/fingerprint/QSEEComFunc.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016 Shane Francis / Jens Andersen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __QSEECOMFUNC_H_
+#define __QSEECOMFUNC_H_
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <linux/ioctl.h>
+#include <sys/mman.h>
+#include <fcntl.h> // open function
+#include <unistd.h> // close function
+#include <linux/msm_ion.h>
+#include "QSEEComAPI.h"
+
+typedef int (*start_app_fn)(struct QSEECom_handle **clnt_handle, const char *path, const char *fname, uint32_t sb_size);
+typedef int (*shutdown_app_fn)(struct QSEECom_handle **clnt_handle);
+typedef int (*load_external_elf)(struct QSEECom_handle **clnt_handle, const char *path,  const char *fname);
+typedef int (*unload_external_elf)(struct QSEECom_handle **handle);
+typedef int (*register_listener)(struct QSEECom_handle **handle, uint32_t lstnr_id, uint32_t sb_length, uint32_t flags);
+typedef int (*unregister_listener)(struct QSEECom_handle *handle);
+typedef int (*send_cmd)(struct QSEECom_handle *handle, void *send_buf, uint32_t sbuf_len, void *rcv_buf, uint32_t rbuf_len);
+typedef int (*send_modified_cmd)(struct QSEECom_handle *handle, void *send_buf, uint32_t sbuf_len, void *resp_buf, uint32_t rbuf_len, struct QSEECom_ion_fd_info  *ifd_data);
+typedef int (*receive_req)(struct QSEECom_handle *handle, void *buf, uint32_t len);
+typedef int (*send_resp)(struct QSEECom_handle *handle, void *send_buf, uint32_t len);
+typedef int (*set_bandwidth)(struct QSEECom_handle *handle, bool high);
+typedef int (*app_load_query)(struct QSEECom_handle *handle, char *app_name);
+
+// DLSYM function pointers
+start_app_fn mStartApp;
+shutdown_app_fn mStopApp;
+load_external_elf load_external_elf_fn;
+unload_external_elf unload_external_elf_fn;
+register_listener register_listener_fn;
+unregister_listener unregister_listener_fn;
+send_cmd send_cmd_fn;
+send_modified_cmd send_modified_cmd_fn;
+receive_req receive_req_fn;
+send_resp send_resp_fn;
+set_bandwidth set_bandwidth_fn;
+app_load_query app_load_query_fn;
+
+struct qcom_km_ion_info_t {
+    int32_t ion_fd;
+    int32_t ifd_data_fd;
+    struct ion_handle_data ion_alloc_handle;
+    unsigned char * ion_sbuffer;
+    uint32_t sbuf_len;
+};
+
+static void *mLibHandle = NULL;
+
+int open_handle();
+
+int32_t qcom_km_ion_dealloc(struct qcom_km_ion_info_t *handle);
+int32_t qcom_km_ION_memalloc(struct qcom_km_ion_info_t *handle, uint32_t size);
+
+#endif

--- a/fingerprint/README.md
+++ b/fingerprint/README.md
@@ -1,0 +1,29 @@
+# Sony Kitakami Fingerprint HAL #
+
+This is an open android HAL to enable the use for the fingerprint authentication sensor on the sony Kitakami platform.
+It makes use of the TrustZone (TZ) fingerprint application via the QSEECOM API (documented here https://android.googlesource.com/platform/hardware/qcom/keymaster/+/android-6.0.1_r26/QSEEComAPI.h)
+
+## Overview ##
+
+* This was based around the OnePlus Two TrustZone fingerprint HAL (found here https://github.com/CyanogenMod/android_device_oneplus_oneplus2/blob/cm-13.0/fingerprint)
+* Extra information was obtained from the Nexus 6P (angler kernel driver) (found here https://android.googlesource.com/kernel/msm/+/3d0a564505ab8452e7e6f52b972db386cc2f5f69)
+* Protocol informations was verified as it passed through the QSEECOM API to linux kernel
+
+
+## License ##
+
+Copyright (C) 2016 Shane Francis / Jens Andersen
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+ 

--- a/fingerprint/fingerprint.c
+++ b/fingerprint/fingerprint.c
@@ -43,7 +43,7 @@ void *enroll_thread_loop()
     int status = 1;
 
     while((status = fpc_capture_image()) >= 0) {
-        ALOGI("%s : Got Input", __func__);
+        ALOGD("%s : Got Input", __func__);
 
         if (status <= FINGERPRINT_ACQUIRED_TOO_FAST) {
             fingerprint_msg_t msg;
@@ -115,7 +115,7 @@ void *auth_thread_loop()
     int status = 1;
 
     while((status = fpc_capture_image()) >= 0) {
-        ALOGI("%s : Got Input", __func__);
+        ALOGD("%s : Got Input", __func__);
 
         if (status <= FINGERPRINT_ACQUIRED_TOO_FAST) {
             fingerprint_msg_t msg;

--- a/fingerprint/fingerprint.c
+++ b/fingerprint/fingerprint.c
@@ -1,0 +1,413 @@
+/*
+ * Copyright (C) 2016 Shane Francis / Jens Andersen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG "AOSP FPC HAL"
+
+#include <errno.h>
+#include <malloc.h>
+#include <string.h>
+#include <cutils/log.h>
+#include <hardware/hardware.h>
+#include <hardware/fingerprint.h>
+#include <pthread.h>
+#include "fpc_imp.h"
+
+
+uint64_t challenge = NULL;
+bool auth_thread_running = false;
+
+pthread_t thread;
+pthread_mutex_t lock;
+
+fingerprint_notify_t callback;
+char db_path[255];
+
+void *enroll_thread_loop()
+{
+    ALOGI("%s", __func__);
+    fpc_enroll_start(1);
+
+    int status = 1;
+
+    while((status = fpc_capture_image()) >= 0) {
+        ALOGI("%s : Got Input", __func__);
+
+        if (status <= FINGERPRINT_ACQUIRED_TOO_FAST) {
+            fingerprint_msg_t msg;
+            msg.type = FINGERPRINT_ACQUIRED;
+            msg.data.acquired.acquired_info = status;
+            callback(&msg);
+        }
+
+        //image captured
+        if (status == FINGERPRINT_ACQUIRED_GOOD) {
+            ALOGI("%s : Enroll Step", __func__);
+            if (fpc_enroll_step() < 100) {
+                int remaining_touches = fpc_get_remaining_touches();
+                ALOGI("%s : Touches Remaining : %d", __func__, remaining_touches);
+                if (remaining_touches > 0) {
+                    fingerprint_msg_t msg;
+                    msg.type = FINGERPRINT_TEMPLATE_ENROLLING;
+                    msg.data.enroll.finger.fid = 0;
+                    msg.data.enroll.finger.gid = 0;
+                    msg.data.enroll.samples_remaining = remaining_touches;
+                    msg.data.enroll.msg = 0;
+                    callback(&msg);
+                }
+            } else {
+                int print_index = fpc_enroll_end();
+                ALOGI("%s : Got print index : %d", __func__,print_index);
+
+                uint32_t db_length = fpc_get_user_db_length();
+                ALOGI("%s : User Database Length Is : %lu", __func__,(unsigned long) db_length);
+                fpc_store_user_db(db_length, db_path);
+
+                uint32_t print_id = fpc_get_print_id(print_index);
+                ALOGI("%s : Got print id : %lu", __func__,(unsigned long) print_id);
+
+                fingerprint_msg_t msg;
+                msg.type = FINGERPRINT_TEMPLATE_ENROLLING;
+                msg.data.enroll.finger.fid = print_id;
+                msg.data.enroll.finger.gid = 0;
+                msg.data.enroll.samples_remaining = 0;
+                msg.data.enroll.msg = 0;
+                callback(&msg);
+                break;
+            }
+        }
+
+        pthread_mutex_lock(&lock);
+        if (!auth_thread_running) {
+            pthread_mutex_unlock(&lock);
+            break;
+        }
+        pthread_mutex_unlock(&lock);
+    }
+
+    fpc_enroll_end();
+    ALOGI("%s : finishing",__func__);
+
+    pthread_mutex_lock(&lock);
+    auth_thread_running = false;
+    pthread_mutex_unlock(&lock);
+    return NULL;
+}
+
+
+void *auth_thread_loop()
+{
+    ALOGI("%s", __func__);
+    fpc_auth_start();
+
+    int status = 1;
+
+    while((status = fpc_capture_image()) >= 0) {
+        ALOGI("%s : Got Input", __func__);
+
+        if (status <= FINGERPRINT_ACQUIRED_TOO_FAST) {
+            fingerprint_msg_t msg;
+            msg.type = FINGERPRINT_ACQUIRED;
+            msg.data.acquired.acquired_info = status;
+            callback(&msg);
+        }
+
+        if (status == FINGERPRINT_ACQUIRED_GOOD) {
+
+            int verify_state = fpc_auth_step();
+            ALOGI("%s : Auth step = %d", __func__, verify_state);
+
+            if (verify_state >= 0) {
+
+                uint32_t print_id = fpc_get_print_id(verify_state);
+                ALOGI("%s : Got print id : %lu", __func__, (unsigned long) print_id);
+
+                hw_auth_token_t hat;
+                fpc_get_hw_auth_obj(&hat, sizeof(hw_auth_token_t));
+
+                ALOGI("%s : hat->challange %lu",__func__,(unsigned long) hat.challenge);
+                ALOGI("%s : hat->user_id %lu",__func__,(unsigned long) hat.user_id);
+                ALOGI("%s : hat->authenticator_id %lu",__func__,(unsigned long) hat.authenticator_id);
+                ALOGI("%s : hat->authenticator_type %d",__func__, hat.authenticator_type);
+                ALOGI("%s : hat->timestamp %lu",__func__,(unsigned long) hat.timestamp);
+                ALOGI("%s : hat size %lu",__func__,(unsigned long) sizeof(hw_auth_token_t));
+
+                fingerprint_msg_t msg;
+                msg.type = FINGERPRINT_AUTHENTICATED;
+                msg.data.authenticated.finger.gid = 0;
+                msg.data.authenticated.finger.fid = print_id;
+
+                msg.data.authenticated.hat = hat;
+
+                callback(&msg);
+                break;
+            }
+        }
+
+        pthread_mutex_lock(&lock);
+        if (!auth_thread_running) {
+            pthread_mutex_unlock(&lock);
+            break;
+        }
+        pthread_mutex_unlock(&lock);
+    }
+
+    fpc_auth_end();
+    ALOGI("%s : finishing",__func__);
+
+    pthread_mutex_lock(&lock);
+    auth_thread_running = false;
+    pthread_mutex_unlock(&lock);
+    return NULL;
+}
+
+static int fingerprint_close(hw_device_t *dev)
+{
+    fpc_close();
+    if (dev) {
+        free(dev);
+        return 0;
+    } else {
+        return -1;
+    }
+}
+
+static uint64_t fingerprint_pre_enroll(struct fingerprint_device __unused *dev)
+{
+    challenge = fpc_load_auth_challange();
+    ALOGI("%s : Challange is : %jd",__func__,challenge);
+    return challenge;
+}
+
+static int fingerprint_enroll(struct fingerprint_device __unused *dev,
+                              const hw_auth_token_t __unused *hat,
+                              uint32_t __unused gid,
+                              uint32_t __unused timeout_sec)
+{
+
+
+    pthread_mutex_lock(&lock);
+    bool thread_running = auth_thread_running;
+    pthread_mutex_unlock(&lock);
+
+    if (thread_running) {
+        ALOGE("%s : Error, thread already running\n", __func__);
+        return -1;
+    }
+
+
+    ALOGI("%s : hat->challange %lu",__func__,(unsigned long) hat->challenge);
+    ALOGI("%s : hat->user_id %lu",__func__,(unsigned long) hat->user_id);
+    ALOGI("%s : hat->authenticator_id %lu",__func__,(unsigned long) hat->authenticator_id);
+    ALOGI("%s : hat->authenticator_type %d",__func__,hat->authenticator_type);
+    ALOGI("%s : hat->timestamp %lu",__func__,(unsigned long) hat->timestamp);
+    ALOGI("%s : hat size %lu",__func__,(unsigned long) sizeof(hw_auth_token_t));
+
+    fpc_verify_auth_challange((void*) hat, sizeof(hw_auth_token_t));
+
+    pthread_mutex_lock(&lock);
+    auth_thread_running = true;
+    pthread_mutex_unlock(&lock);
+
+    if(pthread_create(&thread, NULL, enroll_thread_loop, NULL)) {
+        ALOGE("%s : Error creating thread\n", __func__);
+        auth_thread_running = false;
+        return FINGERPRINT_ERROR;
+    }
+
+    return 0;
+
+}
+
+static uint64_t fingerprint_get_auth_id(struct fingerprint_device __unused *dev)
+{
+
+    uint64_t id = fpc_load_db_id();
+    ALOGI("%s : ID : %jd",__func__,id );
+    return id;
+
+}
+
+static int fingerprint_cancel(struct fingerprint_device __unused *dev)
+{
+    ALOGI("%s : +",__func__);
+
+    pthread_mutex_lock(&lock);
+    bool thread_running = auth_thread_running;
+    pthread_mutex_unlock(&lock);
+
+    ALOGI("%s : check thread running",__func__);
+    if (!auth_thread_running) {
+        ALOGI("%s : - (thread not running)",__func__);
+        return 0;
+    }
+
+    pthread_mutex_lock(&lock);
+    auth_thread_running = false;
+    pthread_mutex_unlock(&lock);
+
+    ALOGI("%s : join running thread",__func__);
+    pthread_join(thread, NULL);
+
+    ALOGI("%s : -",__func__);
+    return 0;
+}
+
+static int fingerprint_remove(struct fingerprint_device __unused *dev,
+                              uint32_t __unused gid, uint32_t __unused fid)
+{
+
+    //Maximum prints per gid is 5
+    uint32_t prints[5];
+    uint32_t print_count = fpc_get_print_count();
+
+    fpc_get_pint_index_cmd_t print_indexs = fpc_get_print_index(print_count);
+
+    //populate print array with index
+    prints[0] = print_indexs.p1;
+    prints[1] = print_indexs.p2;
+    prints[2] = print_indexs.p3;
+    prints[3] = print_indexs.p4;
+    prints[4] = print_indexs.p5;
+
+    ALOGI("%s : delete print : %lu", __func__,(unsigned long) fid);
+
+    for (int i = 0; i < 5; i++){
+        uint32_t print_id = fpc_get_print_id(prints[i]);
+
+        ALOGI("%s : found print : %lu at index %d", __func__,(unsigned long) print_id, i);
+
+        if (print_id == fid){
+            ALOGI("%s : Print index found at : %d", __func__, i);
+
+            int ret = fpc_del_print_id(prints[i]);
+
+            ALOGI("%s : fpc_del_print_id returns : %d", __func__, ret);
+
+            if (ret == 0){
+
+                uint32_t db_length = fpc_get_user_db_length();
+                ALOGI("%s : User Database Length Is : %lu", __func__,(unsigned long) db_length);
+                fpc_store_user_db(db_length, db_path);
+
+                fingerprint_msg_t msg;
+                msg.type = FINGERPRINT_TEMPLATE_REMOVED;
+                msg.data.removed.finger.fid = print_id;
+                msg.data.removed.finger.gid = 0;
+                callback(&msg);
+
+                return 0;
+            }
+        }
+    }
+    return FINGERPRINT_ERROR;
+}
+
+static int fingerprint_set_active_group(struct fingerprint_device __unused *dev,
+                                        uint32_t __unused gid, const char __unused *store_path)
+{
+
+    sprintf(db_path,"%s/data_%d.db",store_path,gid);
+    ALOGI("%s : storage path set to : %s",__func__, db_path);
+    fpc_load_user_db(db_path);
+    return 0;
+
+}
+
+static int fingerprint_authenticate(struct fingerprint_device __unused *dev,
+                                    uint64_t __unused operation_id, __unused uint32_t gid)
+{
+
+    if (auth_thread_running) {
+        ALOGE("%s : Error, thread already running\n", __func__);
+        return -1;
+    }
+
+    pthread_mutex_lock(&lock);
+    auth_thread_running = true;
+    pthread_mutex_unlock(&lock);
+
+    if(pthread_create(&thread, NULL, auth_thread_loop, NULL)) {
+        ALOGE("%s : Error creating thread\n", __func__);
+        auth_thread_running = false;
+        return FINGERPRINT_ERROR;
+    }
+
+    return 0;
+}
+
+static int set_notify_callback(struct fingerprint_device *dev,
+                               fingerprint_notify_t notify)
+{
+    /* Decorate with locks */
+    dev->notify = notify;
+    callback = notify;
+    return 0;
+}
+
+static int fingerprint_open(const hw_module_t* module, const char __unused *id,
+                            hw_device_t** device)
+{
+
+    ALOGI("%s",__func__);
+
+    if (device == NULL) {
+        ALOGE("NULL device on open");
+        return -EINVAL;
+    }
+
+
+    if (fpc_init() < 0) {
+        ALOGE("Could not init FPC device");
+        return -EINVAL;
+    }
+
+    fingerprint_device_t *dev = malloc(sizeof(fingerprint_device_t));
+    memset(dev, 0, sizeof(fingerprint_device_t));
+
+    dev->common.tag = HARDWARE_DEVICE_TAG;
+    dev->common.version = FINGERPRINT_MODULE_API_VERSION_2_0;
+    dev->common.module = (struct hw_module_t*) module;
+    dev->common.close = fingerprint_close;
+
+    dev->pre_enroll = fingerprint_pre_enroll;
+    dev->enroll = fingerprint_enroll;
+    dev->get_authenticator_id = fingerprint_get_auth_id;
+    dev->cancel = fingerprint_cancel;
+    dev->remove = fingerprint_remove;
+    dev->set_active_group = fingerprint_set_active_group;
+    dev->authenticate = fingerprint_authenticate;
+    dev->set_notify = set_notify_callback;
+    dev->notify = NULL;
+
+    *device = (hw_device_t*) dev;
+    return 0;
+}
+
+static struct hw_module_methods_t fingerprint_module_methods = {
+    .open = fingerprint_open,
+};
+
+fingerprint_module_t HAL_MODULE_INFO_SYM = {
+    .common = {
+        .tag                = HARDWARE_MODULE_TAG,
+        .module_api_version = FINGERPRINT_MODULE_API_VERSION_2_0,
+        .hal_api_version    = HARDWARE_HAL_API_VERSION,
+        .id                 = FINGERPRINT_HARDWARE_MODULE_ID,
+        .name               = "Kitakami Fingerprint HAL",
+        .author             = "Shane Francis / Jens Andersen",
+        .methods            = &fingerprint_module_methods,
+    },
+};

--- a/fingerprint/fpc_imp.c
+++ b/fingerprint/fpc_imp.c
@@ -80,7 +80,7 @@ int sys_fs_irq_poll(char *path)
 
     switch (result) {
     case 0:
-        ALOGE ("timeout\n");
+        ALOGD ("timeout\n");
         close(pollfds[0].fd);
         return -1;
     case -1:
@@ -88,7 +88,7 @@ int sys_fs_irq_poll(char *path)
         close(pollfds[0].fd);
         return -1;
     default:
-        ALOGI ("IRQ GOT \n");
+        ALOGD ("IRQ GOT \n");
         close(pollfds[0].fd);
         break;
     }

--- a/fingerprint/fpc_imp.c
+++ b/fingerprint/fpc_imp.c
@@ -340,11 +340,13 @@ int fpc_capture_image()
 
     int ret = fpc_wait_for_finger();
 
-    //If wait reported 0 we can try and capture the image
     if (ret == 0) {
+        //If wait reported 0 we can try and capture the image
         ret = send_normal_command(FPC_CAPTURE_IMAGE,0,mHandle);
+    } else {
+        //return a high value as to not trigger a user notification
+        ret = 1000; //same as FINGERPRINT_ERROR_VENDOR_BASE
     }
-
 
     if (device_disable() < 0) {
         ALOGE("Error stopping device\n");

--- a/fingerprint/fpc_imp.c
+++ b/fingerprint/fpc_imp.c
@@ -287,11 +287,11 @@ int fpc_wait_for_finger()
     int finger_state  = send_normal_command(FPC_CHK_FP_LOST,FPC_CHK_FP_LOST,mHandle);
 
     if (finger_state == 4) {
-        ALOGI("%s : WAIT FOR FINGER UP\n", __func__);
+        ALOGD("%s : WAIT FOR FINGER UP\n", __func__);
     } else if (finger_state == 8) {
-        ALOGI("%s : WAIT FOR FINGER DOWN\n", __func__);
+        ALOGD("%s : WAIT FOR FINGER DOWN\n", __func__);
     } else if (finger_state == 2) {
-        ALOGI("%s : WAIT FOR FINGER NOT NEEDED\n", __func__);
+        ALOGD("%s : WAIT FOR FINGER NOT NEEDED\n", __func__);
         return 1;
     } else {
         return -1;
@@ -304,7 +304,7 @@ int fpc_wait_for_finger()
     }
     sysfs_write(SPI_CLK_FILE,"0");
 
-    ALOGI("Attempting to poll device IRQ\n");
+    ALOGD("Attempting to poll device IRQ\n");
 
     if (sys_fs_irq_poll(SPI_IRQ_FILE) < 0) {
         sysfs_write(SPI_CLK_FILE,"1");
@@ -318,10 +318,10 @@ int fpc_wait_for_finger()
     int wake_type = send_normal_command(FPC_GET_WAKE_TYPE,0,mHandle);
 
     if (wake_type == 3) {
-        ALOGI("%s : READY TO CAPTURE\n", __func__);
+        ALOGD("%s : READY TO CAPTURE\n", __func__);
         return 0;
     } else {
-        ALOGI("%s : NOT READY TRY AGAIN\n", __func__);
+        ALOGD("%s : NOT READY TRY AGAIN\n", __func__);
         return 1;
     }
 

--- a/fingerprint/fpc_imp.c
+++ b/fingerprint/fpc_imp.c
@@ -1,0 +1,784 @@
+/*
+ * Copyright (C) 2016 Shane Francis / Jens Andersen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fpc_imp.h"
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+
+#define LOG_TAG "FPC IMP"
+#define LOG_NDEBUG 0
+
+#include <cutils/log.h>
+
+#define SPI_CLK_FILE "/sys/bus/spi/devices/spi0.1/clk_enable"
+#define SPI_PREP_FILE "/sys/bus/spi/devices/spi0.1/spi_prepare"
+#define SPI_WAKE_FILE "/sys/bus/spi/devices/spi0.1/wakeup_enable"
+#define SPI_IRQ_FILE "/sys/bus/spi/devices/spi0.1/irq"
+
+int sysfs_write(char *path, char *s)
+{
+    char buf[80];
+    int len;
+    int ret = 0;
+    int fd = open(path, O_WRONLY);
+
+    if (fd < 0) {
+        strerror_r(errno, buf, sizeof(buf));
+        ALOGE("Error opening %s: %s\n", path, buf);
+        return -1 ;
+    }
+
+    len = write(fd, s, strlen(s));
+    if (len < 0) {
+        strerror_r(errno, buf, sizeof(buf));
+        ALOGE("Error writing to %s: %s\n", path, buf);
+
+        ret = -1;
+    }
+
+    close(fd);
+
+    return ret;
+}
+
+int sys_fs_irq_poll(char *path)
+{
+
+    char buf[80];
+    int ret = 0;
+    int result;
+    struct pollfd pollfds[2];
+    pollfds[0].fd = open(path, O_RDONLY | O_NONBLOCK);
+
+    if (pollfds[0].fd < 0) {
+        strerror_r(errno, buf, sizeof(buf));
+        ALOGE("Error opening %s: %s\n", path, buf);
+        return -1 ;
+    }
+
+    char dummybuf;
+    read(pollfds[0].fd, &dummybuf, 1);
+    pollfds[0].events = POLLPRI;
+
+    result = poll(pollfds, 1, 1000);
+
+    switch (result) {
+    case 0:
+        ALOGE ("timeout\n");
+        close(pollfds[0].fd);
+        return -1;
+    case -1:
+        ALOGE ("poll error \n");
+        close(pollfds[0].fd);
+        return -1;
+    default:
+        ALOGI ("IRQ GOT \n");
+        close(pollfds[0].fd);
+        break;
+    }
+
+    close(pollfds[0].fd);
+
+    return ret;
+}
+
+int device_enable()
+{
+    if (sysfs_write(SPI_PREP_FILE,"enable")< 0) {
+        return -1;
+    }
+
+    if (sysfs_write(SPI_CLK_FILE,"1")< 0) {
+        return -1;
+    }
+    return 1;
+}
+
+int device_disable()
+{
+    if (sysfs_write(SPI_CLK_FILE,"0")< 0) {
+        return -1;
+    }
+
+    if (sysfs_write(SPI_PREP_FILE,"disable")< 0) {
+        return -1;
+    }
+    return 1;
+}
+
+int send_modified_command_to_tz(uint32_t cmd, struct QSEECom_handle * handle, void * buffer, uint32_t len)
+{
+
+    fpc_send_mod_cmd_t* send_cmd = (fpc_send_mod_cmd_t*) handle->ion_sbuffer;
+    fpc_send_std_cmd_t* rec_cmd = (fpc_send_std_cmd_t*) handle->ion_sbuffer + 64;
+
+    struct QSEECom_ion_fd_info  ion_fd_info;
+    struct qcom_km_ion_info_t ihandle;
+
+    ihandle.ion_fd = 0;
+
+    if (qcom_km_ION_memalloc(&ihandle, len) <0) {
+        ALOGE("ION allocation  failed");
+        return -1;
+    }
+
+    memset(&ion_fd_info, 0, sizeof(struct QSEECom_ion_fd_info));
+    ion_fd_info.data[0].fd = ihandle.ifd_data_fd;
+    ion_fd_info.data[0].cmd_buf_offset = 4;
+
+    send_cmd->cmd_id = cmd;
+    send_cmd->v_addr = (intptr_t) ihandle.ion_sbuffer;
+    send_cmd->length = len;
+    send_cmd->extra = 0x00;
+
+    memcpy((unsigned char *)ihandle.ion_sbuffer, buffer, len);
+
+    int ret = send_modified_cmd_fn(handle,send_cmd,64,rec_cmd,64,&ion_fd_info);
+
+    if(ret < 0) {
+        qcom_km_ion_dealloc(&ihandle);
+        return -1;
+    }
+
+    if (send_cmd->v_addr != 0) {
+        ALOGE("Error on TZ\n");
+        qcom_km_ion_dealloc(&ihandle);
+        return -1;
+    }
+
+    qcom_km_ion_dealloc(&ihandle);
+    return 0;
+}
+
+int send_normal_command(uint32_t cmd, uint32_t param, struct QSEECom_handle * handle)
+{
+
+    fpc_send_std_cmd_t* send_cmd = (fpc_send_std_cmd_t*) handle->ion_sbuffer;
+    fpc_send_std_cmd_t* rec_cmd = (fpc_send_std_cmd_t*) handle->ion_sbuffer + 64;
+
+    send_cmd->cmd_id = cmd;
+    send_cmd->ret_val = param;
+
+    int ret = send_cmd_fn(handle,send_cmd,64,rec_cmd,64);
+
+    if(ret < 0) {
+        return -1;
+    }
+
+    return rec_cmd->ret_val;
+}
+
+uint64_t get_int64_command(uint32_t cmd, uint32_t param, struct QSEECom_handle * handle)
+{
+
+    fpc_send_int64_cmd_t* send_cmd = (fpc_send_int64_cmd_t*) handle->ion_sbuffer;
+    fpc_send_int64_cmd_t* rec_cmd = (fpc_send_int64_cmd_t*) handle->ion_sbuffer + 64;
+
+    send_cmd->cmd_id = cmd;
+    send_cmd->ret_val = param;
+
+    int ret = send_cmd_fn(handle,send_cmd,64,rec_cmd,64);
+
+    if(ret < 0) {
+        return -1;
+    }
+
+    return send_cmd->ret_val;
+
+}
+
+uint32_t fpc_set_auth_challange()
+{
+    return send_normal_command(FPC_SET_AUTH_CHALLANGE,0,mHandle);
+}
+
+uint64_t fpc_load_auth_challange()
+{
+    return get_int64_command(FPC_GET_AUTH_CHALLENGE,0,mHandle);
+}
+
+uint64_t fpc_load_db_id()
+{
+    return get_int64_command(FPC_GET_DB_ID,0,mHandle);
+}
+
+int fpc_get_hw_auth_obj(void * buffer, int length)
+{
+
+    fpc_send_mod_cmd_t* send_cmd = (fpc_send_mod_cmd_t*) mHandle->ion_sbuffer;
+    fpc_send_std_cmd_t* rec_cmd = (fpc_send_std_cmd_t*) mHandle->ion_sbuffer + 64;
+
+    struct QSEECom_ion_fd_info  ion_fd_info;
+    struct qcom_km_ion_info_t ihandle;
+
+    ihandle.ion_fd = 0;
+
+    if (qcom_km_ION_memalloc(&ihandle, length) <0) {
+        ALOGE("ION allocation  failed");
+        return -1;
+    }
+
+    memset(&ion_fd_info, 0, sizeof(struct QSEECom_ion_fd_info));
+    ion_fd_info.data[0].fd = ihandle.ifd_data_fd;
+    ion_fd_info.data[0].cmd_buf_offset = 4;
+
+    send_cmd->cmd_id = FPC_GET_AUTH_HAT;
+    send_cmd->v_addr = (intptr_t) ihandle.ion_sbuffer;
+    send_cmd->length = length;
+    send_cmd->extra = 0x00;
+
+    memset((unsigned char *)ihandle.ion_sbuffer, 0, length);
+
+    int ret = send_modified_cmd_fn(mHandle,send_cmd,64,rec_cmd,64,&ion_fd_info);
+
+    memcpy(buffer, (unsigned char *)ihandle.ion_sbuffer, length);
+
+    if(ret < 0) {
+        qcom_km_ion_dealloc(&ihandle);
+        return -1;
+    }
+
+    if (send_cmd->v_addr != 0) {
+        ALOGE("Error on TZ\n");
+        qcom_km_ion_dealloc(&ihandle);
+        return -1;
+    }
+
+    qcom_km_ion_dealloc(&ihandle);
+    return 0;
+
+}
+
+int fpc_verify_auth_challange(void* hat, uint32_t size)
+{
+    return send_modified_command_to_tz(FPC_VERIFY_AUTH_CHALLENGE,mHandle,hat,size);
+}
+
+uint32_t fpc_get_remaining_touches()
+{
+    return send_normal_command(FPC_GET_REMAINING_TOUCHES,0,mHandle);
+}
+
+uint32_t fpc_del_print_id(uint32_t id)
+{
+    return send_normal_command(FPC_GET_DEL_PRINT,id,mHandle);
+}
+
+// Returns -1 on error, 1 on check again and 0 on ready to capture
+int fpc_wait_for_finger()
+{
+
+    int finger_state  = send_normal_command(FPC_CHK_FP_LOST,FPC_CHK_FP_LOST,mHandle);
+
+    if (finger_state == 4) {
+        ALOGI("%s : WAIT FOR FINGER UP\n", __func__);
+    } else if (finger_state == 8) {
+        ALOGI("%s : WAIT FOR FINGER DOWN\n", __func__);
+    } else if (finger_state == 2) {
+        ALOGI("%s : WAIT FOR FINGER NOT NEEDED\n", __func__);
+        return 1;
+    } else {
+        return -1;
+    }
+
+    sysfs_write(SPI_WAKE_FILE,"1");
+    if (send_normal_command(FPC_SET_WAKE,0,mHandle) != 0) {
+        ALOGE("Error sending FPC_SET_WAKE to tz\n");
+        return -1;
+    }
+    sysfs_write(SPI_CLK_FILE,"0");
+
+    ALOGI("Attempting to poll device IRQ\n");
+
+    if (sys_fs_irq_poll(SPI_IRQ_FILE) < 0) {
+        sysfs_write(SPI_CLK_FILE,"1");
+        sysfs_write(SPI_WAKE_FILE,"0");
+        return 1;
+    }
+
+    sysfs_write(SPI_CLK_FILE,"1");
+    sysfs_write(SPI_WAKE_FILE,"0");
+
+    int wake_type = send_normal_command(FPC_GET_WAKE_TYPE,0,mHandle);
+
+    if (wake_type == 3) {
+        ALOGI("%s : READY TO CAPTURE\n", __func__);
+        return 0;
+    } else {
+        ALOGI("%s : NOT READY TRY AGAIN\n", __func__);
+        return 1;
+    }
+
+    return 1;
+}
+
+// Attempt to capture image
+int fpc_capture_image()
+{
+
+    if (device_enable() < 0) {
+        ALOGE("Error starting device\n");
+        return -1;
+    }
+
+
+    int ret = fpc_wait_for_finger();
+
+    //If wait reported 0 we can try and capture the image
+    if (ret == 0) {
+        ret = send_normal_command(FPC_CAPTURE_IMAGE,0,mHandle);
+    }
+
+
+    if (device_disable() < 0) {
+        ALOGE("Error stopping device\n");
+        return -1;
+    }
+
+    return ret;
+}
+
+int fpc_enroll_step()
+{
+
+    fpc_send_std_cmd_t* send_cmd = (fpc_send_std_cmd_t*) mHandle->ion_sbuffer;
+    fpc_send_std_cmd_t* rec_cmd = (fpc_send_std_cmd_t*) mHandle->ion_sbuffer + 64;
+
+    send_cmd->cmd_id = FPC_ENROLL_STEP;
+    send_cmd->ret_val = 0x24;
+
+    int ret = send_cmd_fn(mHandle,send_cmd,64,rec_cmd,64);
+
+    if(ret < 0) {
+        return -1;
+    }
+
+    return rec_cmd->ret_val;
+}
+
+int fpc_enroll_start(int print_index)
+{
+    fpc_send_enroll_start_cmd_t* send_cmd = (fpc_send_enroll_start_cmd_t*) mHandle->ion_sbuffer;
+    fpc_send_std_cmd_t* rec_cmd = (fpc_send_std_cmd_t*) mHandle->ion_sbuffer + 64;
+
+    send_cmd->cmd_id = FPC_ENROLL_START;
+    send_cmd->ret_val = 0x00;
+    send_cmd->na1 = 0x45;
+    send_cmd->print_index = print_index;
+
+    int ret = send_cmd_fn(mHandle,send_cmd,64,rec_cmd,64);
+
+    if(ret < 0) {
+        return -1;
+    }
+
+    return rec_cmd->ret_val;
+}
+
+int fpc_enroll_end()
+{
+
+    uint32_t ret = send_normal_command(FPC_ENROLL_END,0x0,mHandle);
+
+    if (ret != 0) {
+        ALOGE("Error sending FPC_ENROLL_END to tz\n");
+        return -1;
+    }
+    return ret;
+}
+
+
+int fpc_auth_start()
+{
+
+    int print_count = fpc_get_print_count();
+    ALOGI("%s : Number Of Prints Available : %d",__func__,print_count);
+
+    fpc_get_pint_index_cmd_t print_idx = fpc_get_print_index(print_count);
+
+    fpc_get_pint_index_cmd_t* send_cmd = (fpc_get_pint_index_cmd_t*) mHandle->ion_sbuffer;
+    fpc_send_std_cmd_t* rec_cmd = (fpc_send_std_cmd_t*) mHandle->ion_sbuffer + 64;
+
+
+    send_cmd->cmd_id = FPC_AUTH_START;
+    send_cmd->p1 = print_idx.p1;
+    send_cmd->p2 = print_idx.p2;
+    send_cmd->p3 = print_idx.p3;
+    send_cmd->p4 = print_idx.p4;
+    send_cmd->p5 = print_idx.p5;
+    send_cmd->print_count = print_idx.print_count;
+
+    int ret = send_cmd_fn(mHandle,send_cmd,64,rec_cmd,64);
+
+    if(ret < 0) {
+        ALOGE("Error sending FPC_AUTH_START to tz\n");
+        return -1;
+    }
+
+    return rec_cmd->ret_val;
+}
+
+uint32_t fpc_auth_step()
+{
+
+    fpc_send_std_cmd_t* send_cmd = (fpc_send_std_cmd_t*) mHandle->ion_sbuffer;
+    fpc_send_auth_cmd_t* rec_cmd = (fpc_send_auth_cmd_t*) mHandle->ion_sbuffer + 64;
+
+    send_cmd->cmd_id = FPC_AUTH_STEP;
+    send_cmd->ret_val = 0x00;
+
+    int ret = send_cmd_fn(mHandle,send_cmd,64,rec_cmd,64);
+
+    if(ret < 0) {
+        return -1;
+    }
+
+    //if the print didnt capture properly return error and continue
+    if (rec_cmd->ret_val < 2) {
+        return -1;
+    }
+
+    return rec_cmd->id;
+}
+
+int fpc_auth_end()
+{
+
+    uint32_t ret = send_normal_command(FPC_AUTH_END,0x0,mHandle);
+
+    if (ret != 0) {
+        ALOGE("Error sending FPC_AUTH_END to tz\n");
+        return -1;
+    }
+    return ret;
+}
+
+uint32_t fpc_get_print_id(int id)
+{
+
+    fpc_send_std_cmd_t* send_cmd = (fpc_send_std_cmd_t*) mHandle->ion_sbuffer;
+    fpc_send_std_cmd_t* rec_cmd = (fpc_send_std_cmd_t*) mHandle->ion_sbuffer + 64;
+
+    send_cmd->cmd_id = FPC_GET_PRINT_ID;
+    send_cmd->ret_val = id;
+
+    int ret = send_cmd_fn(mHandle,send_cmd,64,rec_cmd,64);
+
+    if(ret < 0) {
+        return -1;
+    }
+
+    return send_cmd->ret_val;
+}
+
+
+uint32_t fpc_get_print_count()
+{
+
+    fpc_send_std_cmd_t* send_cmd = (fpc_send_std_cmd_t*) mHandle->ion_sbuffer;
+    fpc_send_std_cmd_t* rec_cmd = (fpc_send_std_cmd_t*) mHandle->ion_sbuffer + 64;
+
+    send_cmd->cmd_id = FPC_GET_ID_COUNT;
+    send_cmd->ret_val = 0x00;
+
+    int ret = send_cmd_fn(mHandle,send_cmd,64,rec_cmd,64);
+
+    if(ret < 0) {
+        return -1;
+    }
+
+    return send_cmd->ret_val;
+}
+
+
+fpc_get_pint_index_cmd_t fpc_get_print_index(int count)
+{
+
+    fpc_get_pint_index_cmd_t data;
+
+    fpc_send_std_cmd_t* send_cmd = (fpc_send_std_cmd_t*) mHandle->ion_sbuffer;
+    fpc_get_pint_index_cmd_t* rec_cmd = (fpc_get_pint_index_cmd_t*) mHandle->ion_sbuffer + 64;
+
+    send_cmd->cmd_id = FPC_GET_ID_LIST;
+    send_cmd->ret_val = count;
+    send_cmd->length = count;
+
+    int ret = send_cmd_fn(mHandle,send_cmd,64,rec_cmd,64);
+
+    data.p1 = rec_cmd->p1;
+    data.p2 = rec_cmd->p2;
+    data.p3 = rec_cmd->p3;
+    data.p4 = rec_cmd->p4;
+    data.p5 = rec_cmd->p5;
+    data.print_count = rec_cmd->print_count;
+
+    return data;
+}
+
+
+uint32_t fpc_get_user_db_length()
+{
+
+    fpc_send_std_cmd_t* send_cmd = (fpc_send_std_cmd_t*) mHandle->ion_sbuffer;
+    fpc_send_std_cmd_t* rec_cmd = (fpc_send_std_cmd_t*) mHandle->ion_sbuffer + 64;
+
+    send_cmd->cmd_id = FPC_GET_DB_LENGTH;
+    send_cmd->ret_val = 0x00;
+
+    int ret = send_cmd_fn(mHandle,send_cmd,64,rec_cmd,64);
+
+    if(ret < 0) {
+        return -1;
+    }
+
+    return send_cmd->ret_val;
+}
+
+
+uint32_t fpc_load_user_db(char* path)
+{
+
+    FILE *f = fopen(path, "r");
+
+    if (f == NULL) {
+        ALOGE("Error opening file : %s", path);
+        return -1;
+    }
+
+    fseek(f, 0, SEEK_END);
+    long fsize = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    ALOGI("Loading DB of size : %ld", fsize);
+
+    struct qcom_km_ion_info_t ihandle;
+    struct QSEECom_ion_fd_info  ion_fd_info;
+
+    if (qcom_km_ION_memalloc(&ihandle, fsize) <0) {
+        ALOGE("ION allocation  failed");
+        return -1;
+    }
+
+    fread(ihandle.ion_sbuffer, fsize, 1, f);
+
+    fclose(f);
+
+    fpc_send_mod_cmd_t* send_cmd = (fpc_send_mod_cmd_t*) mHandle->ion_sbuffer;
+    fpc_send_std_cmd_t* rec_cmd = (fpc_send_std_cmd_t*) mHandle->ion_sbuffer + 64;
+
+    memset(&ion_fd_info, 0, sizeof(struct QSEECom_ion_fd_info));
+    ion_fd_info.data[0].fd = ihandle.ifd_data_fd;
+    ion_fd_info.data[0].cmd_buf_offset = 4;
+
+    send_cmd->cmd_id = FPC_SET_DB_DATA;
+    send_cmd->v_addr = (intptr_t) ihandle.ion_sbuffer;
+    send_cmd->length = fsize;
+    send_cmd->extra = 0x00;
+
+    int ret = send_modified_cmd_fn(mHandle,send_cmd,64,rec_cmd,64,&ion_fd_info);
+
+    if(ret < 0) {
+        qcom_km_ion_dealloc(&ihandle);
+        return -1;
+    }
+
+    if (send_cmd->v_addr != 0) {
+        ALOGE("Error on TZ\n");
+        qcom_km_ion_dealloc(&ihandle);
+        return -1;
+    }
+
+    qcom_km_ion_dealloc(&ihandle);
+    return 0;
+
+}
+
+uint32_t fpc_store_user_db(uint32_t length, char* path)
+{
+
+    fpc_send_mod_cmd_t* send_cmd = (fpc_send_mod_cmd_t*) mHandle->ion_sbuffer;
+    fpc_send_std_cmd_t* rec_cmd = (fpc_send_std_cmd_t*) mHandle->ion_sbuffer + 64;
+
+    struct QSEECom_ion_fd_info  ion_fd_info;
+    struct qcom_km_ion_info_t ihandle;
+
+    ihandle.ion_fd = 0;
+
+    if (qcom_km_ION_memalloc(&ihandle, length) <0) {
+        ALOGE("ION allocation  failed");
+        return -1;
+    }
+
+    memset(&ion_fd_info, 0, sizeof(struct QSEECom_ion_fd_info));
+    ion_fd_info.data[0].fd = ihandle.ifd_data_fd;
+    ion_fd_info.data[0].cmd_buf_offset = 4;
+
+    send_cmd->cmd_id = FPC_GET_DB_DATA;
+    send_cmd->v_addr = (intptr_t) ihandle.ion_sbuffer;
+    send_cmd->length = length;
+    send_cmd->extra = 0x00;
+
+    memset((unsigned char *)ihandle.ion_sbuffer, 0, length);
+
+    int ret = send_modified_cmd_fn(mHandle,send_cmd,64,rec_cmd,64,&ion_fd_info);
+
+    if(ret < 0) {
+        qcom_km_ion_dealloc(&ihandle);
+        return -1;
+    }
+
+    if (send_cmd->v_addr != 0) {
+        ALOGE("Error on TZ\n");
+        qcom_km_ion_dealloc(&ihandle);
+        return -1;
+    }
+
+
+    FILE *f = fopen(path, "w");
+
+    if (f == NULL) {
+        ALOGE("Error opening file : %s", path);
+        return -1;
+    }
+
+    fwrite(ihandle.ion_sbuffer, length, 1, f);
+
+    fclose(f);
+
+    qcom_km_ion_dealloc(&ihandle);
+    return 0;
+}
+
+int fpc_close()
+{
+    if (device_disable() < 0) {
+        ALOGE("Error stopping device\n");
+        return -1;
+    }
+    return 1;
+}
+
+int fpc_init()
+{
+
+    ALOGE("INIT FPC TZ APP\n");
+
+    open_handle();
+
+    if (open_handle() < 1) {
+        ALOGE("Qseecom Lib Not Open !\n");
+        return -1;
+    }
+
+    if (device_enable() < 0) {
+        ALOGE("Error starting device\n");
+        return -1;
+    }
+
+    ALOGE("Starting app %s\n", FP_TZAPP_NAME);
+    if (mStartApp(&mHandle, FP_TZAPP_PATH, FP_TZAPP_NAME, 1024) < 0) {
+        ALOGE("Could not load app : %s\n", FP_TZAPP_NAME);
+        return -1;
+    }
+    ALOGE("TZ App loaded : %s\n", FP_TZAPP_NAME);
+
+
+    ALOGE("Starting app %s\n", KM_TZAPP_NAME);
+    if (mStartApp(&mHdl, KM_TZAPP_PATH, KM_TZAPP_NAME, 1024) < 0) {
+        ALOGE("Could not load app : %s\n", KM_TZAPP_NAME);
+        return -1;
+    }
+    ALOGE("TZ App loaded : %s\n", KM_TZAPP_NAME);
+
+    // Start creating one off command to get cert from keymaster
+    fpc_send_std_cmd_t *req = (fpc_send_std_cmd_t *) mHdl->ion_sbuffer;
+    req->cmd_id = 0x205;
+    req->ret_val = 0x02;
+
+    void * send_buf = mHdl->ion_sbuffer;
+    void * rec_buf = mHdl->ion_sbuffer + 64;
+
+    if (send_cmd_fn(mHdl, send_buf, 64, rec_buf, 1024-64) < 0) {
+        return -1;
+    }
+
+    //Send command to keymaster
+    fpc_send_std_cmd_t* ret_data = (fpc_send_std_cmd_t*) rec_buf;
+
+    ALOGE("Keymaster Response Code : %u\n", ret_data->ret_val);
+    ALOGE("Keymaster Response Length : %u\n", ret_data->length);
+
+    void * data_buff = &ret_data->length + 1;
+
+    if (send_modified_command_to_tz(FPC_SET_INIT_DATA,mHandle,data_buff,ret_data->length) < 0) {
+        ALOGE("Error sending data to tz\n");
+        return -1;
+    }
+
+    if (send_normal_command(FPC_INIT,0,mHandle) != 0) {
+        ALOGE("Error sending FPC_INIT to tz\n");
+        return -1;
+    }
+
+    if (send_normal_command(FPC_GET_INIT_STATE,0,mHandle) != 0) {
+        ALOGE("Error sending FPC_GET_INIT_STATE to tz\n");
+        return -1;
+    }
+
+    if (send_normal_command(FPC_INIT_UNK_1,0,mHandle) != 12) {
+        ALOGE("Error sending FPC_INIT_UNK_1 to tz\n");
+        return -1;
+    }
+
+    if (device_enable() < 0) {
+        ALOGE("Error starting device\n");
+        return -1;
+    }
+
+    if (send_normal_command(FPC_INIT_UNK_2,0,mHandle) != 0) {
+        ALOGE("Error sending FPC_INIT_UNK_2 to tz\n");
+        return -1;
+    }
+
+    int fpc_info = send_normal_command(FPC_INIT_UNK_0,0,mHandle);
+
+    ALOGI("Got device data : %d \n", fpc_info);
+
+    if (device_disable() < 0) {
+        ALOGE("Error stopping device\n");
+        return -1;
+    }
+
+    set_bandwidth_fn(mHandle,true);
+
+    if (send_normal_command(FPC_INIT_NEW_DB,0,mHandle) != 0) {
+        ALOGE("Error sending FPC_INIT_NEW_DB to tz\n");
+        return -1;
+    }
+
+    if (send_normal_command(FPC_SET_FP_STORE,0,mHandle) != 0) {
+        ALOGE("Error sending FPC_SET_FP_STORE to tz\n");
+        return -1;
+    }
+
+    set_bandwidth_fn(mHandle,false);
+
+    return 1;
+
+}

--- a/fingerprint/fpc_imp.h
+++ b/fingerprint/fpc_imp.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016 Shane Francis / Jens Andersen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __FPCIMPL_H_
+#define __FPCIMPL_H_
+
+#include "QSEEComFunc.h"
+#include <stdbool.h>
+#include "tz_api.h"
+
+struct QSEECom_handle * mHandle;
+struct QSEECom_handle * mHdl;
+
+uint64_t fpc_load_db_id(); //load db ID, used as authenticator ID in android
+uint64_t fpc_load_auth_challange(); //genertate and load an auth challange for pre enroll
+uint32_t fpc_set_auth_challange(); //set auth challange during authenticate
+int fpc_verify_auth_challange(void* hat, uint32_t size); //verify auth challage before enroll (ensure its still valid)
+int fpc_get_hw_auth_obj(void * buffer, int length); //get HAT object (copied into buffer) on authenticate
+uint32_t fpc_get_remaining_touches(); //get remaining prints needed during enroll
+uint32_t fpc_get_print_id(int id); //gets uid of print from index provided
+uint32_t fpc_get_print_count(); //get count of enrolled prints
+uint32_t fpc_del_print_id(uint32_t id); //delete print at index
+fpc_get_pint_index_cmd_t fpc_get_print_index(int count); //get list of print index's available
+int fpc_wait_for_finger(); //wait for event IRQ on print reader
+int fpc_capture_image(); //capture image ready for enroll / auth
+int fpc_enroll_step(); //step forward enroll & process image (only available if capture image returns OK)
+int fpc_enroll_start(int print_index); //start enrollment
+int fpc_enroll_end(); //end enrollment
+int fpc_auth_start(); //start auth
+uint32_t fpc_auth_step(); //step forward auth & process image (only available if capture image returns OK)
+int fpc_auth_end(); //end auth
+uint32_t fpc_get_user_db_length(); //get size of working db
+uint32_t fpc_load_user_db(char* path); //load user DB into TZ app from storage
+uint32_t fpc_store_user_db(uint32_t length, char* path); //store running TZ db
+int fpc_close(); //close this implementation
+int fpc_init(); //init sensor
+
+#endif

--- a/fingerprint/tz_api.h
+++ b/fingerprint/tz_api.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2016 Shane Francis / Jens Andersen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __TZAPI_H_
+#define __TZAPI_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define FP_TZAPP_PATH "/system/vendor/firmware/"
+#define FP_TZAPP_NAME "tzfingerprint"
+
+#define KM_TZAPP_PATH "/firmware/image/"
+#define KM_TZAPP_NAME "kmota"
+
+#define BUFFER_SIZE 64
+
+//enumerate tz app command ID's
+enum fingerprint_cmd_t {
+    FPC_INIT = 0x00,
+    FPC_ENROLL_START = 0x03,
+    FPC_ENROLL_STEP = 0x04,
+    FPC_ENROLL_END = 0x05,
+    FPC_AUTH_START = 0x07,
+    FPC_AUTH_STEP = 0x08,
+    FPC_AUTH_END = 0x09,
+    FPC_CHK_FP_LOST = 0x0A,
+    FPC_SET_WAKE = 0x0B,
+    FPC_GET_WAKE_TYPE = 0x0C,
+    FPC_INIT_NEW_DB = 0x0F,
+    FPC_SET_FP_STORE = 0x1A,
+    FPC_GET_PRINT_ID = 0x1F,
+    FPC_SET_DB_DATA = 0x10,
+    FPC_GET_DB_LENGTH = 0x11,
+    FPC_GET_DB_DATA = 0x12,
+    FPC_GET_ID_LIST = 0x13,
+    FPC_GET_ID_COUNT = 0x14,
+    FPC_GET_DEL_PRINT = 0x15,
+    FPC_CAPTURE_IMAGE = 0x17,
+    FPC_GET_INIT_STATE = 0x19,
+    FPC_GET_AUTH_HAT = 0x21,
+    FPC_GET_DB_ID = 0x20,
+    FPC_VERIFY_AUTH_CHALLENGE = 0x22,
+    FPC_GET_AUTH_CHALLENGE = 0x23,
+    FPC_SET_AUTH_CHALLANGE = 0x24,
+    FPC_SET_INIT_DATA = 0x25,
+    FPC_INIT_UNK_0 = 0x2A,
+    FPC_INIT_UNK_1 = 0x2B,
+    FPC_GET_REMAINING_TOUCHES = 0x2C,
+    FPC_INIT_UNK_2 = 0x26,
+};
+
+typedef struct {
+    uint32_t cmd_id;
+    uint32_t ret_val; //Some cases this is used for return value of the command
+    uint32_t length; //Some length of data supplied by previous modified command
+    uint32_t extra; //Some length of data supplied by previous modified command
+} fpc_send_std_cmd_t;
+
+
+
+typedef struct {
+    uint32_t cmd_id;
+    uint32_t ret_val; //Some cases this is used for return value of the command
+    uint32_t length; //Some length of data supplied by previous modified command
+    uint32_t id; //Some length of data supplied by previous modified command
+} fpc_send_auth_cmd_t;
+
+
+typedef struct {
+    uint32_t cmd_id;
+    uint32_t ret_val; //Some cases this is used for return value of the command
+    uint32_t na1; // always 0x45 ?
+    uint32_t na2; //???
+    uint32_t na3; //???
+    uint32_t na4; //???
+    uint32_t print_index;
+} fpc_send_enroll_start_cmd_t;
+
+
+typedef struct {
+    uint32_t cmd_id;
+    uint32_t p1; //Some cases this is used for return value of the command
+    uint32_t p2; // always 0x45 ?
+    uint32_t p3; //???
+    uint32_t p4; //???
+    uint32_t p5; //???
+    uint32_t print_count;
+} fpc_get_pint_index_cmd_t;
+
+typedef struct {
+    uint32_t cmd_id;
+    uint32_t v_addr; //Virtual address of ion mmap buffer
+    uint32_t length; //Length of data on ion buffer
+    uint32_t extra; //???
+} fpc_send_mod_cmd_t;
+
+
+typedef struct {
+    uint32_t cmd_id;
+    uint32_t v_addr;
+    uint64_t ret_val; //64bit int
+} fpc_send_int64_cmd_t;
+
+#ifdef __cplusplus
+}
+#endif
+#endif


### PR DESCRIPTION
  * This was based around the OnePlus Two TrustZone fingerprint HAL (found here
   https://github.com/CyanogenMod/android_device_oneplus_oneplus2/blob/cm-13.0/fingerprint)

  * Extra information was obtained from the Nexus 6P (angler kernel driver) (found here
   https://android.googlesource.com/kernel/msm/+/3d0a564505ab8452e7e6f52b972db386cc2f5f69)

  * Protocol informations was verified as it passed through the QSEECOM API to linux kerne

  Authors Jens Andersen & Shane Francis