### PR TITLE
sony: common: init: Add timekeep dependencies

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -183,6 +183,9 @@ on boot
     mkdir /dev/socket/qmux_gps 0770 gps gps
     chmod 2770 /dev/socket/qmux_gps
 
+    # Create folder for timekeep
+    mkdir /data/time/ 0700 system system
+
     # Camera Recording
     mkdir /dev/video
     symlink /dev/video32 /dev/video/venus_dec


### PR DESCRIPTION
It is required for timekeep.
sonyxperiadev/timekeep#8
