### PR TITLE
Enable camera hal version 3

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -254,7 +254,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Camera
 PRODUCT_PROPERTY_OVERRIDES += \
     camera.disable_zsl_mode=0 \
-    persist.camera.HAL3.enabled=0 \
+    persist.camera.HAL3.enabled=1 \
     persist.camera.gyro.disable=1 \
     persist.camera.feature.cac=0 \
     persist.camera.ois.disable=0


### PR DESCRIPTION
I have compared camera stability between camera hal v3 and old hal. Camera hal v3 is much more stable. When I set persist.camera.HAL3.enabled to 0, I can only take few pictures(maybe 5 pics) and then "can't connect to camera" message shows and I should restart phone to make camera working again. But when I enable hal v3, I can take many pictures without camera connectivity error.