### PR TITLE
Allow fingerprintd access to devices/sysfs required for kitakami fingerprint

### DIFF
--- a/sepolicy/file.te
+++ b/sepolicy/file.te
@@ -4,3 +4,5 @@ type ta_data_file, file_type;
 type addrsetup_data_file, file_type, data_file_type;
 
 type sysfs_addrsetup, fs_type, sysfs_type;
+
+type sysfs_fingerprintd_writable, fs_type, sysfs_type;

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -55,3 +55,8 @@
 /sys/devices/soc.0/bluesleep.81/rfkill/rfkill0/state    u:object_r:sysfs_bluetooth_writable:s0
 /sys/devices/bluesleep.89/rfkill/rfkill0/state          u:object_r:sysfs_bluetooth_writable:s0
 
+# Fingerprint
+/sys/bus/spi/devices/spi0.1/clk_enable       u:object_r:sysfs_fingerprintd_writable:s0
+/sys/bus/spi/devices/spi0.1/spi_prepare      u:object_r:sysfs_fingerprintd_writable:s0
+/sys/bus/spi/devices/spi0.1/wakeup_enable    u:object_r:sysfs_fingerprintd_writable:s0
+/sys/bus/spi/devices/spi0.1/irq              u:object_r:sysfs_fingerprintd_writable:s0

--- a/sepolicy/fingerprintd.te
+++ b/sepolicy/fingerprintd.te
@@ -1,1 +1,2 @@
 allow fingerprintd sysfs_fingerprintd_writable:file rw_file_perms;
+allow fingerprintd tee_device:chr_file rw_file_perms;

--- a/sepolicy/fingerprintd.te
+++ b/sepolicy/fingerprintd.te
@@ -1,0 +1,1 @@
+allow fingerprintd sysfs_fingerprintd_writable:file rw_file_perms;


### PR DESCRIPTION
/sys/bus/spi/devices/spi0.1/spi_prepare still has some issues - it gets swooped up by the generic sysfs rules and denied - ideas appreciated?