### PR TITLE
Fix GPS on windy-devices

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -344,6 +344,7 @@ service iprenew_bt-pan /system/bin/dhcpcd -n
 on property:ro.boot.baseband=apq
     setprop ro.radio.noril yes
     stop ril-daemon
+    enable qmuxd
 
 on property:ro.boot.baseband=msm
     enable qmuxd


### PR DESCRIPTION
Enable qmuxd service on wifi-only devices

Modem files from Stock are needed on windy too !!