### PR TITLE
sony-common: Update Graphics Permissions

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -178,7 +178,10 @@ on boot
     # Create symlink for fb1 as HDMI
     symlink /dev/graphics/fb1 /dev/graphics/hdmi
 
-    # Remove write permissions to video related nodes
+    # Graphics Permissions
+    chown system graphics /sys/class/graphics/fb0/idle_time
+    chmod 0664 /sys/class/graphics/fb0/idle_time
+
     chown system graphics /sys/class/graphics/fb1/avi_itc
     chown system graphics /sys/class/graphics/fb1/avi_cn0_1
     chown system graphics /sys/class/graphics/fb1/hpd


### PR DESCRIPTION
01-01 23:46:04.353   325   325 E qdutils : setIdleTimeout:Unable to open /sys/devices/virtual/graphics/fb0/idle_time node Permission denied

Signed-off-by: David Viteri <davidteri91@gmail.com>