### PR TITLE
Move sysfs and props for cpuquiet hotplugging

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -52,8 +52,6 @@ TARGET_NO_RPC := true
 # Charger
 BOARD_CHARGER_ENABLE_SUSPEND := true
 
-TARGET_SYSTEM_PROP := device/sony/common/system.prop
-
 # Include an expanded selection of fonts
 EXTENDED_FONT_FOOTPRINT := true
 

--- a/power/power.c
+++ b/power/power.c
@@ -27,24 +27,34 @@
 #include <hardware/hardware.h>
 #include <hardware/power.h>
 
+#define CPUQUIET_MIN_CPUS "/sys/devices/system/cpu/cpuquiet/nr_min_cpus"
+#define CPUQUIET_MAX_CPUS "/sys/devices/system/cpu/cpuquiet/nr_power_max_cpus"
 #define RQBALANCE_BALANCE_LEVEL "/sys/devices/system/cpu/cpuquiet/rqbalance/balance_level"
 #define RQBALANCE_UP_THRESHOLD "/sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds"
 #define RQBALANCE_DOWN_THRESHOLD "/sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds"
 
+#define LOW_MIN_CPUS "cpuquiet.low.min_cpus"
+#define LOW_MAX_CPUS "cpuquiet.low.max_cpus"
 #define LOW_POWER_BALANCE_LEVEL "rqbalance.low.balance_level"
 #define LOW_POWER_UP_THRESHOLD "rqbalance.low.up_threshold"
 #define LOW_POWER_DOWN_THRESHOLD "rqbalance.low.down_threshold"
 
+#define NORMAL_MIN_CPUS "cpuquiet.normal.min_cpus"
+#define NORMAL_MAX_CPUS "cpuquiet.normal.max_cpus"
 #define NORMAL_POWER_BALANCE_LEVEL "rqbalance.normal.balance_level"
 #define NORMAL_POWER_UP_THRESHOLD "rqbalance.normal.up_threshold"
 #define NORMAL_POWER_DOWN_THRESHOLD "rqbalance.normal.down_threshold"
 
 #define PROPERTY_VALUE_MAX 128
 
+char low_min_cpus[PROPERTY_VALUE_MAX];
+char low_max_cpus[PROPERTY_VALUE_MAX];
 char low_balance[PROPERTY_VALUE_MAX];
 char low_up[PROPERTY_VALUE_MAX];
 char low_down[PROPERTY_VALUE_MAX];
 
+char normal_min_cpus[PROPERTY_VALUE_MAX];
+char normal_max_cpus[PROPERTY_VALUE_MAX];
 char normal_balance[PROPERTY_VALUE_MAX];
 char normal_up[PROPERTY_VALUE_MAX];
 char normal_down[PROPERTY_VALUE_MAX];
@@ -78,6 +88,9 @@ int sysfs_write(char *path, char *s)
 void set_low_power()
 {
     ALOGI("Setting low power mode");
+    // MIN before MAX is intentional
+    sysfs_write(CPUQUIET_MIN_CPUS, low_min_cpus);
+    sysfs_write(CPUQUIET_MAX_CPUS, low_max_cpus);
     sysfs_write(RQBALANCE_BALANCE_LEVEL, low_balance);
     sysfs_write(RQBALANCE_UP_THRESHOLD, low_up);
     sysfs_write(RQBALANCE_DOWN_THRESHOLD, low_down);
@@ -86,6 +99,9 @@ void set_low_power()
 void set_normal_power()
 {
     ALOGI("Setting normal power mode");
+    // MAX before MIN is intentional
+    sysfs_write(CPUQUIET_MAX_CPUS, normal_max_cpus);
+    sysfs_write(CPUQUIET_MIN_CPUS, normal_min_cpus);
     sysfs_write(RQBALANCE_BALANCE_LEVEL, normal_balance);
     sysfs_write(RQBALANCE_UP_THRESHOLD, normal_up);
     sysfs_write(RQBALANCE_DOWN_THRESHOLD, normal_down);
@@ -95,6 +111,10 @@ static void power_init(struct power_module *module)
 {
     ALOGI("Simple PowerHAL is alive!.");
 
+    property_get(LOW_MIN_CPUS, low_min_cpus, "0");
+    ALOGI("LOW_MIN_CPUS: %s", low_min_cpus);
+    property_get(LOW_MAX_CPUS, low_max_cpus, "0");
+    ALOGI("LOW_MAX_CPUS: %s", low_max_cpus);
     property_get(LOW_POWER_BALANCE_LEVEL, low_balance, "0");
     ALOGI("LOW_POWER_BALANCE_LEVEL: %s", low_balance);
     property_get(LOW_POWER_UP_THRESHOLD, low_up, "0");
@@ -102,6 +122,10 @@ static void power_init(struct power_module *module)
     property_get(LOW_POWER_DOWN_THRESHOLD, low_down, "0");
     ALOGI("LOW_POWER_DOWN_THRESHOLD: %s", low_down);
 
+    property_get(NORMAL_MIN_CPUS, normal_min_cpus, "0");
+    ALOGI("NORMAL_MIN_CPUS: %s", normal_min_cpus);
+    property_get(NORMAL_MAX_CPUS, normal_max_cpus, "0");
+    ALOGI("NORMAL_MAX_CPUS: %s", normal_max_cpus);
     property_get(NORMAL_POWER_BALANCE_LEVEL, normal_balance, "0");
     ALOGI("NORMAL_POWER_BALANCE_LEVEL: %s", normal_balance);
     property_get(NORMAL_POWER_UP_THRESHOLD, normal_up, "0");

--- a/system.prop
+++ b/system.prop
@@ -1,9 +1,0 @@
-#
-# rqbalance specific values
-#
-rqbalance.low.balance_level=80
-rqbalance.low.up_threshold=200 450 550 580 600 640 750 4294967295
-rqbalance.low.down_threshold=0 120 320 400 440 500 550 700
-rqbalance.normal.balance_level=40
-rqbalance.normal.up_threshold=100 300 400 500 525 600 700 4294967295
-rqbalance.normal.down_threshold=0 100 300 400 425 500 600 650


### PR DESCRIPTION
Core limiting via msm_performance works well, but cpuquiet absolutely
hates it. rqbalance is not aware of msm_performance so it spams dmesg
because it cannot online a core for 'unknown' reasons.

We can achieve the same result using cpuquiet which rqbalance is
aware of. We can also have two sources of core limiting, power
profile and thermal.

We also need to tune rqbalance and cpuquiet per platform so also
move their system props.

Signed-off-by: Adam Farden <adam@farden.cz>