### PR TITLE
sony-common: use proper black conceal color

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -161,6 +161,10 @@ PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.data.qmi.adb_logmask=0
 
+# Black conceal color
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.vidc.dec.conceal_color=32784
+
 # Default to LTE/GSM/WCDMA.
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.telephony.default_network=9


### PR DESCRIPTION
actual kernel is using 0x8010 which is black see:
       https://github.com/sonyxperiadev/kernel/blob/aosp/LA.BF64.1.1_rb1.27/drivers/media/platform/msm/vidc/msm_vdec.c#L26

actual media hal 5.1.1_r37 is using 0x8080 see:
       https://android.googlesource.com/platform/hardware/qcom/media/+/android-5.1.1_r37/mm-video-v4l2/vidc/vdec/src/omx_vdec_msm8974.cpp#129

aligned this from userspace using:
       https://android.googlesource.com/platform/hardware/qcom/media/+/android-5.1.1_r37/mm-video-v4l2/vidc/vdec/src/omx_vdec_msm8974.cpp#1754

Signed-off-by: David Viteri <davidteri91@gmail.com>