### PR TITLE
Add broadcom fm radio stuff

### DIFF
--- a/brcm_fmradio/Android.mk
+++ b/brcm_fmradio/Android.mk
@@ -1,0 +1,4 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(call all-makefiles-under,$(LOCAL_PATH))
+

--- a/brcm_fmradio/brcm-uim-sysfs/Android.mk
+++ b/brcm_fmradio/brcm-uim-sysfs/Android.mk
@@ -1,0 +1,24 @@
+LOCAL_PATH:= $(call my-dir)
+include $(CLEAR_VARS)
+
+#
+# UIM Application
+#
+
+LOCAL_C_INCLUDES:= $(LOCAL_PATH)/include
+
+LOCAL_SRC_FILES:= \
+    uim.c \
+    upio.c \
+    brcm_hci_dump.c \
+    btsnoop.c \
+    utils.c
+
+LOCAL_CLANG := false
+LOCAL_CFLAGS:= -c -W -Wall -O2 -D_POSIX_SOURCE -DUIM_DEBUG -DBLUEDROID_ENABLE_V4L2
+LOCAL_SHARED_LIBRARIES:= libnetutils libcutils liblog
+
+LOCAL_MODULE := brcm-uim-sysfs
+LOCAL_MODULE_TAGS := optional
+
+include $(BUILD_EXECUTABLE)

--- a/brcm_fmradio/brcm-uim-sysfs/brcm_hci_dump.c
+++ b/brcm_fmradio/brcm-uim-sysfs/brcm_hci_dump.c
@@ -1,0 +1,719 @@
+/*
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program;if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+  *  Copyright (C) 2009-2015 Broadcom Corporation
+  *  Copyright (C) 2015 Sony Mobile Communications Inc.
+  *
+  *  NOTE: This file has been modified by Sony Mobile Communications Inc.
+  *  Modifications are licensed under the License.
+ */
+
+/************************************************************************************
+*
+*  Filename:      brcm_hci_dump.c
+*
+*  Description:   Client program to read hcisnoop packets from Line discipline driver
+*
+***********************************************************************************/
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <linux/netlink.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <cutils/log.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <malloc.h>
+#include <string.h>
+#include "utils.h"
+#include "btsnoop.h"
+#include "brcm_hci_dump.h"
+
+#define DBG FALSE
+
+#if DBG
+#define BRCM_HCI_DUMP_DBG(fmt, arg...) ALOGI("brcm_hci_dump:%s "fmt"\n" ,__func__, ## arg)
+#else
+#define BRCM_HCI_DUMP_DBG(fmt, arg...)
+#endif
+#define BRCM_HCI_DUMP_ERR(fmt, arg...) ALOGE("brcm_hci_dump:%s "fmt"\n" ,__func__, ## arg)
+
+
+/* netlink protocol type for which kernel will respond.
+** This is also declared in Line discipline driver for Kernel space - User space
+** communication. (For HCI packet to transfer from Kernel space to User space) */
+#define NETLINK_USER 29
+
+/* Size of memory allocated in kernel to userspace netlink socket to hold incoming hcisnoop packet */
+#define MAX_PAYLOAD 2048
+
+/* snoop status */
+HCI_SNOOP_STATUS snoop_status = HCI_SNOOP_STOP;
+
+/* Thread for hci snoop */
+pthread_t thread_hcisnoop;
+
+/* hci snoop filepath */
+extern char hci_snoop_path[HCI_SNOOP_PATH_LEN];
+
+
+/*******************************************************************************
+**
+** Function         acl_rx_frame_integrity_check
+**
+** Description      This function is called from the HCI transport when a
+**                  L2CAP start packet has been received:
+**                  - If the packet is the first message of a series of L2CAP
+**                    fragmented frames:
+**                      > Allocate a new buffer bigger enough to hold entire
+**                        contents of all fragmented messages.
+**                      > Copy content of this packet into new buffer
+**                      > Keep the new buffer in a processing queue
+**                  - If the packet is a L2CAP continuation packet
+**                      > Copy the content into the base buffer
+**                      > Checks if the updated base buffer has complete L2CAP
+**                        message, i.e. no more continuation packets are
+**                        expected.
+**
+** Returns          the address of a self-contained valid packet, or
+**                  NULL if a fragmented packet or invalid packet
+**
+*******************************************************************************/
+
+
+HC_BT_HDR* acl_rx_frame_integrity_check_v4l2 (HC_BT_HDR *p_rcv_msg)
+{
+    uint8_t     *p;
+    uint16_t    handle;
+    uint16_t    hci_len;
+    uint16_t    total_len;
+    uint16_t    cid;
+    uint8_t     pkt_type;
+    HC_BT_HDR  *p_return_buf = NULL;
+
+    p = (uint8_t *)(p_rcv_msg + 1);
+    total_len = 0;
+    cid = 0;
+
+    STREAM_TO_UINT16 (handle, p);
+    STREAM_TO_UINT16 (hci_len, p);
+
+    pkt_type = (uint8_t)(((handle) >> 12) & 0x0003);
+    handle   = (uint16_t)((handle) & 0x0FFF);
+
+    if ((pkt_type == ACL_RX_PKT_START) && (hci_len))
+    {
+        BRCM_HCI_DUMP_DBG("Inside pkt_type == ACL_RX_PKT_START && (hci_len)");
+        /* Start Packet */
+        STREAM_TO_UINT16 (total_len, p);
+        STREAM_TO_UINT16 (cid, p);
+
+        BRCM_HCI_DUMP_DBG("total_len = 0x%02X cid = 0x%02X", total_len, cid);
+    }
+
+    if (utils_get_count())
+    {
+        uint16_t save_handle;
+        HC_BT_HDR *p_hdr = utils_get_first();
+
+        BRCM_HCI_DUMP_DBG("In acl_rx_q.count");
+
+        while (p_hdr != NULL)
+        {
+            p = (uint8_t *)(p_hdr + 1);
+            STREAM_TO_UINT16 (save_handle, p);
+            save_handle   = (uint16_t)((save_handle) & 0x0FFF);
+            if (save_handle == handle)
+            {
+                p_return_buf = p_hdr;
+                break;
+            }
+            p_hdr = (HC_BT_HDR *) utils_getnext(p_hdr);
+        }
+    }
+
+    if (pkt_type == ACL_RX_PKT_START)       /*** START PACKET ***/
+    {
+        BRCM_HCI_DUMP_DBG("Start of packet");
+        /* Start of packet. If we were in the middle of receiving */
+        /* a packet on the same ACL handle, the original packet is incomplete.
+         * Drop it. */
+        if (p_return_buf)
+        {
+            BRCM_HCI_DUMP_DBG("HCI_V4L2 - dropping incomplete ACL frame");
+
+            utils_remove_from_queue(p_return_buf);
+            utils_release(p_return_buf);
+
+            p_return_buf = NULL;
+        }
+
+        if (hci_len)
+        {
+            BRCM_HCI_DUMP_DBG("hci_len = %d", hci_len);
+            if (cid == 0)
+            {
+                BRCM_HCI_DUMP_DBG("HCI_V4L2 - dropping ACL frame with" \
+                    "invalid CID 0x0000.");
+                return NULL;
+            }
+
+            if (total_len > (uint16_t)MAX_ACL_PDU_SIZE)
+            {
+                BRCM_HCI_DUMP_DBG("HCI_V4L2 - dropping ACL frame with "\
+                    "PDU size 0x%04x exceeding max design limit.", total_len);
+                return NULL;
+            }
+
+            if (hci_len > (uint16_t)(MAX_ACL_PDU_SIZE+L2CAP_HEADER_SIZE))
+            {
+                BRCM_HCI_DUMP_DBG("HCI_V4L2 - dropping ACL frame with" \
+                 "HCI packet size 0x%04x exceeding max design limit.", hci_len);
+                return NULL;
+            }
+
+            if (hci_len > (total_len + L2CAP_HEADER_SIZE))
+            {
+                BRCM_HCI_DUMP_DBG("HCI_V4L2 - dropping ACL frame with"\
+                    "payload size 0x%04x bigger than its carried PDU +"\
+                    "header size 0x%04x", hci_len,
+                        (total_len + L2CAP_HEADER_SIZE));
+                return NULL;
+            }
+
+            if ((total_len + L2CAP_HEADER_SIZE) > hci_len)
+            {
+                /* Will expect to see fragmented ACL packets */
+                BRCM_HCI_DUMP_DBG("Will expect to see fragmented ACL packets");
+
+                /* Allocate a buffer for message */
+                int len = total_len + HCI_ACL_PREAMBLE_SIZE + \
+                                L2CAP_HEADER_SIZE + BT_HC_HDR_SIZE;
+                BRCM_HCI_DUMP_DBG("allocate a buffer for message len = %d", len);
+                p_return_buf = (HC_BT_HDR *) utils_alloc(len);
+                BRCM_HCI_DUMP_DBG("allocated memory for p_return_buf=%p",
+                                      p_return_buf);
+
+                if (p_return_buf)
+                {
+                    p_return_buf->offset = 0;
+                    p_return_buf->layer_specific = 0;
+                    p_return_buf->event = MSG_HC_TO_STACK_HCI_ACL;
+                    p_return_buf->len = p_rcv_msg->len;
+                    memcpy((uint8_t *)(p_return_buf+1), \
+                            (uint8_t *)(p_rcv_msg+1),\
+                            p_rcv_msg->len);
+
+                    /* Keep the base buffer address in the watching queue */
+                    BRCM_HCI_DUMP_DBG("Adding START pkt to acl_rx_q with "\
+                                 "offset = %d len = %d",p_return_buf->offset,
+                                                          p_return_buf->len);
+                    utils_enqueue(p_return_buf);
+
+                    BRCM_HCI_DUMP_DBG("Also writing START pkt to" \
+                        "btsnoop_capture");
+                    btsnoop_capture(p_return_buf, TRUE);
+                }
+                else
+                {
+                    BRCM_HCI_DUMP_DBG("HCI_V4L2 - failed to get buffer to "\
+                        "assemble fragmented ACL packets with total length = "\
+                        "0x%04x",
+                          (total_len+L2CAP_HEADER_SIZE+HCI_ACL_PREAMBLE_SIZE));
+                }
+                return NULL;
+            }
+        }
+
+        BRCM_HCI_DUMP_DBG("p_return_buf = p_rcv_msg;");
+        p_return_buf = p_rcv_msg;
+    }
+    else                                    /*** CONTINUATION PACKET ***/
+    {
+        BRCM_HCI_DUMP_DBG("CONTINUATION PACKET");
+        uint16_t rcv_len = hci_len;
+
+        if (p_return_buf)
+        {
+            /* Packet continuation and found the original rx buffer */
+            BRCM_HCI_DUMP_DBG("Packet continuation and found the original rx"\
+                                                                     "buffer");
+            uint8_t *p_f = p = (uint8_t *)(p_return_buf + 1) + 2;
+            uint32_t new_len;
+
+            STREAM_TO_UINT16 (hci_len, p);
+            STREAM_TO_UINT16 (total_len, p); // the length of ACL packet
+
+            BRCM_HCI_DUMP_DBG("CONTINUATION PACKET hci_len = 0x%04X " \
+                "total_len = 0x%04X", hci_len, total_len);
+
+            new_len = (uint32_t)hci_len + (uint32_t)rcv_len - L2CAP_HEADER_SIZE;
+
+            BRCM_HCI_DUMP_DBG("CONTINUATION PACKET new_len = %d", new_len);
+
+            if (new_len > (uint32_t) total_len)
+            {
+                BRCM_HCI_DUMP_DBG("HCI_V4L2 - ACL frames reassembly failed:");
+                STREAM_TO_UINT16 (handle, p);
+                BRCM_HCI_DUMP_DBG("\t Total length of all segmented packets exceeds"
+                      "\t the original PDU length [CID:0x%04X].", handle);
+
+                ALOGW("HCI_V4L2 - dropping invalid ACL frames");
+                BRCM_HCI_DUMP_DBG("remove from queue");
+                utils_remove_from_queue(p_return_buf);
+                utils_release(p_return_buf);
+                p_return_buf = NULL;
+                return p_return_buf;
+            }
+
+            // Update HCI header of first segment (base buffer) with new len
+            BRCM_HCI_DUMP_DBG("Update HCI header of first segment (base buffer)"\
+                                                               "with new len");
+            hci_len += rcv_len;
+            UINT16_TO_STREAM (p_f, hci_len);
+            BRCM_HCI_DUMP_DBG("hci_len = 0x%02X",hci_len);
+
+            BRCM_HCI_DUMP_DBG("Copy content of this fragmented packet into"\
+                                                             "the base buffer");
+            // Copy content of this fragmented packet into the base buffer
+            p_f = (uint8_t *)(p_return_buf + 1);
+            p = (uint8_t *)(p_rcv_msg + 1);
+            memcpy((uint8_t *)(p_f+p_return_buf->len), \
+                    (uint8_t *)(p+HCI_ACL_PREAMBLE_SIZE), \
+                    rcv_len);
+            p_return_buf->len += rcv_len;
+            BRCM_HCI_DUMP_DBG("p_f = %p p = %p rcv_len = 0x%02X "\
+                "p_return_buf->len = 0x%02X", p_f, p, rcv_len, p_return_buf->len);
+            BRCM_HCI_DUMP_DBG("Copy content of this fragmented packet into "\
+                                                             "the base buffer");
+
+            if (total_len > (p_return_buf->len -
+                                  (HCI_ACL_PREAMBLE_SIZE+L2CAP_HEADER_SIZE)))
+            {
+                /* If the L2CAP length has not been reached, tell HCI_V4L2 not to send
+                            * the fragmented packet to stack */
+                BRCM_HCI_DUMP_DBG("If the L2CAP length has not been reached,"\
+                                          "tell HCI_V4L2 not to send" \
+                                          "the fragmented packet to stack");
+                return NULL;
+            }
+            else
+            {
+                /*
+                 * All fragmented packets had been reassembled.
+                 * Remove the base buffer from the watching list.
+                 */
+                BRCM_HCI_DUMP_DBG("All fragmented packets had been reassembled");
+                utils_remove_from_queue(p_return_buf);
+                BRCM_HCI_DUMP_DBG("after utils_remove_from_queue");
+            }
+        }
+        else
+        {
+            BRCM_HCI_DUMP_DBG("HCI_V4L2 - dropping ACL frame marked as "\
+                "CONTINUING Pkt but found no START Pkt");
+            return NULL;
+        }
+    }
+
+    BRCM_HCI_DUMP_DBG("p_return_buf->len = %d at the end", p_return_buf->len);
+    BRCM_HCI_DUMP_DBG("writing to snoop file when at end");
+
+    BRCM_HCI_DUMP_DBG("write to btsnoop_capture with p_return_buf->len = %d",
+                                                             p_return_buf->len);
+    btsnoop_capture(p_return_buf, TRUE);
+    return (p_return_buf);
+}
+
+
+
+/*****************************************************************************
+**   Socket signal functions to wake up hci_snoop_thread for termination
+**
+**   creating an unnamed pair of connected sockets
+**      - signal_fds[0]: join fd_set in select call of userial_read_thread
+**      - signal_fds[1]: trigger from userial_close
+*****************************************************************************/
+static int signal_fds[2]={0,1};
+
+static inline int create_signal_fds(fd_set* set)
+{
+    if(signal_fds[0]==0 && socketpair(AF_UNIX, SOCK_STREAM, 0, signal_fds)<0)
+    {
+        BRCM_HCI_DUMP_ERR("create_signal_sockets:socketpair failed, errno: %d",
+                                                                        errno);
+        return -1;
+    }
+    FD_SET(signal_fds[0], set);
+    return signal_fds[0];
+}
+
+static inline int send_wakeup_signal(char sig_cmd)
+{
+    return send(signal_fds[1], &sig_cmd, sizeof(sig_cmd), 0);
+}
+
+static inline char reset_signal()
+{
+    char sig_recv = -1;
+    recv(signal_fds[0], &sig_recv, sizeof(sig_recv), MSG_WAITALL);
+    return sig_recv;
+}
+
+static inline int is_signaled(fd_set* set)
+{
+    return FD_ISSET(signal_fds[0], set);
+}
+
+
+/* Read thread for snooping packets from Line discipline driver */
+static void* v4l2_hci_snoop_thread(void* parameters)
+{
+    HC_BT_HDR *p_buf = NULL;
+    fd_set input;
+    char reason = 0;
+    int len = 0;
+
+    //ACL related variables
+    uint8_t *p;
+    uint8_t byte;
+    uint16_t msg_len;
+
+    struct sockaddr_nl src_addr, dest_addr;
+    struct nlmsghdr *nlh = NULL;
+    struct iovec iov;
+    int sock_fd;
+    struct msghdr msg;
+
+    BRCM_HCI_DUMP_DBG("hci_snoop_thread START");
+    snoop_status = HCI_SNOOP_RUNNING;
+
+    sock_fd = socket(PF_NETLINK, SOCK_RAW , NETLINK_USER);
+    if (sock_fd < 0)
+    {
+        BRCM_HCI_DUMP_ERR("Unable to create netlink socket");
+        return -1;
+    }
+
+    memset(&src_addr, 0, sizeof(src_addr));
+    src_addr.nl_family = AF_NETLINK;
+    src_addr.nl_pid = getpid(); /* self pid */
+
+    bind(sock_fd, (struct sockaddr *)&src_addr, sizeof(src_addr));
+
+    memset(&dest_addr, 0, sizeof(dest_addr));
+    memset(&dest_addr, 0, sizeof(dest_addr));
+    dest_addr.nl_family = AF_NETLINK;
+    dest_addr.nl_pid = 0; /* For Linux Kernel */
+    dest_addr.nl_groups = 0; /* unicast */
+
+    nlh = (struct nlmsghdr *)malloc(NLMSG_SPACE(MAX_PAYLOAD));
+    memset(nlh, 0, NLMSG_SPACE(MAX_PAYLOAD));
+    nlh->nlmsg_len = NLMSG_SPACE(MAX_PAYLOAD);
+    nlh->nlmsg_pid = getpid();
+    nlh->nlmsg_flags = 0;
+
+    strcpy(NLMSG_DATA(nlh), "START HCI SNOOP");
+
+    iov.iov_base = (void *)nlh;
+    iov.iov_len = nlh->nlmsg_len;
+    msg.msg_name = (void *)&dest_addr;
+    msg.msg_namelen = sizeof(dest_addr);
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+
+
+    BRCM_HCI_DUMP_DBG("Sending message to Line discipline driver\n");
+    sendmsg(sock_fd, &msg, 0);
+
+    BRCM_HCI_DUMP_DBG("Waiting for response from Line discipline driver\n");
+
+    fcntl(sock_fd, F_SETFL, O_NONBLOCK);
+    BRCM_HCI_DUMP_DBG("set netlink socket to non-blocking");
+
+    utils_init();
+
+    /* Receive packet from Line discipline driver */
+    while(1)
+    {
+        /* initialize the fdset */
+        /* Initialize the input fd set */
+        FD_ZERO(&input);
+        FD_SET(sock_fd, &input);
+
+        int fd_max = create_signal_fds(&input);
+        fd_max = fd_max > sock_fd ? fd_max : sock_fd;
+
+        /* select call will block until snoop pkt is received from ldisc */
+        len = select(fd_max+1, &input, NULL, NULL, NULL);
+        if(is_signaled(&input))
+        {
+            BRCM_HCI_DUMP_DBG("HCI snoop thread is signalled");
+            reason = reset_signal();
+            BRCM_HCI_DUMP_DBG("reason = %d", reason);
+            if (reason == HCISNOOP_EXIT)
+            {
+                BRCM_HCI_DUMP_DBG("HCI snoop thread termination SIGNAL RECEIVED");
+                snoop_status = HCI_SNOOP_STOP;
+                free(nlh);
+                close(sock_fd);
+                BRCM_HCI_DUMP_DBG("Exiting snoop thread");
+                return 0;
+            }
+            else {
+                BRCM_HCI_DUMP_ERR("UNKNOWN signal received");
+            }
+        }
+
+        if (FD_ISSET(sock_fd, &input))
+        {
+            recvmsg(sock_fd, &msg, 0);
+            BRCM_HCI_DUMP_DBG("recevied packet");
+            len = NLMSG_PAYLOAD(nlh, 0);
+            BRCM_HCI_DUMP_DBG("finished reading len of recevied packet");
+
+
+            if(len > 0) {
+                BRCM_HCI_DUMP_DBG("Received packet of len=%d from ldisc", len);
+                p_buf = NLMSG_DATA(nlh);
+
+                if(p_buf == NULL) {
+                    BRCM_HCI_DUMP_DBG("p_buf is NULL");
+                    continue;
+                }
+
+                /* start processing the Rx packets */
+                    if(p_buf->event == MSG_HC_TO_STACK_HCI_ACL)
+                    {
+                        BRCM_HCI_DUMP_DBG("ACL packet");
+                        /* ACL packets */
+                        HC_BT_HDR *p_msg;
+
+                        if (p_buf->len < HCI_ACL_PREAMBLE_SIZE)
+                        {
+                            BRCM_HCI_DUMP_ERR("[h4] Invalid ACL length "\
+                                              "(0x%04x) drop this packet", \
+                                                                    p_buf->len);
+                            continue;
+                        }
+
+                        p = (uint8_t *) (p_buf + 1);
+                        byte = *(p+1);
+                        p += 2;
+                        STREAM_TO_UINT16(msg_len, p);
+                        BRCM_HCI_DUMP_DBG("ACL packet: msg_len = %d", msg_len);
+
+                        if (p_buf->len != (msg_len + HCI_ACL_PREAMBLE_SIZE))
+                        {
+                            BRCM_HCI_DUMP_ERR("[h4] ACL message length "\
+                                "(0x%04x) does not match to its data payload" \
+                                "length (0x%04x) drop this packet",
+                                  p_buf->len, msg_len);
+                            BRCM_HCI_DUMP_DBG("calling continue");
+                            continue;
+                        }
+
+                        if (msg_len)
+                        {
+                            BRCM_HCI_DUMP_DBG("check if start of packet");
+                            /* Check if this is a start packet */
+                            byte = ((byte >> 4) & 0x03);
+
+                            if (byte == ACL_RX_PKT_START)
+                            {
+                                BRCM_HCI_DUMP_DBG("byte == ACL_RX_PKT_START");
+                                if (msg_len < L2CAP_HEADER_SIZE)
+                                {
+                                    BRCM_HCI_DUMP_ERR("[h5] dropping "\
+                                        "incomplete ACL frame with data" \
+                                       "payload len=%d (<L2CAP_HEADER_SIZE).",
+                                        msg_len);
+                                    BRCM_HCI_DUMP_DBG("calling continue");
+                                    continue;
+                                }
+                            }
+                        }
+
+                        if ((p_msg = acl_rx_frame_integrity_check_v4l2(p_buf))
+                                                                       == NULL)
+                        {
+                            BRCM_HCI_DUMP_DBG("calling continue");
+                            continue;
+                        }
+                        else {
+                            if(p_msg != p_buf)
+                            {
+                                BRCM_HCI_DUMP_DBG("freeing p_msg");
+                                utils_release(p_msg);
+                            }
+                        }
+
+                        BRCM_HCI_DUMP_DBG("ACL packet: p_msg->len = %d",
+                                                                   p_msg->len);
+                    }
+                    /* For non Evnt pkt */
+                    else if (p_buf->event == MSG_HC_TO_STACK_HCI_EVT)
+                    {
+                        BRCM_HCI_DUMP_DBG("EVT packet");
+                        /* Event packets */
+                        if (p_buf->len < HCI_EVT_PREAMBLE_SIZE)
+                        {
+                            BRCM_HCI_DUMP_ERR("[h5] Invalid EVT length " \
+                                "(0x%04x) drop this packet", p_buf->len);
+                            continue;
+                        }
+
+                        p = (uint8_t *) (p_buf + 1);
+                        msg_len = *(p+1);
+
+                        if (p_buf->len != (msg_len + HCI_EVT_PREAMBLE_SIZE))
+                        {
+                            BRCM_HCI_DUMP_ERR("[h4] EVT message length "\
+                                "(0x%04x) does not match to " \
+                                  "its parameters total length (0x%04x) drop" \
+                                  "this packet", p_buf->len, msg_len);
+                            continue;
+                        }
+
+                        btsnoop_capture(p_buf, TRUE);
+                    }
+                /* start processing the Tx packets */
+                    else if(p_buf->event == MSG_STACK_TO_HC_HCI_ACL ||
+                            p_buf->event == MSG_STACK_TO_HC_HCI_SCO ||
+                            p_buf->event == MSG_STACK_TO_HC_HCI_CMD ||
+                            p_buf->event == MSG_FM_TO_HC_HCI_CMD)
+                    {
+                        btsnoop_capture(p_buf, FALSE);
+                    }
+                    else if (p_buf->event == MSG_HC_TO_FM_HCI_EVT){
+                        btsnoop_capture(p_buf, TRUE);
+                    }
+                /* UNKNOWN packets */
+                    else
+                    {
+                        BRCM_HCI_DUMP_ERR("UNKNOWN event for the packet");
+                    }
+             }
+        }
+        else {
+            BRCM_HCI_DUMP_ERR("select failed with len=%d", len);
+        }
+    }
+
+    BRCM_HCI_DUMP_DBG("Exiting thread hci_snoop_thread from end");
+
+    return 0;
+}
+
+
+int hci_snoop_bkp_file()
+{
+    if (hci_snoop_path != NULL)
+    {
+            char new_path[256] = {0};
+
+            strcpy(new_path, hci_snoop_path);
+            strcat(new_path, ".old");
+            BRCM_HCI_DUMP_DBG("renaming file and creating backup");
+            if (rename(hci_snoop_path, new_path))
+            {
+                BRCM_HCI_DUMP_ERR("logging():rename failed, %d", errno);
+            }
+            BRCM_HCI_DUMP_DBG("opening snoop file");
+            btsnoop_open(hci_snoop_path);
+            return 0;
+    }
+    else {
+        BRCM_HCI_DUMP_ERR("snoop file path is NULL");
+        return -1;
+    }
+
+}
+
+int v4l2_start_hci_snoop()
+{
+    int result=0;
+
+    if(snoop_status == HCI_SNOOP_STOP)
+    {
+        btsnoop_init();
+
+        /* backup previous file and open new snoop file */
+        if(hci_snoop_bkp_file())
+        {
+            BRCM_HCI_DUMP_ERR("Unable to create backup file");
+            return -1;
+        }
+
+        /* start hci snoop thread */
+        if ((result=pthread_create(&thread_hcisnoop, NULL,
+                                          &v4l2_hci_snoop_thread, NULL)) < 0)
+        {
+            BRCM_HCI_DUMP_ERR("pthread_create() FAILED result:%d", result);
+            btsnoop_close();
+            btsnoop_cleanup();
+            return result;
+        }
+
+        ALOGI("brcm_hci_dump:%s hcisnoop read thread STARTED", __func__);
+    }
+    else {
+        BRCM_HCI_DUMP_DBG("hcisnoop read thread already RUNNING");
+    }
+    return result;
+}
+
+int v4l2_stop_hci_snoop()
+{
+    int result;
+
+    BRCM_HCI_DUMP_DBG("called");
+
+    if (snoop_status == HCI_SNOOP_RUNNING)
+    {
+        BRCM_HCI_DUMP_DBG("Sending signal HCISNOOP_EXIT");
+        send_wakeup_signal(HCISNOOP_EXIT);
+    }
+
+    BRCM_HCI_DUMP_DBG("Waiting for pthread_join");
+    if ((result=pthread_join(thread_hcisnoop, NULL)) < 0) {
+        ALOGE("pthread_join() FAILED result:%d", result);
+        return result;
+    }
+
+    BRCM_HCI_DUMP_DBG("snoop joined");
+
+    btsnoop_close();
+    btsnoop_cleanup();
+
+    BRCM_HCI_DUMP_DBG("btsnoop cleanup done");
+
+    BRCM_HCI_DUMP_DBG("hcisnoop read thread EXITED");
+    return result;
+}
+
+int v4l2_get_hci_snoop_status()
+{
+    return snoop_status;
+}
+
+
+
+

--- a/brcm_fmradio/brcm-uim-sysfs/btsnoop.c
+++ b/brcm_fmradio/brcm-uim-sysfs/btsnoop.c
@@ -1,0 +1,731 @@
+/*
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program;if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+  *  Copyright (C) 2009-2015 Broadcom Corporation
+ */
+
+
+/****************************************************************************
+ *
+ *  Name:       btsnoopdisp.c
+ *
+ *  Function:   this file contains functions to generate a BTSNOOP file
+ *
+ *
+ ****************************************************************************/
+#include <stdio.h>
+#include <dlfcn.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <pthread.h>
+#include <sys/prctl.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <fcntl.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <string.h>
+
+/* for gettimeofday */
+#include <sys/time.h>
+/* for the S_* open parameters */
+#include <sys/stat.h>
+/* for write */
+#include <unistd.h>
+/* for O_* open parameters */
+#include <fcntl.h>
+/* defines the O_* open parameters */
+#include <fcntl.h>
+
+#define LOG_TAG "BTSNOOP-DISP-V4L2"
+#include <cutils/log.h>
+
+#include "utils.h"
+#include "btsnoop.h"
+#include "v4l2_cfg.h"
+
+#ifndef BTSNOOP_DBG
+#define BTSNOOP_DBG FALSE
+#endif
+
+#if BTSNOOP_DBG
+#define SNOOPDBG(param, ...) {ALOGD(param, ## __VA_ARGS__);}
+#else
+#define SNOOPDBG(param, ...) {}
+#endif
+
+/* file descriptor of the BT snoop file (by default, -1 means disabled) */
+int hci_btsnoop_fd = -1;
+
+/* Macro to perform a multiplication of 2 unsigned 32bit values and store the result
+ * in an unsigned 64 bit value (as two 32 bit variables):
+ * u64 = u32In1 * u32In2
+ * u32OutLow = u64[31:0]
+ * u32OutHi = u64[63:32]
+ * basically the algorithm:
+ * (hi1*2^16 + lo1)*(hi2*2^16 + lo2) = lo1*lo2 + (hi1*hi2)*2^32 + (hi1*lo2 + hi2*lo1)*2^16
+ * and the carry is propagated 16 bit by 16 bit:
+ * result[15:0] = lo1*lo2 & 0xFFFF
+ * result[31:16] = ((lo1*lo2) >> 16) + (hi1*lo2 + hi2*lo1)
+ * and so on
+ */
+#define HCIDISP_MULT_64(u32In1, u32In2, u32OutLo, u32OutHi)                             \
+do {                                                                                    \
+    uint32_t u32In1Tmp = u32In1;                                                          \
+    uint32_t u32In2Tmp = u32In2;                                                          \
+    uint32_t u32Tmp, u32Carry;                                                            \
+    u32OutLo = (u32In1Tmp & 0xFFFF) * (u32In2Tmp & 0xFFFF);              /*lo1*lo2*/    \
+    u32OutHi = ((u32In1Tmp >> 16) & 0xFFFF) * ((u32In2Tmp >> 16) & 0xFFFF); /*hi1*hi2*/ \
+    u32Tmp = (u32In1Tmp & 0xFFFF) * ((u32In2Tmp >> 16) & 0xFFFF);  /*lo1*hi2*/          \
+    u32Carry = (uint32_t)((u32OutLo>>16)&0xFFFF);                                         \
+    u32Carry += (u32Tmp&0xFFFF);                                                        \
+    u32OutLo += (u32Tmp << 16) ;                                                        \
+    u32OutHi += (u32Tmp >> 16);                                                         \
+    u32Tmp = ((u32In1Tmp >> 16) & 0xFFFF) * (u32In2Tmp & 0xFFFF);                       \
+    u32Carry += (u32Tmp)&0xFFFF;                                                        \
+    u32Carry>>=16;                                                                      \
+    u32OutLo += (u32Tmp << 16);                                                         \
+    u32OutHi += (u32Tmp >> 16);                                                         \
+    u32OutHi += u32Carry;                                                               \
+} while (0)
+
+/* Macro to make an addition of 2 64 bit values:
+ * result = (u32OutHi & u32OutLo) + (u32InHi & u32InLo)
+ * u32OutHi = result[63:32]
+ * u32OutLo = result[31:0]
+ */
+#define HCIDISP_ADD_64(u32InLo, u32InHi, u32OutLo, u32OutHi)                            \
+do {                                                                                    \
+    (u32OutLo) += (u32InLo);                                                            \
+    if ((u32OutLo) < (u32InLo)) (u32OutHi)++;                                           \
+    (u32OutHi) += (u32InHi);                                                            \
+} while (0)
+
+/* EPOCH in microseconds since 01/01/0000 : 0x00dcddb3.0f2f8000 */
+#define BTSNOOP_EPOCH_HI 0x00dcddb3U
+#define BTSNOOP_EPOCH_LO 0x0f2f8000U
+
+#define BTSNOOPBUF_SIZE 2048
+static char snoop_buf[BTSNOOPBUF_SIZE];
+
+#define BTSNOOP_WRITE_MEMORY(DEST,SRC,SIZE,OFFSET)                                     \
+    if (OFFSET + (SIZE) > BTSNOOPBUF_SIZE) {                                           \
+        SNOOPDBG("BTSNOOP_WRITE_MEMORY OVERFLOW size = %d, offset = %d", SIZE, OFFSET);\
+        return;                                                                        \
+    }                                                                                  \
+    memcpy((void*)((char*)DEST + OFFSET), SRC, (SIZE));                              \
+    OFFSET += (SIZE);
+
+/*******************************************************************************
+ **
+ ** Function         tv_to_btsnoop_ts
+ **
+ ** Description      This function generate a BT Snoop timestamp.
+ **
+ ** Returns          void
+ **
+ ** NOTE
+ ** The return value is 64 bit as 2 32 bit variables out_lo and * out_hi.
+ ** A BT Snoop timestamp is the number of microseconds since 01/01/0000.
+ ** The timeval structure contains the number of microseconds since EPOCH
+ ** (01/01/1970) encoded as: tv.tv_sec, number of seconds since EPOCH and
+ ** tv_usec, number of microseconds in current second
+ **
+ ** Therefore the algorithm is:
+ **  result = tv.tv_sec * 1000000
+ **  result += tv.tv_usec
+ **  result += EPOCH_OFFSET
+ *******************************************************************************/
+static void tv_to_btsnoop_ts(uint32_t *out_lo, uint32_t *out_hi, struct timeval *tv)
+{
+    /* multiply the seconds by 1000000 */
+    HCIDISP_MULT_64(tv->tv_sec, 0xf4240, *out_lo, *out_hi);
+
+    /* add the microseconds */
+    HCIDISP_ADD_64((uint32_t)tv->tv_usec, 0, *out_lo, *out_hi);
+
+    /* add the epoch */
+    HCIDISP_ADD_64(BTSNOOP_EPOCH_LO, BTSNOOP_EPOCH_HI, *out_lo, *out_hi);
+}
+
+/*******************************************************************************
+ **
+ ** Function         l_to_be
+ **
+ ** Description      Function to convert a 32 bit value into big endian format
+ **
+ ** Returns          32 bit value in big endian format
+*******************************************************************************/
+static uint32_t l_to_be(uint32_t x)
+{
+    #if __BIG_ENDIAN != TRUE
+    x = (x >> 24) |
+        ((x >> 8) & 0xFF00) |
+        ((x << 8) & 0xFF0000) |
+        (x << 24);
+    #endif
+    return x;
+}
+
+/*******************************************************************************
+ **
+ ** Function         btsnoop_is_open
+ **
+ ** Description      Function to check if BTSNOOP is open
+ **
+ ** Returns          1 if open otherwise 0
+*******************************************************************************/
+int btsnoop_is_open(void)
+{
+#if defined(BTSNOOPDISP_INCLUDED) && (BTSNOOPDISP_INCLUDED == TRUE)
+    SNOOPDBG("btsnoop_is_open: snoop fd = %d\n", hci_btsnoop_fd);
+
+    if (hci_btsnoop_fd != -1)
+    {
+        return 1;
+    }
+    return 0;
+#else
+    return 2;  /* Snoop not available  */
+#endif
+}
+
+/*******************************************************************************
+ **
+ ** Function         btsnoop_log_open
+ **
+ ** Description      Function to open the BTSNOOP file
+ **
+ ** Returns          None
+*******************************************************************************/
+static int btsnoop_log_open(char *btsnoop_logfile)
+{
+#if defined(BTSNOOPDISP_INCLUDED) && (BTSNOOPDISP_INCLUDED == TRUE)
+    hci_btsnoop_fd = -1;
+
+    SNOOPDBG("btsnoop_log_open: snoop log file = %s\n", btsnoop_logfile);
+
+    /* write the BT snoop header */
+    if ((btsnoop_logfile != NULL) && (strlen(btsnoop_logfile) != 0))
+    {
+        hci_btsnoop_fd = open(btsnoop_logfile, \
+                              O_WRONLY|O_CREAT|O_TRUNC, \
+                              S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH);
+        if (hci_btsnoop_fd == -1)
+        {
+            perror("open");
+            SNOOPDBG("btsnoop_log_open: Unable to open snoop log file\n");
+            hci_btsnoop_fd = -1;
+            return 0;
+        }
+        write(hci_btsnoop_fd, "btsnoop\0\0\0\0\1\0\0\x3\xea", 16);
+        return 1;
+    }
+#endif
+    return 2;  /* Snoop not available  */
+}
+
+/*******************************************************************************
+ **
+ ** Function         btsnoop_log_close
+ **
+ ** Description      Function to close the BTSNOOP file
+ **
+ ** Returns          None
+*******************************************************************************/
+static int btsnoop_log_close(void)
+{
+#if defined(BTSNOOPDISP_INCLUDED) && (BTSNOOPDISP_INCLUDED == TRUE)
+    /* write the BT snoop header */
+    if (hci_btsnoop_fd != -1)
+    {
+        SNOOPDBG("btsnoop_log_close: Closing snoop log file\n");
+        close(hci_btsnoop_fd);
+        hci_btsnoop_fd = -1;
+        return 1;
+    }
+    return 0;
+#else
+    return 2;  /* Snoop not available  */
+#endif
+}
+
+/*******************************************************************************
+ **
+ ** Function         btsnoop_hci_cmd
+ **
+ ** Description      Function to add a command in the BTSNOOP file
+ **
+ ** Returns          None
+*******************************************************************************/
+void btsnoop_hci_cmd(uint8_t *p)
+{
+    SNOOPDBG("btsnoop_hci_cmd: fd = %d", hci_btsnoop_fd);
+
+    if (hci_btsnoop_fd != -1)
+    {
+        uint32_t value, value_hi;
+        struct timeval tv;
+        uint32_t btsnoop_offset = 0;
+
+        /* since these display functions are called from different contexts */
+        utils_lock();
+
+        /* store the length in both original and included fields */
+        value = l_to_be(p[2] + 4);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        /* flags: command sent from the host */
+        value = l_to_be(2);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        /* drops: none */
+        value = 0;
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        /* time */
+        gettimeofday(&tv, NULL);
+        tv_to_btsnoop_ts(&value, &value_hi, &tv);
+        value_hi = l_to_be(value_hi);
+        value = l_to_be(value);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value_hi,4,btsnoop_offset);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        /* data */
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,"\x1",1,btsnoop_offset);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,p,p[2] + 3,btsnoop_offset);
+
+        write(hci_btsnoop_fd, snoop_buf, btsnoop_offset);
+
+        /* since these display functions are called from different contexts */
+        utils_unlock();
+    }
+}
+
+/*******************************************************************************
+ **
+ ** Function         btsnoop_hci_evt
+ **
+ ** Description      Function to add a event in the BTSNOOP file
+ **
+ ** Returns          None
+*******************************************************************************/
+void btsnoop_hci_evt(uint8_t *p)
+{
+    SNOOPDBG("btsnoop_hci_evt: fd = %d", hci_btsnoop_fd);
+
+    if (hci_btsnoop_fd != -1)
+    {
+        uint32_t value, value_hi;
+        struct timeval tv;
+        uint32_t btsnoop_offset = 0;
+
+        /* since these display functions are called from different contexts */
+        utils_lock();
+
+        /* store the length in both original and included fields */
+        value = l_to_be(p[1] + 3);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        /* flags: event received in the host */
+        value = l_to_be(3);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        /* drops: none */
+        value = 0;
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        /* time */
+        gettimeofday(&tv, NULL);
+        tv_to_btsnoop_ts(&value, &value_hi, &tv);
+        value_hi = l_to_be(value_hi);
+        value = l_to_be(value);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value_hi,4,btsnoop_offset);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        /* data */
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,"\x4",1,btsnoop_offset);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,p,p[1] + 2,btsnoop_offset);
+
+        write(hci_btsnoop_fd, snoop_buf, btsnoop_offset);
+
+        /* since these display functions are called from different contexts */
+        utils_unlock();
+    }
+}
+
+/*******************************************************************************
+ **
+ ** Function         btsnoop_sco_data
+ **
+ ** Description      Function to add a SCO data packet in the BTSNOOP file
+ **
+ ** Returns          None
+*******************************************************************************/
+void btsnoop_sco_data(uint8_t *p, uint8_t is_rcvd)
+{
+    SNOOPDBG("btsnoop_sco_data: fd = %d", hci_btsnoop_fd);
+
+    if (hci_btsnoop_fd != -1)
+    {
+        uint32_t value, value_hi;
+        struct timeval tv;
+        uint32_t btsnoop_offset = 0;
+
+        /* since these display functions are called from different contexts */
+        utils_lock();
+
+        /* store the length in both original and included fields */
+        value = l_to_be(p[2] + 4);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        /* flags: data can be sent or received */
+        value = l_to_be(is_rcvd?1:0);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        /* drops: none */
+        value = 0;
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        /* time */
+        gettimeofday(&tv, NULL);
+        tv_to_btsnoop_ts(&value, &value_hi, &tv);
+        value_hi = l_to_be(value_hi);
+        value = l_to_be(value);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value_hi,4,btsnoop_offset);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        /* data */
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,"\x3",1,btsnoop_offset);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,p,p[2] + 3,btsnoop_offset);
+
+        write(hci_btsnoop_fd, snoop_buf, btsnoop_offset);
+
+        /* since these display functions are called from different contexts */
+        utils_unlock();
+    }
+}
+
+/*******************************************************************************
+ **
+ ** Function         btsnoop_acl_data
+ **
+ ** Description      Function to add an ACL data packet in the BTSNOOP file
+ **
+ ** Returns          None
+*******************************************************************************/
+void btsnoop_acl_data(uint8_t *p, uint8_t is_rcvd)
+{
+    SNOOPDBG("btsnoop_acl_data: fd = %d", hci_btsnoop_fd);
+    if (hci_btsnoop_fd != -1)
+    {
+        uint32_t value, value_hi;
+        struct timeval tv;
+        uint32_t btsnoop_offset = 0;
+
+        /* since these display functions are called from different contexts */
+        utils_lock();
+
+        /* store the length in both original and included fields */
+        value = l_to_be((p[3]<<8) + p[2] + 5);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        /* flags: data can be sent or received */
+        value = l_to_be(is_rcvd?1:0);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        /* drops: none */
+        value = 0;
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+
+        /* time */
+        gettimeofday(&tv, NULL);
+        tv_to_btsnoop_ts(&value, &value_hi, &tv);
+        value_hi = l_to_be(value_hi);
+        value = l_to_be(value);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value_hi,4,btsnoop_offset);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,&value,4,btsnoop_offset);
+        /* data */
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,"\x2",1,btsnoop_offset);
+        BTSNOOP_WRITE_MEMORY(&snoop_buf,p,(p[3]<<8) + p[2] + 4,btsnoop_offset);
+
+        write(hci_btsnoop_fd, snoop_buf, btsnoop_offset);
+
+        /* since these display functions are called from different contexts */
+        utils_unlock();
+    }
+}
+
+/********************************************************************************
+ ** API allow external realtime parsing of output using e.g hcidump
+ *********************************************************************************/
+
+#define EXT_PARSER_PORT 4330
+
+static pthread_t thread_id;
+static int s_listen = -1;
+static int ext_parser_fd = -1;
+
+static void ext_parser_detached(void);
+
+static int ext_parser_accept(int port)
+{
+    socklen_t           clilen;
+    struct sockaddr_in  cliaddr, servaddr;
+    int s, srvlen;
+    int n = 1;
+    int size_n;
+    int result = 0;
+
+    ALOGD("waiting for connection on port %d", port);
+
+    s_listen = socket(AF_INET, SOCK_STREAM, 0);
+
+    if (s_listen < 0)
+    {
+        ALOGE("listener not created: listen fd %d", s_listen);
+        return -1;
+    }
+
+    memset(&servaddr, 0, sizeof(servaddr));
+    servaddr.sin_family      = AF_INET;
+    servaddr.sin_addr.s_addr = htonl(INADDR_ANY);
+    servaddr.sin_port        = htons(port);
+
+    srvlen = sizeof(servaddr);
+
+    /* allow reuse of sock addr upon bind */
+    result = setsockopt(s_listen, SOL_SOCKET, SO_REUSEADDR, &n, sizeof(n));
+
+    if (result<0)
+    {
+        perror("setsockopt");
+    }
+
+    result = bind(s_listen, (struct sockaddr *) &servaddr, srvlen);
+
+    if (result < 0)
+        perror("bind");
+
+    result = listen(s_listen, 1);
+
+    if (result < 0)
+        perror("listen");
+
+    clilen = sizeof(struct sockaddr_in);
+
+    s = accept(s_listen, (struct sockaddr *) &cliaddr, &clilen);
+
+    if (s < 0)
+{
+        perror("accept");
+        return -1;
+    }
+
+    ALOGD("connected (%d)", s);
+
+    return s;
+}
+
+static int send_ext_parser(char *p, int len)
+{
+    int n;
+
+    /* check if io socket is connected */
+    if (ext_parser_fd == -1)
+        return 0;
+
+    SNOOPDBG("write %d to snoop socket\n", len);
+
+    n = write(ext_parser_fd, p, len);
+
+    if (n<=0)
+    {
+        ext_parser_detached();
+    }
+
+    return n;
+}
+
+static void ext_parser_detached(void)
+{
+    ALOGD("ext parser detached");
+
+    if (ext_parser_fd>0)
+        close(ext_parser_fd);
+
+    if (s_listen > 0)
+        close(s_listen);
+
+    ext_parser_fd = -1;
+    s_listen = -1;
+}
+
+static void interruptFn (int sig)
+{
+    ALOGD("interruptFn");
+    pthread_exit(0);
+}
+
+static void ext_parser_thread(void* param)
+{
+    int fd;
+    int sig = SIGUSR2;
+    sigset_t sigSet;
+    sigemptyset (&sigSet);
+    sigaddset (&sigSet, sig);
+
+    ALOGD("ext_parser_thread");
+
+    prctl(PR_SET_NAME, (unsigned long)"BtsnoopExtParser", 0, 0, 0);
+
+    pthread_sigmask (SIG_UNBLOCK, &sigSet, NULL);
+
+    struct sigaction act;
+    act.sa_handler = interruptFn;
+    sigaction (sig, &act, NULL );
+
+    do
+    {
+        fd = ext_parser_accept(EXT_PARSER_PORT);
+
+        ext_parser_fd = fd;
+
+        ALOGD("ext parser attached on fd %d\n", ext_parser_fd);
+    } while (1);
+}
+
+void btsnoop_stop_listener(void)
+{
+    ALOGD("btsnoop_init");
+    ext_parser_detached();
+}
+
+void btsnoop_init(void)
+{
+#if defined(BTSNOOP_EXT_PARSER_INCLUDED) && (BTSNOOP_EXT_PARSER_INCLUDED == TRUE)
+    ALOGD("btsnoop_init");
+
+    /* always setup ext listener port */
+    if (pthread_create(&thread_id, NULL,
+                       (void*)ext_parser_thread,NULL)!=0)
+      perror("pthread_create");
+#endif
+}
+
+void btsnoop_open(char *p_path)
+{
+#if defined(BTSNOOPDISP_INCLUDED) && (BTSNOOPDISP_INCLUDED == TRUE)
+    ALOGD("btsnoop_open");
+    btsnoop_log_open(p_path);
+#endif // BTSNOOPDISP_INCLUDED
+}
+
+void btsnoop_close(void)
+{
+#if defined(BTSNOOPDISP_INCLUDED) && (BTSNOOPDISP_INCLUDED == TRUE)
+    ALOGD("btsnoop_close");
+    btsnoop_log_close();
+#endif
+}
+
+void btsnoop_cleanup (void)
+{
+#if defined(BTSNOOP_EXT_PARSER_INCLUDED) && (BTSNOOP_EXT_PARSER_INCLUDED == TRUE)
+    ALOGD("btsnoop_cleanup");
+    pthread_kill(thread_id, SIGUSR2);
+    pthread_join(thread_id, NULL);
+    ext_parser_detached();
+#endif
+}
+
+
+#define HCIT_TYPE_COMMAND   1
+#define HCIT_TYPE_ACL_DATA  2
+#define HCIT_TYPE_SCO_DATA  3
+#define HCIT_TYPE_EVENT     4
+
+void btsnoop_capture(HC_BT_HDR *p_buf, uint8_t is_rcvd)
+{
+    uint8_t *p = (uint8_t *)(p_buf + 1) + p_buf->offset;
+
+    SNOOPDBG("btsnoop_capture: fd = %d, type %x, rcvd %d, ext %d", \
+             hci_btsnoop_fd, p_buf->event, is_rcvd, ext_parser_fd);
+
+#if defined(A2DP_LATENCY_TRACKER_ENABLE) && (A2DP_LATENCY_TRACKER_ENABLE == TRUE)
+    if ((p_buf->event & MSG_EVT_MASK) == MSG_HC_TO_STACK_HCI_ACL)
+    {
+        /* assume each received a2dp frame is in one buffer scan 32 first bytes of packet */
+        A2DP_LT_SCAN_ACL(p, (p_buf->len>32)?32:p_buf->len);
+    }
+#endif
+
+#if defined(BTSNOOP_EXT_PARSER_INCLUDED) && (BTSNOOP_EXT_PARSER_INCLUDED == TRUE)
+    if (ext_parser_fd > 0)
+    {
+        uint8_t tmp = *p;
+
+        /* borrow one byte for H4 packet type indicator */
+        p--;
+
+        switch (p_buf->event & MSG_EVT_MASK)
+        {
+              case MSG_HC_TO_STACK_HCI_EVT:
+                  *p = HCIT_TYPE_EVENT;
+                  break;
+              case MSG_HC_TO_STACK_HCI_ACL:
+              case MSG_STACK_TO_HC_HCI_ACL:
+                  *p = HCIT_TYPE_ACL_DATA;
+                  break;
+              case MSG_HC_TO_STACK_HCI_SCO:
+              case MSG_STACK_TO_HC_HCI_SCO:
+                  *p = HCIT_TYPE_SCO_DATA;
+                  break;
+              case MSG_STACK_TO_HC_HCI_CMD:
+                  *p = HCIT_TYPE_COMMAND;
+                  break;
+        }
+
+        send_ext_parser((char*)p, p_buf->len+1);
+        *(++p) = tmp;
+        return;
+    }
+#endif
+
+#if defined(BTSNOOPDISP_INCLUDED) && (BTSNOOPDISP_INCLUDED == TRUE)
+    if (hci_btsnoop_fd == -1)
+        return;
+
+    switch (p_buf->event & MSG_EVT_MASK)
+    {
+        case MSG_HC_TO_STACK_HCI_EVT:
+        case MSG_HC_TO_FM_HCI_EVT:
+            SNOOPDBG("TYPE : EVT");
+            btsnoop_hci_evt(p);
+            break;
+        case MSG_HC_TO_STACK_HCI_ACL:
+        case MSG_STACK_TO_HC_HCI_ACL:
+            SNOOPDBG("TYPE : ACL");
+            btsnoop_acl_data(p, is_rcvd);
+            break;
+        case MSG_HC_TO_STACK_HCI_SCO:
+        case MSG_STACK_TO_HC_HCI_SCO:
+            SNOOPDBG("TYPE : SCO");
+            btsnoop_sco_data(p, is_rcvd);
+            break;
+        case MSG_STACK_TO_HC_HCI_CMD:
+        case MSG_FM_TO_HC_HCI_CMD:
+            SNOOPDBG("TYPE : CMD");
+            btsnoop_hci_cmd(p);
+            break;
+    }
+#endif // BTSNOOPDISP_INCLUDED
+}
+
+

--- a/brcm_fmradio/brcm-uim-sysfs/include/brcm_hci_dump.h
+++ b/brcm_fmradio/brcm-uim-sysfs/include/brcm_hci_dump.h
@@ -1,0 +1,123 @@
+/*
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program;if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+  *  Copyright (C) 2009-2015 Broadcom Corporation
+  *  Copyright (C) 2015 Sony Mobile Communications Inc.
+  *
+  *  NOTE: This file has been modified by Sony Mobile Communications Inc.
+  *  Modifications are licensed under the License.
+ */
+
+#ifndef __HCI_SNOOP_DUMP_V4L2
+#define __HCI_SNOOP_DUMP_V4L2
+
+#define HCI_SNOOP_PATH_LEN 200
+
+#define MSG_FM_TO_HC_HCI_CMD           0x4000
+#define MSG_HC_TO_FM_HCI_EVT           0x3000
+
+#define TRUE   1
+#define FALSE  0
+
+/* function declarations */
+int v4l2_start_hci_snoop();
+int v4l2_stop_hci_snoop();
+int v4l2_get_hci_snoop_status();
+
+typedef enum
+{
+    HCI_SNOOP_STARTING,
+    HCI_SNOOP_RUNNING,
+    HCI_SNOOP_STOP
+} HCI_SNOOP_STATUS;
+
+enum {
+    HCISNOOP_EXIT,
+};
+
+
+/* HCI HCI_V4L2 message type definitions */
+#define HCI_V4L2_TYPE_COMMAND         1
+#define HCI_V4L2_TYPE_ACL_DATA        2
+#define HCI_V4L2_TYPE_SCO_DATA        3
+#define HCI_V4L2_TYPE_EVENT           4
+#define HCI_V4L2_TYPE_FM_CMD          8
+
+
+/* Message event ID passed from stack to vendor lib */
+#define MSG_STACK_TO_HC_HCI_ACL        0x2100 /* eq. BT_EVT_TO_LM_HCI_ACL */
+#define MSG_STACK_TO_HC_HCI_SCO        0x2200 /* eq. BT_EVT_TO_LM_HCI_SCO */
+#define MSG_STACK_TO_HC_HCI_CMD        0x2000 /* eq. BT_EVT_TO_LM_HCI_CMD */
+#define MSG_FM_TO_HC_HCI_CMD           0x4000
+#define MSG_HC_TO_STACK_HCI_EVT        0x1000 /* eq. BT_EVT_TO_BTU_HCI_EVT */
+#define MSG_HC_TO_FM_HCI_EVT           0x3000
+
+
+/* Preamble length for HCI Commands:
+**      2-bytes for opcode and 1 byte for length
+*/
+#define HCI_CMD_PREAMBLE_SIZE   3
+
+/* Preamble length for HCI Events:
+**      1-byte for opcode and 1 byte for length
+*/
+#define HCI_EVT_PREAMBLE_SIZE   2
+
+/* Preamble length for SCO Data:
+**      2-byte for Handle and 1 byte for length
+*/
+#define HCI_SCO_PREAMBLE_SIZE   3
+
+/* Preamble length for ACL Data:
+**      2-byte for Handle and 2 byte for length
+*/
+#define HCI_ACL_PREAMBLE_SIZE   4
+
+/* Table of HCI preamble sizes for the different HCI message types */
+static const uint8_t hci_preamble_table[] =
+{
+    HCI_CMD_PREAMBLE_SIZE,
+    HCI_ACL_PREAMBLE_SIZE,
+    HCI_SCO_PREAMBLE_SIZE,
+    HCI_EVT_PREAMBLE_SIZE
+};
+
+
+
+#define ACL_RX_PKT_START        2
+#define ACL_RX_PKT_CONTINUE     1
+#define L2CAP_HEADER_SIZE       4
+#define MAX_ACL_PDU_SIZE ((uint16_t)0xFFFF - HCI_ACL_PREAMBLE_SIZE \
+                                                     - L2CAP_HEADER_SIZE)
+/* Preamble length for ACL Data:
+**      2-byte for Handle and 2 byte for length
+*/
+#define HCI_ACL_PREAMBLE_SIZE   4
+#define MSG_HC_TO_STACK_HCI_ACL        0x1100 /* eq. BT_EVT_TO_BTU_HCI_ACL */
+
+
+/******************************************************************************
+**  Constants & Macros
+******************************************************************************/
+
+#define STREAM_TO_UINT16(u16, p) {u16 = ((uint16_t)(*(p)) + (((uint16_t)(*((p) + 1))) << 8)); (p) += 2;}
+#define UINT16_TO_STREAM(p, u16) {*(p)++ = (uint8_t)(u16); *(p)++ = (uint8_t)((u16) >> 8);}
+#define UINT32_TO_STREAM(p, u32) {*(p)++ = (uint8_t)(u32); *(p)++ = (uint8_t)((u32) >> 8); *(p)++ = (uint8_t)((u32) >> 16); *(p)++ = (uint8_t)((u32) >> 24);}
+
+
+
+#endif
+

--- a/brcm_fmradio/brcm-uim-sysfs/include/btsnoop.h
+++ b/brcm_fmradio/brcm-uim-sysfs/include/btsnoop.h
@@ -1,0 +1,71 @@
+/*
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program;if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+  *  Copyright (C) 2009-2015 Broadcom Corporation
+ */
+
+#ifndef V4L2_SNOOP
+#define V4L2_SNOOP
+
+
+#ifndef BTSNOOPDISP_INCLUDED
+#define BTSNOOPDISP_INCLUDED TRUE
+#endif
+
+/* Disable external parser for production */
+#ifndef BTSNOOP_EXT_PARSER_INCLUDED
+#define BTSNOOP_EXT_PARSER_INCLUDED FALSE
+#endif
+
+typedef struct
+{
+    uint16_t          event;
+    uint16_t          len;
+    uint16_t          offset;
+    uint16_t          layer_specific;
+} HC_BT_HDR;
+
+#define BT_HC_HDR_SIZE (sizeof(HC_BT_HDR))
+
+
+/* Message event mask across Host/Controller lib and stack */
+#define MSG_EVT_MASK                    0xFF00 /* eq. BT_EVT_MASK */
+#define MSG_SUB_EVT_MASK                0x00FF /* eq. BT_SUB_EVT_MASK */
+
+/* Message event ID passed from Host/Controller lib to stack */
+#define MSG_HC_TO_STACK_HCI_ERR        0x1300 /* eq. BT_EVT_TO_BTU_HCIT_ERR */
+#define MSG_HC_TO_STACK_HCI_ACL        0x1100 /* eq. BT_EVT_TO_BTU_HCI_ACL */
+#define MSG_HC_TO_STACK_HCI_SCO        0x1200 /* eq. BT_EVT_TO_BTU_HCI_SCO */
+#define MSG_HC_TO_STACK_HCI_EVT        0x1000 /* eq. BT_EVT_TO_BTU_HCI_EVT */
+#define MSG_HC_TO_STACK_L2C_SEG_XMIT   0x1900 /* eq. BT_EVT_TO_BTU_L2C_SEG_XMIT */
+
+/* Message event ID passed from stack to vendor lib */
+#define MSG_STACK_TO_HC_HCI_ACL        0x2100 /* eq. BT_EVT_TO_LM_HCI_ACL */
+#define MSG_STACK_TO_HC_HCI_SCO        0x2200 /* eq. BT_EVT_TO_LM_HCI_SCO */
+#define MSG_STACK_TO_HC_HCI_CMD        0x2000 /* eq. BT_EVT_TO_LM_HCI_CMD */
+
+/* Message event/cmd related to FM*/
+#define MSG_FM_TO_HC_HCI_CMD           0x4000
+#define MSG_HC_TO_FM_HCI_EVT           0x3000
+
+void btsnoop_capture(HC_BT_HDR *p_buf, uint8_t is_rcvd);
+void btsnoop_open(char *p_path);
+void btsnoop_init(void);
+void btsnoop_close(void);
+void btsnoop_cleanup (void);
+
+#endif
+

--- a/brcm_fmradio/brcm-uim-sysfs/include/uim.h
+++ b/brcm_fmradio/brcm-uim-sysfs/include/uim.h
@@ -1,0 +1,185 @@
+/*
+ *  User Mode Init manager - For shared transport
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program;if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ *  Copyright (C) 2009-2015 Broadcom Corporation
+ */
+
+
+/************************************************************************************
+*
+*  Filename:      brcm_uim.h
+*
+*  Description:   User Interface Module header file.
+*
+***********************************************************************************/
+
+
+#ifndef UIM_H
+#define UIM_H
+
+#define TRUE 1
+#define FALSE 0
+
+/*HCI Command and Event information*/
+#define HCI_HDR_OPCODE          0xff36
+#define WRITE_BD_ADDR_OPCODE    0xFC06
+#define RESP_PREFIX             0x04
+#define MAX_TRY                 10
+
+/* HCI Packet types */
+#define HCI_COMMAND_PKT         0x01
+#define HCI_EVENT_PKT           0x04
+
+
+/* HCI command macros */
+#define HCI_EVENT_HDR_SIZE              2
+#define HCI_COMMAND_HDR_SIZE            3
+#define UIM_WRITE_BD_ADDR_CP_SIZE       6
+
+
+/* HCI event macros */
+#define EVT_CMD_COMPLETE_SIZE   3
+#define EVT_CMD_STATUS_SIZE     4
+#define EVT_CMD_COMPLETE        0x0E
+#define EVT_CMD_STATUS          0x0F
+
+/* Set proto for shared LDISC */
+#define HCIUARTSETPROTO     _IOW('U', 200, int)
+#define HCI_UART_H4     0
+#define HCI_UART_BCSP   1
+#define HCI_UART_3WIRE  2
+#define HCI_UART_H4DS   3
+#define HCI_UART_LL     4
+
+#define LPM_SLEEP_MODE 1
+#define LPM_IDLE_THRESHOLD 1
+#define LPM_HC_IDLE_THRESHOLD 1
+#define LPM_BT_WAKE_POLARITY 1
+#define LPM_HOST_WAKE_POLARITY 1
+#define LPM_ALLOW_HOST_SLEEP_DURING_SCO 1
+#define LPM_COMBINE_SLEEP_MODE_AND_LPM 1
+#define LPM_ENABLE_UART_TXD_TRI_STATE 0
+#define LPM_PULSED_HOST_WAKE 0
+#define LPM_CMD_PARAM_SIZE 12
+
+/* low power mode parameters */
+typedef struct
+{
+    uint8_t sleep_mode;                     /* 0(disable),1(UART),9(H5) */
+    uint8_t host_stack_idle_threshold;      /* Unit scale 300ms/25ms */
+    uint8_t host_controller_idle_threshold; /* Unit scale 300ms/25ms */
+    uint8_t bt_wake_polarity;               /* 0=Active Low, 1= Active High */
+    uint8_t host_wake_polarity;             /* 0=Active Low, 1= Active High */
+    uint8_t allow_host_sleep_during_sco;
+    uint8_t combine_sleep_mode_and_lpm;
+    uint8_t enable_uart_txd_tri_state;      /* UART_TXD Tri-State */
+    uint8_t sleep_guard_time;               /* sleep guard time in 12.5ms */
+    uint8_t wakeup_guard_time;              /* wakeup guard time in 12.5ms */
+    uint8_t txd_config;                     /* TXD is high in sleep state */
+    uint8_t pulsed_host_wake;               /* pulsed host wake if mode = 1 */
+} btuim_lpm_param_t;
+
+/* HCI command header*/
+typedef struct {
+    uint16_t        opcode;         /* OCF & OGF */
+    uint8_t         plen;
+} __attribute__ ((packed))      hci_command_hdr;
+
+/* HCI event header*/
+typedef struct {
+    uint8_t         evt;
+    uint8_t         plen;
+} __attribute__ ((packed))      hci_event_hdr;
+
+/* HCI command complete event*/
+typedef struct {
+    uint8_t         ncmd;
+    uint16_t        opcode;
+} __attribute__ ((packed)) evt_cmd_complete;
+
+/* HCI event status*/
+typedef struct {
+    uint8_t         status;
+    uint8_t         ncmd;
+    uint16_t        opcode;
+} __attribute__ ((packed)) evt_cmd_status;
+
+/* HCI Event structure to set the cusrom baud rate*/
+typedef struct {
+    uint8_t uart_prefix;
+    hci_event_hdr hci_hdr;
+    evt_cmd_complete cmd_complete;
+    uint8_t status;
+    uint8_t data[16];
+} __attribute__ ((packed)) command_complete_t;
+
+typedef struct {
+    unsigned char address[6];
+} __attribute__((packed)) bdaddr_t;
+
+/* HCI Command structure to set the uim BD address*/
+typedef struct {
+    uint8_t uart_prefix;
+    hci_command_hdr hci_hdr;
+    bdaddr_t addr;
+} __attribute__ ((packed)) uim_bdaddr_change_cmd;
+
+/* Sys_fs entry. The Line discipline driver sets this to 1 when bluedroid open BT protocol driver */
+/* Note: This entry is used in bt_hci_bdroid.c (Android source). Also present in
+ *  brcm_sh_ldisc.c (v4l2_drivers) and board specific file (android kernel source) */
+#define INSTALL_SYSFS_ENTRY "/sys/bus/platform/drivers/bcm_ldisc/bcmbt_ldisc.93/install"
+#define LDISC_VENDOR_PARAMS   "/sys/bus/platform/drivers/bcm_ldisc/bcmbt_ldisc.93/vendor_params"
+
+#define BDADDR_SYSFS_ENTRY  "/sys/bus/platform/drivers/bcm_ldisc/bcmbt_ldisc.93/bdaddr"
+#define FW_PATCHFILE_SYSFS_ENTRY  "/sys/bus/platform/drivers/bcm_ldisc/bcmbt_ldisc.93/fw_patchfile"
+#define LDISC_SYSFS_SNOOP     "/sys/bus/platform/drivers/bcm_ldisc/bcmbt_ldisc.93/snoop_enable"
+
+/* install sysfs entry values */
+#define V4L2_STATUS_ERR '2'  // error occured in BT application (HCI command timeout or HW error)
+#define V4L2_STATUS_ON  '1'  // Atleast one procol driver is registered
+#define V4L2_STATUS_OFF '0'  // No procol drivers registered
+
+/* File used for hardware config. Read udev_name, baudrate and module path from this file */
+#define VENDOR_LIB_CONF_FILE "/etc/bluetooth/bt_vendor.conf"
+
+
+/* HCI response opcodes */
+#define HCI_RSP_OPCODE_HCI_RST        0x0c03
+#define HCI_RSP_OPCODE_HCI_LPM_DIS        0xfc27
+#define HCI_RSP_OPCODE_SET_BAUDRATE   0xfc18
+#define HCI_RSP_OPCODE_HCI_UART_CLOCK_SET        0xfc45
+
+#define MAX_KMODULE_PATH_SIZE 100
+#define UART_PORT_NAME_SIZE 20
+
+#define N_BRCM_HCI 26
+
+
+/* Functions to insert and remove the kernel modules from the system*/
+extern int init_module(void *, unsigned int, const char *);
+extern int delete_module(const char *, unsigned int);
+
+/* Function declarations */
+void proc_init_uart(int uart_fd, struct termios *termios);
+int st_uart_config(unsigned char install);
+int proc_hci_reset();
+extern int upio_set_bluetooth_power(int on);
+int proc_hci_uartclockset();
+void read_default_bdaddr();
+int proc_bdaddr();
+
+#endif /* UIM_H */

--- a/brcm_fmradio/brcm-uim-sysfs/include/utils.h
+++ b/brcm_fmradio/brcm-uim-sysfs/include/utils.h
@@ -1,0 +1,243 @@
+/*
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program;if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+  *  Copyright (C) 2009-2015 Broadcom Corporation
+ */
+
+
+/******************************************************************************
+ *
+ *  Filename:      utils.h
+ *
+ *  Description:   Utility functions declaration
+ *
+ ******************************************************************************/
+
+#ifndef UTILS_H
+#define UTILS_H
+
+
+
+/******************************************************************************
+**  Type definitions
+******************************************************************************/
+
+typedef struct
+{
+    void        *p_first;
+    void        *p_last;
+    uint16_t    count;
+} BUFFER_Q;
+
+typedef struct _hc_buffer_hdr
+{
+    struct _hc_buffer_hdr *p_next;   /* next buffer in the queue */
+} HC_BUFFER_HDR_T;
+
+#define BT_HC_BUFFER_HDR_SIZE (sizeof(HC_BUFFER_HDR_T))
+
+#define MAX_ACL_PKT_SIZE 4096
+
+
+/******************************************************************************
+**  Extern variables and functions
+******************************************************************************/
+
+/******************************************************************************
+**  Functions
+******************************************************************************/
+
+/*******************************************************************************
+**
+** Function        utils_init
+**
+** Description     Utils initialization
+**
+** Returns         None
+**
+*******************************************************************************/
+void utils_init ();
+
+/*******************************************************************************
+**
+** Function        utils_cleanup
+**
+** Description     Utils cleanup
+**
+** Returns         None
+**
+*******************************************************************************/
+void utils_cleanup ();
+
+/*******************************************************************************
+**
+** Function        utils_queue_init
+**
+** Description     Initialize the given buffer queue
+**
+** Returns         None
+**
+*******************************************************************************/
+static void utils_queue_init (BUFFER_Q *p_q);
+
+/*******************************************************************************
+**
+** Function        utils_enqueue
+**
+** Description     Enqueue a buffer at the tail of the given queue
+**
+** Returns         None
+**
+*******************************************************************************/
+void utils_enqueue (void *p_buf);
+
+/*******************************************************************************
+**
+** Function        utils_dequeue
+**
+** Description     Dequeues a buffer from the head of the given queue
+**
+** Returns         NULL if queue is empty, else buffer
+**
+*******************************************************************************/
+void *utils_dequeue (BUFFER_Q *p_q);
+
+/*******************************************************************************
+**
+** Function        utils_dequeue_unlocked
+**
+** Description     Dequeues a buffer from the head of the given queue without lock
+**
+** Returns         NULL if queue is empty, else buffer
+**
+*******************************************************************************/
+void *utils_dequeue_unlocked (BUFFER_Q *p_q);
+
+/*******************************************************************************
+**
+** Function        utils_getnext
+**
+** Description     Return a pointer to the next buffer linked to the given buffer
+**
+** Returns         NULL if the given buffer does not point to any next buffer,
+**                 else next buffer address
+**
+*******************************************************************************/
+void *utils_getnext (void *p_buf);
+
+/*******************************************************************************
+**
+** Function        utils_remove_from_queue
+**
+** Description     Dequeue the given buffer from the middle of the given queue
+**
+** Returns         NULL if the given queue is empty, else the given buffer
+**
+*******************************************************************************/
+void *utils_remove_from_queue (void *p_buf);
+
+/*******************************************************************************
+**
+** Function        utils_remove_from_queue_unlocked
+**
+** Description     Dequeue the given buffer from the middle of the given queue without lock
+**
+** Returns         NULL if the given queue is empty, else the given buffer
+**
+*******************************************************************************/
+void *utils_remove_from_queue_unlocked (BUFFER_Q *p_q, void *p_buf);
+
+
+/*******************************************************************************
+**
+** Function        utils_delay
+**
+** Description     sleep unconditionally for timeout milliseconds
+**
+** Returns         None
+**
+*******************************************************************************/
+void utils_delay (uint32_t timeout);
+
+/*******************************************************************************
+**
+** Function        utils_lock
+**
+** Description     application calls this function before entering critical
+**                 section
+**
+** Returns         None
+**
+*******************************************************************************/
+void utils_lock (void);
+
+/*******************************************************************************
+**
+** Function        utils_unlock
+**
+** Description     application calls this function when leaving critical
+**                 section
+**
+** Returns         None
+**
+*******************************************************************************/
+void utils_unlock (void);
+
+/*******************************************************************************
+**
+** Function        utils_alloc
+**
+** Description     allocate memory for buffer
+**
+** Returns         None
+**
+*******************************************************************************/
+uint8_t* utils_alloc (int size);
+
+/*******************************************************************************
+**
+** Function        utils_lelease
+**
+** Description     release memory for buffer
+**
+** Returns         None+**
+*******************************************************************************/
+void utils_release(uint8_t* ptr);
+
+/*******************************************************************************
+**
+** Function        utils_get_count
+**
+** Description     Get number of allocated buffers
+**
+** Returns         None
+**
+*******************************************************************************/
+uint16_t utils_get_count();
+
+/*******************************************************************************
+**
+** Function        utils_get_count
+**
+** Description     Get number of allocated buffers
+**
+** Returns         None
+**
+*******************************************************************************/
+void* utils_get_first ();
+
+#endif /* UTILS_H */
+

--- a/brcm_fmradio/brcm-uim-sysfs/include/v4l2_cfg.h
+++ b/brcm_fmradio/brcm-uim-sysfs/include/v4l2_cfg.h
@@ -1,0 +1,48 @@
+/*
+ *  User Mode Init manager - For shared transport
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program;if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+ *  Copyright (C) 2009-2015 Broadcom Corporation
+ */
+
+
+/************************************************************************************
+*
+*  Filename:      v4l2_cfg.h
+*
+*  Description:   Configure v4l2 related settings.
+*
+***********************************************************************************/
+
+#define TRUE 1
+#define FALSE 0
+
+/* Set this to false for production release */
+#ifndef V4L2_SNOOP_ENABLE
+#define V4L2_SNOOP_ENABLE TRUE
+#endif
+
+/* Set this to true for debugging uim */
+#ifndef UIM_DEBUG
+#define UIM_DEBUG FALSE
+#endif
+
+/* Set this to false for production release */
+#ifndef DBG_V4L2_DRIVERS
+#define DBG_V4L2_DRIVERS TRUE
+#endif
+
+

--- a/brcm_fmradio/brcm-uim-sysfs/uim.c
+++ b/brcm_fmradio/brcm-uim-sysfs/uim.c
@@ -1,0 +1,1580 @@
+/*
+ *  User Mode Init manager - For shared transport
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program;if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+  *  Copyright (C) 2009-2015 Broadcom Corporation
+  *  Copyright (C) 2015 Sony Mobile Communications Inc.
+  *
+  *  NOTE: This file has been modified by Sony Mobile Communications Inc.
+  *  Modifications are licensed under the License.
+ */
+
+
+ /************************************************************************************
+*
+*  Filename:      uim.c
+*
+*  Description:   User Interface Module (UIM) for performing UART config when a driver (BT protocol driver or
+*                      V4L2 based FM driver) registers with Line discipline driver.
+*                      This program runs as a daemon on system bootup.
+*
+***********************************************************************************/
+/* Set macro to true in buildspec.mk */
+
+#include <stdio.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <signal.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+#include <poll.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/utsname.h>
+#include <dirent.h>
+#include <malloc.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "uim.h"
+#include "brcm_hci_dump.h"
+#include "v4l2_cfg.h"
+#ifdef ANDROID
+#include <private/android_filesystem_config.h>
+#include <cutils/properties.h>
+#include <cutils/log.h>
+#include <cutils/misc.h>
+#endif
+
+#define LOG_TAG "brcm-uim"
+
+#define UIM_DEBUG 1
+
+#if UIM_DEBUG          /* limited debug messages */
+#define UIM_START_FUNC()      ALOGI("brcm-uim: Begin %s", __FUNCTION__)
+#define UIM_END_FUNC()      ALOGI("brcm-uim: End %s", __FUNCTION__)
+#define UIM_DBG(fmt, arg...)  ALOGI("brcm-uim:"fmt"\n" , ## arg)
+#else /* error msgs only */
+#define UIM_START_FUNC()
+#define UIM_END_FUNC()
+#define UIM_DBG(fmt, arg...)
+#endif
+#define UIM_VER(fmt, arg...) ALOGI("brcm-uim: "fmt"\n" , ## arg)
+#define UIM_ERR(fmt, arg...) ALOGE("brcm-uim: ERR "fmt"\n" , ## arg)
+
+
+#define CFG_PARAM_STRING_SIZE 300
+#define UIM_FAIL -1
+#define FACTORY_BT_BDADDR_STORAGE_LEN   17
+#define BD_ADDR_LEN     6                   /* Device address length */
+#define PROPERTY_BT_BDADDR_PATH         "ro.bt.bdaddr_path"
+#define PERSIST_BDADDR_PROPERTY         "persist.service.bdroid.bdaddr"
+#define STACK_CONF_FILE "/etc/bluetooth/bt_stack.conf"
+#define FW_PATCH_FILENAME_MAXLEN 80
+#define fw_patchfile_path "/vendor/firmware"
+#define FW_PATCHFILE_EXTENSION      ".hcd"
+#define FW_PATCHFILE_EXTENSION_LEN  4
+#define HCI_EVT_CMD_CMPL_LOCAL_NAME_STRING 7
+#define READ_LOCALNAME_RESP_BUFF_SIZE 100
+
+typedef char bdstr_t[18];
+
+/* Maintains the exit state of UIM*/
+static int exiting;
+
+/* File descriptor for the UART device*/
+int dev_fd = -1;
+
+/* termios to set baudrate */
+struct termios termios;
+
+/* BD address as string and a pointer to array of hex bytes */
+bdaddr_t bd_addr;
+
+/* parameters read from bt_vendor.conf */
+static char hw_cfg_string[CFG_PARAM_STRING_SIZE] = {0}; /* pass as parameter to ldisc */
+static unsigned long cust_baud_rate = 3000000;
+static char driver_module_path[MAX_KMODULE_PATH_SIZE] = "/system/lib/modules/";
+static char uart_port_name[UART_PORT_NAME_SIZE] = "/dev/ttyS1";
+int lpmenable;
+int hci_snoop_enable = 0;
+char hci_snoop_path[HCI_SNOOP_PATH_LEN] = "/sdcard/btsnoop_hci.log";
+static char bt_dbg_cfg_string[CFG_PARAM_STRING_SIZE] = "";
+static char fm_dbg_cfg_string[CFG_PARAM_STRING_SIZE] = "";
+static char fw_patchfile_name[FW_PATCH_FILENAME_MAXLEN] = "";
+
+
+btuim_lpm_param_t lpm_uim_param =
+{
+    LPM_SLEEP_MODE,//1
+    LPM_IDLE_THRESHOLD,//1
+    LPM_HC_IDLE_THRESHOLD,//1
+    LPM_BT_WAKE_POLARITY,//1
+    LPM_HOST_WAKE_POLARITY,//1
+    LPM_ALLOW_HOST_SLEEP_DURING_SCO,//1
+    LPM_COMBINE_SLEEP_MODE_AND_LPM,//1
+    LPM_ENABLE_UART_TXD_TRI_STATE,//0
+    0,  /* not applicable */
+    0,  /* not applicable */
+    0,  /* not applicable */
+    LPM_PULSED_HOST_WAKE//0
+};
+
+int pass_vendor_params()
+{
+    int fd_vendor_params = 0;
+    int len;
+
+    fd_vendor_params = open(LDISC_VENDOR_PARAMS, O_WRONLY);
+    if (fd_vendor_params > 0)
+    {
+        if(write(fd_vendor_params, hw_cfg_string, CFG_PARAM_STRING_SIZE) < 0)
+            return UIM_FAIL;
+
+        UIM_DBG("vendor params passed to ldisc");
+        return 0;
+    }
+    else
+        return UIM_FAIL;
+}
+
+/*******************************************************************************
+**
+** Function        userial_set_port
+**
+** Description     Configure UART port name
+**
+** Returns         0 : Success
+**                 Otherwise : Fail
+**
+*******************************************************************************/
+int userial_set_port(char *p_conf_name, char *p_conf_value)
+{
+    strcpy(uart_port_name, p_conf_value);
+    UIM_DBG("%s = %s", p_conf_name, p_conf_value);
+    return 0;
+}
+/*******************************************************************************
+**
+** Function        hw_set_lpm_polarity
+**
+** Description     configures host & bt wake polarity
+**                 0: active low (negative logic)
+**                 1: active high (positive logic)
+**
+** Returns         0 : Success
+**                 Otherwise : Fail
+**
+*******************************************************************************/
+int hw_set_lpm_polarity(char *p_conf_name, char *p_conf_value)
+{
+    uint8_t polarity = (atoi(p_conf_value) & 1);
+    lpm_uim_param.bt_wake_polarity = lpm_uim_param.host_wake_polarity = polarity;
+
+    UIM_DBG("%s BT_WAKE and HOST_WAKE polarity set", __func__);
+    UIM_DBG("%s = %s", p_conf_name, p_conf_value);
+    return 0;
+}
+/*****************************************************************************
+* Function to convert the BD address from hex to ascii value
+*****************************************************************************/
+
+char* bd2str(const bdaddr_t *bdaddr, bdstr_t *bdstr)
+    {
+        const uint8_t *addr = bdaddr->address;
+
+        sprintf(*bdstr, "%02x:%02x:%02x:%02x:%02x:%02x",
+                           addr[0], addr[1], addr[2],
+                           addr[3], addr[4], addr[5]);
+        return *bdstr;
+}
+/*******************************************************************************
+**
+** Function        hw_set_btwake
+**
+** Description     Enable bluesleep in Line discipline driver based on this value
+**
+** Returns         0 : Success
+**                 Otherwise : Fail
+**
+*******************************************************************************/
+int hw_set_btwake(char *p_conf_name, char *p_conf_value)
+{
+    char bluesleep_enable[10];
+    int bluesleepenable;
+    strcat(hw_cfg_string, " LpmUseBluesleep=");
+    if (strcmp(p_conf_value, "true") == 0){
+        bluesleepenable =1;
+        sprintf(bluesleep_enable,"%d",bluesleepenable);
+    }
+    else{
+        bluesleepenable =0;
+        sprintf(bluesleep_enable,"%d",bluesleepenable);
+    }
+    strcat(hw_cfg_string, bluesleep_enable);
+    UIM_DBG("%s = %s", p_conf_name, p_conf_value);
+    return 0;
+}
+
+/*******************************************************************************
+ **
+ ** Function        hw_check_readcontroller_addr
+ **
+ ** Description     Check whether to read controller bd address
+ **
+ ** Returns         0 : Success
+ **                 Otherwise : Fail
+ **
+ *******************************************************************************/
+int hw_check_readcontroller_addr(char *p_conf_name, char *p_conf_value)
+{
+    char controller_addrread[10];
+    int controlleraddrread;
+    strcat(hw_cfg_string, " ControllerAddrRead=");
+    if (strcmp(p_conf_value, "true") == 0){
+        controlleraddrread =1;
+        sprintf(controller_addrread,"%d",controlleraddrread);
+    }
+    else{
+        controlleraddrread =0;
+        sprintf(controller_addrread,"%d",controlleraddrread);
+    }
+    strcat(hw_cfg_string, controller_addrread);
+    UIM_DBG("%s = %s", p_conf_name, p_conf_value);
+    return 0;
+}
+
+/*******************************************************************************
+ **
+ ** Function        hw_set_lpm
+ **
+ ** Description     Enable LPM in Line discipline driver based on this value
+ **
+ ** Returns         0 : Success
+ **                 Otherwise : Fail
+ **
+ *******************************************************************************/
+int hw_set_lpm(char *p_conf_name, char *p_conf_value)
+{
+    if (strcmp(p_conf_value, "true") == 0)
+        lpmenable =1;
+    else
+        lpmenable =0;
+
+    UIM_DBG("%s = %s", p_conf_name, p_conf_value);
+    return 0;
+}
+
+
+/*******************************************************************************
+ **
+ ** Function        hw_set_uart_baudrate
+ **
+ ** Description     Give the baudrate for uart
+ **
+ ** Returns         0 : Success
+ **                 Otherwise : Fail
+ **
+ *******************************************************************************/
+int hw_set_uart_baudrate(char *p_conf_name, char *p_conf_value)
+{
+    strcat(hw_cfg_string, " custom_baudrate=");
+    strcat(hw_cfg_string, p_conf_value);
+    sscanf(p_conf_value, "%lu", &cust_baud_rate);
+    UIM_DBG("%s = %s", p_conf_name, p_conf_value);
+    return 0;
+}
+
+
+/*******************************************************************************
+ **
+ ** Function        hw_set_driver_module_path
+ **
+ ** Description     set the location of .ko modules (driver modules) to insmod at startup.
+ **
+ ** Returns         0 : Success
+ **                 Otherwise : Fail
+ **
+ *******************************************************************************/
+int hw_set_driver_module_path(char *p_conf_name, char *p_conf_value)
+{
+    strcpy(driver_module_path, p_conf_value);
+    UIM_DBG("%s = %s", p_conf_name, p_conf_value);
+    return 0;
+}
+
+/*******************************************************************************
+ **
+ ** Function        hw_set_patchram_settlement_delay
+ **
+ ** Description     set the location of .ko modules (driver modules) to insmod at startup.
+ **
+ ** Returns         0 : Success
+ **                 Otherwise : Fail
+ **
+ *******************************************************************************/
+int hw_set_patchram_settlement_delay(char *p_conf_name, char *p_conf_value)
+{
+    strcat(hw_cfg_string, " patchram_settlement_delay=");
+    strcat(hw_cfg_string, p_conf_value);
+    UIM_DBG("%s = %s", p_conf_name, p_conf_value);
+    return 0;
+}
+
+/*******************************************************************************
+ **
+ ** Function        hw_set_patchram_filename
+ **
+ ** Description     set the patchram filename.
+ **
+ ** Returns         0 : Success
+ **                 Otherwise : Fail
+ **
+ *******************************************************************************/
+int hw_set_patchram_filename(char *p_conf_name, char *p_conf_value)
+{
+    strcpy(fw_patchfile_name, p_conf_value);
+    UIM_DBG("%s = %s", p_conf_name, p_conf_value);
+    return 0;
+}
+
+
+#if DBG_V4L2_DRIVERS
+/*******************************************************************************
+ **
+ ** Function        dbg_ldisc_drv
+ **
+ ** Description     set to enable debugging in Line discipline driver
+ **
+ ** Returns         0 : Success
+ **                 Otherwise : Fail
+ **
+ *******************************************************************************/
+int dbg_ldisc_drv(char *p_conf_name, char *p_conf_value)
+{
+    strcat(hw_cfg_string, " ldisc_dbg_param=");
+    strcat(hw_cfg_string, p_conf_value);
+    UIM_DBG("%s = %s", p_conf_name, p_conf_value);
+    return 0;
+}
+
+/*******************************************************************************
+ **
+ ** Function        dbg_bt_drv
+ **
+ ** Description     set to enable debugging in BT driver
+ **
+ ** Returns         0 : Success
+ **                 Otherwise : Fail
+ **
+ *******************************************************************************/
+int dbg_bt_drv(char *p_conf_name, char *p_conf_value)
+{
+    strcat(bt_dbg_cfg_string, " bt_dbg_param=");
+    strcat(bt_dbg_cfg_string, p_conf_value);
+    UIM_DBG("%s = %s", p_conf_name, p_conf_value);
+    return 0;
+}
+
+/*******************************************************************************
+ **
+ ** Function        dbg_fm_drv
+ **
+ ** Description     set to enable debugging in FM driver
+ **
+ ** Returns         0 : Success
+ **                 Otherwise : Fail
+ **
+ *******************************************************************************/
+int dbg_fm_drv(char *p_conf_name, char *p_conf_value)
+{
+    strcat(fm_dbg_cfg_string, " fm_dbg_param=");
+    strcat(fm_dbg_cfg_string, p_conf_value);
+    UIM_DBG("%s = %s", p_conf_name, p_conf_value);
+    return 0;
+}
+
+#endif
+
+
+#if V4L2_SNOOP_ENABLE
+/*******************************************************************************
+ **
+ ** Function        enable_hci_snoop
+ **
+ ** Description     read parameter to enable/disable hci snoop for V4L2
+ **
+ ** Returns         0 : Success
+ **                 Otherwise : Fail
+ **
+ *******************************************************************************/
+int enable_hci_snoop(char *p_conf_name, char *p_conf_value)
+{
+    if (strcmp(p_conf_value, "true") == 0)
+    {
+        hci_snoop_enable = 1;
+        strcat(hw_cfg_string, " ldisc_snoop_enable_param=1");
+    }
+    else
+    {
+        hci_snoop_enable = 0;
+        strcat(hw_cfg_string, " ldisc_snoop_enable_param=0");
+    }
+    UIM_DBG("%s = %s", p_conf_name, p_conf_value);
+    return 0;
+}
+
+
+/*******************************************************************************
+ **
+ ** Function        path_hci_snoop
+ **
+ ** Description     read filepath for hci snoop for V4L2
+ **
+ ** Returns         0 : Success
+ **                 Otherwise : Fail
+ **
+ *******************************************************************************/
+int path_hci_snoop(char *p_conf_name, char *p_conf_value)
+{
+    memset(hci_snoop_path, 0, sizeof(hci_snoop_path));
+    strcpy(hci_snoop_path, p_conf_value);
+    UIM_DBG("%s = %s", p_conf_name, p_conf_value);
+    return 0;
+}
+#endif
+
+
+/******************************************************************************
+**  Local type definitions
+******************************************************************************/
+
+#define CONF_COMMENT '#'
+#define CONF_DELIMITERS " =\n\r\t"
+#define CONF_VALUES_DELIMITERS "=\n\r\t"
+#define CONF_MAX_LINE_LEN 255
+
+typedef int (conf_action_t)(char *p_conf_name, char *p_conf_value);
+
+typedef struct {
+    const char *conf_entry;
+    conf_action_t *p_action;
+} conf_entry_t;
+
+
+/*
+ * Currently supported entries in vendor_conf and corresponding action functions
+ */
+static const conf_entry_t vendor_conf_table[] = {
+    {"UartPort", userial_set_port},
+    {"UartBaudRate", hw_set_uart_baudrate},
+    {"FwPatchSettlementDelay", hw_set_patchram_settlement_delay},
+    {"LpmWakePolarity",hw_set_lpm_polarity},
+    {"DriverModulePath", hw_set_driver_module_path},
+    {"LpmEnable", hw_set_lpm},
+    {"LpmUseBluesleep", hw_set_btwake},
+    {"UseControllerBdaddr",hw_check_readcontroller_addr},
+    {"FwPatchFileName", hw_set_patchram_filename},
+#if DBG_V4L2_DRIVERS
+    {"DBG_BT_DRV",dbg_bt_drv},
+    {"DBG_LDISC_DRV",dbg_ldisc_drv},
+    {"DBG_FM_DRV",dbg_fm_drv},
+#endif
+    {(const char *) NULL, NULL}
+};
+
+
+#if V4L2_SNOOP_ENABLE
+static const conf_entry_t stack_conf_table[] = {
+    {"BtSnoopLogOutput", enable_hci_snoop},
+    {"BtSnoopFileName", path_hci_snoop},
+    {(const char *) NULL, NULL}
+};
+#endif
+
+
+/*******************************************************************************
+**
+** Function        vnd_load_conf
+**
+** Description     Read conf entry from p_path file one by one and call
+**                 the corresponding config function
+**
+** Returns         0 on success
+**                   -1 on failure
+**
+*******************************************************************************/
+int vnd_load_conf(const char *p_path, const conf_entry_t* conf_table)
+{
+    FILE          *p_file;
+    char          *p_name;
+    char          *p_value;
+    conf_entry_t  *p_entry;
+    char line[CONF_MAX_LINE_LEN+1]; /* add 1 for \0 char */
+
+    UIM_START_FUNC();
+    UIM_DBG("Attempt to load conf from %s", p_path);
+
+    if ((p_file = fopen(p_path, "r")) != NULL)
+    {
+        /* read line by line */
+        while (fgets(line, CONF_MAX_LINE_LEN+1, p_file) != NULL)
+        {
+            if (line[0] == CONF_COMMENT)
+                continue;
+
+            p_name = strtok(line, CONF_DELIMITERS);
+
+            if (NULL == p_name)
+            {
+                continue;
+            }
+
+            p_value = strtok(NULL, CONF_DELIMITERS);
+
+            if (NULL == p_value)
+            {
+                UIM_DBG("vnd_load_conf: missing value for name: %s", p_name);
+                continue;
+            }
+
+            p_entry = (conf_entry_t *)conf_table;
+
+            while (p_entry->conf_entry != NULL)
+            {
+                if (strcmp(p_entry->conf_entry, (const char *)p_name) == 0)
+                {
+                    p_entry->p_action(p_name, p_value);
+                    break;
+                }
+
+                p_entry++;
+            }
+        }
+
+        fclose(p_file);
+        UIM_END_FUNC();
+        return 0;
+    }
+    else
+    {
+        UIM_DBG("vnd_load_conf file >%s< not found", p_path);
+        UIM_END_FUNC();
+        return -1;
+    }
+    return 0;
+}
+
+
+static inline void cleanup()
+{
+    if (dev_fd == -1)
+        return;
+
+    tcflush(dev_fd, TCIOFLUSH);
+
+    close(dev_fd);
+    dev_fd = -1;
+
+    UIM_DBG("%s complete", __func__);
+}
+
+static inline void err_cleanup(int st_fd)
+{
+    cleanup();
+    UIM_ERR("setting upio power to 0 for error recovery");
+    upio_set_bluetooth_power(0);
+    UIM_ERR("Closing shared transport fd - st_fd");
+    if (st_fd)
+        close(st_fd);
+    st_fd = -1;
+    UIM_ERR("Restarting UIM due to error!");
+}
+
+
+#ifdef ANDROID   /* library for android to do insmod/rmmod  */
+
+/*****************************************************************************/
+/* Function to insert the kernel module into the system
+  ****************************************************************************/
+static int insmod(const char *filename, const char *args)
+{
+    void *module;
+    unsigned int size;
+    int ret = -1;
+
+    UIM_START_FUNC();
+
+    module = (void *)load_file(filename, &size);
+    if (!module)
+    {
+        UIM_DBG("unable to access %s", filename);
+        return ret;
+    }
+
+    ret = init_module(module, size, args);
+    free(module);
+
+    UIM_DBG("%s err code = %d",__func__, ret);
+    return ret;
+}
+
+
+/*****************************************************************************/
+/* Function to remove the kernel module from the system
+****************************************************************************/
+static int rmmod(const char *modname)
+{
+    int ret = -1;
+    int maxtry = MAX_TRY;
+
+    UIM_START_FUNC();
+
+    /* Retry MAX_TRY number of times in case of failure */
+    while (maxtry-- > 0) {
+        ret = delete_module(modname, O_NONBLOCK | O_EXCL);
+        if (ret < 0 && errno == EAGAIN)
+            sleep(1);
+        else
+            break;
+    }
+
+    /* Failed to remove the module */
+    if (ret != 0)
+        UIM_ERR("Unable to unload driver module \"%s\": %s",
+                modname, strerror(errno));
+    return ret;
+}
+#endif /* ANDROID */
+
+
+
+/*****************************************************************************/
+/* Function to read the HCI event from the given file descriptor
+ *
+ * This will parse the response received and returns error
+ * if the required response is not received
+ */
+int read_hci_event(int fd, unsigned char *buf, int size)
+{
+    int remain, rd;
+    int count = 0;
+    int reading = 1;
+    int rd_retry_count = 0;
+    struct timespec tm = {0, 50*1000*1000};
+
+    UIM_START_FUNC();
+
+    UIM_VER(" read_hci_event");
+    if (size <= 0)
+        return -1;
+
+    /* The first byte identifies the packet type. For HCI event packets, it
+     * should be 0x04, so we read until we get to the 0x04. */
+    while (reading) {
+        rd = read(fd, buf, 1);
+        if (rd <= 0 && rd_retry_count++ < 4) {
+            nanosleep(&tm, NULL);
+            continue;
+        } else if (rd_retry_count >= 4) {
+            return -1;
+        }
+
+        if (buf[0] == RESP_PREFIX) {
+            break;
+        }
+    }
+    count++;
+
+    /* The next two bytes are the event code and parameter total length. */
+    while (count < 3) {
+        rd = read(fd, buf + count, 3 - count);
+        if (rd <= 0)
+            return -1;
+        count += rd;
+    }
+
+    /* Now we read the parameters. */
+    if (buf[2] < (size - 3))
+        remain = buf[2];
+    else
+        remain = size - 3;
+
+    while ((count - 3) < remain) {
+        rd = read(fd, buf + count, remain - (count - 3));
+        if (rd <= 0)
+            return -1;
+        count += rd;
+    }
+
+    UIM_END_FUNC();
+    return count;
+}
+
+/* Function to read the Command complete event
+ *
+ * This will read the response for the command send to BT chip
+ * and validate response against response opcode
+ */
+static int read_command_complete(int fd, unsigned short opcode)
+{
+    command_complete_t resp;
+
+    UIM_START_FUNC();
+
+    UIM_VER(" Command complete started");
+    if (read_hci_event(fd, (unsigned char *)&resp, sizeof(resp)) < 0) {
+        UIM_ERR(" Invalid response");
+        return -1;
+    }
+
+    /* Response should be an event packet */
+    if (resp.uart_prefix != HCI_EVENT_PKT) {
+        UIM_ERR
+            (" Error in response: not an event packet, but 0x%02x!",
+             resp.uart_prefix);
+        return -1;
+    }
+
+    /* Response should be a command complete event */
+    if (resp.hci_hdr.evt != EVT_CMD_COMPLETE) {
+        /* event must be event-complete */
+        UIM_ERR
+            (" Error in response: not a cmd-complete event,but 0x%02x!",
+             resp.hci_hdr.evt);
+        return -1;
+    }
+
+    if (resp.hci_hdr.plen < 4) {
+        /* plen >= 4 for EVT_CMD_COMPLETE */
+        UIM_ERR(" Error in response: plen is not >= 4, but 0x%02x!",
+                resp.hci_hdr.plen);
+        return -1;
+    }
+
+    if (resp.cmd_complete.opcode != (unsigned short)opcode) {
+        UIM_ERR(" Error in response: opcode is 0x%04x, not 0x%04x!",
+                resp.cmd_complete.opcode, opcode);
+        return -1;
+    }
+
+    UIM_DBG(" Command complete done");
+    return resp.status == 0 ? 0 : -1;
+}
+
+
+
+
+/*****************************************************************************
+* Function to encode baudrate from int to char sequence
+*****************************************************************************/
+void
+BRCM_encode_baud_rate(uint baud_rate, unsigned char *encoded_baud)
+{
+    if(baud_rate == 0 || encoded_baud == NULL) {
+        fprintf(stderr, "Baudrate not supported!");
+        return;
+    }
+
+    encoded_baud[3] = (unsigned char)(baud_rate >> 24);
+    encoded_baud[2] = (unsigned char)(baud_rate >> 16);
+    encoded_baud[1] = (unsigned char)(baud_rate >> 8);
+    encoded_baud[0] = (unsigned char)(baud_rate & 0xFF);
+}
+
+void
+BRCM_encode_bd_address( unsigned char  *bd_addrr)
+{
+    if(bd_addrr == NULL) {
+        fprintf(stderr, "BD addr not supported!");
+        return;
+    }
+
+    bd_addrr[0] = bd_addr.address[5];
+    bd_addrr[1] = bd_addr.address[4];
+    bd_addrr[2] = bd_addr.address[3];
+    bd_addrr[3] = bd_addr.address[2];
+    bd_addrr[4] = bd_addr.address[1];
+    bd_addrr[5] = bd_addr.address[0];
+}
+
+typedef struct {
+    int baud_rate;
+    int termios_value;
+} tBaudRates;
+
+tBaudRates baud_rates[] = {
+    { 115200, B115200 },
+    { 230400, B230400 },
+    { 460800, B460800 },
+    { 500000, B500000 },
+    { 576000, B576000 },
+    { 921600, B921600 },
+    { 1000000, B1000000 },
+    { 1152000, B1152000 },
+    { 1500000, B1500000 },
+    { 2000000, B2000000 },
+    { 2500000, B2500000 },
+    { 3000000, B3000000 },
+    { 4000000, B4000000 },
+};
+
+
+/*****************************************************************************
+* Function to validate value of custom baudrate.
+*****************************************************************************/
+int
+validate_baudrate(int baud_rate, int *value)
+{
+    unsigned int i;
+
+    for (i = 0; i < (sizeof(baud_rates) / sizeof(tBaudRates)); i++) {
+        if (baud_rates[i].baud_rate == baud_rate) {
+            *value = baud_rates[i].termios_value;
+            return(1);
+        }
+    }
+
+    return(0);
+}
+
+/*****************************************************************************
+* Function to set lpm param  value based on the config entry
+*****************************************************************************/
+static int proc_set_lpm_param()
+{
+    const char hci_writesleepmode_cmd[] = {0x01, 0x27, 0xFC, 0x0C, 0x00,0x00,0x001,\
+                                          0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00};
+    char cmd[100];
+    UIM_DBG("lpmenable %d",lpmenable);
+    char *temp = hci_writesleepmode_cmd;
+    strcat(hw_cfg_string, " lpm_param=");
+    if(lpmenable) {
+        memcpy((temp+4), &lpm_uim_param, LPM_CMD_PARAM_SIZE);
+        UIM_DBG("%s lpm is enabled", __func__);
+        }
+    else
+        memset((temp+4), 0, LPM_CMD_PARAM_SIZE);
+
+    sprintf(cmd, "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x",
+              temp[0], temp[1], temp[2],temp[3], temp[4], temp[5],
+              temp[6], temp[7], temp[8],temp[9], temp[10], temp[11],
+              temp[12], temp[13], temp[14],temp[15]);
+    strcat(hw_cfg_string , cmd);
+    return 0;
+}
+
+/*****************************************************************************/
+/* Function to set the UART custom baud rate.
+ *
+ * The UART baud rate has already been
+ * set to default value 115200 before calling this function.
+ * The baud rate is then changed to custom baud rate by this function
+ *****************************************************************************/
+static int proc_set_custom_baud_rate()
+{
+    unsigned char hci_update_baud_rate[] = { 0x01, 0x18, 0xFC, 0x06,0x00, \
+                                               0x00,0x00,0x00,0x00,0x00 };
+    int len;
+    int termi_baudrate;
+
+    UIM_START_FUNC();
+
+    if (validate_baudrate(cust_baud_rate, &termi_baudrate)) {
+         BRCM_encode_baud_rate(cust_baud_rate, &hci_update_baud_rate[6]);
+    }
+    else
+        return -1;
+
+    len = write(dev_fd, hci_update_baud_rate, 10);
+    if (len < 0) {
+        UIM_ERR(" failed to write baud rate\n");
+        cleanup();
+        return -1;
+    }
+
+    /* Read the response for the HCI set custom baud rate command */
+    if (read_command_complete(dev_fd, HCI_RSP_OPCODE_SET_BAUDRATE) < 0) {
+        UIM_ERR(" Invalid response to set custom baudrate");
+        cleanup();
+        return -1;
+    }
+
+    /* set custom baudrate */
+    cfsetospeed(&termios, termi_baudrate);
+    cfsetispeed(&termios, termi_baudrate);
+    tcsetattr(dev_fd, TCSANOW, &termios);
+
+    fcntl(dev_fd, F_SETFL,fcntl(dev_fd, F_GETFL) | O_NONBLOCK);
+    UIM_DBG("baud rate set to %ld", cust_baud_rate);
+
+    UIM_END_FUNC();
+    return 0;
+}
+
+
+/*******************************************************************************
+**
+** Function         hw_strncmp
+**
+** Description      Used to compare two strings in caseless
+**
+** Returns          0: match, otherwise: not match
+**
+*******************************************************************************/
+static int hw_strncmp (const char *p_str1, const char *p_str2, const int len)
+{
+    int i;
+
+    if (!p_str1 || !p_str2)
+        return (1);
+
+    for (i = 0; i < len; i++)
+    {
+        if (toupper(p_str1[i]) != toupper(p_str2[i]))
+            return (i+1);
+    }
+
+    return 0;
+}
+
+
+/*******************************************************************************
+**
+** Function         hw_config_findpatch
+**
+** Description      Search for a proper firmware patch file
+**                  The selected firmware patch file name with full path
+**                  will be stored in the input string parameter, i.e.
+**                  p_chip_id_str, when returns.
+**
+** Returns          TRUE when found the target patch file, otherwise FALSE
+**
+*******************************************************************************/
+static uint8_t hw_config_findpatch(char *p_chip_id_str)
+{
+    DIR *dirp;
+    struct dirent *dp;
+    int filenamelen;
+    uint8_t retval = FALSE;
+
+    if ((dirp = opendir(fw_patchfile_path)) != NULL)
+    {
+        UIM_DBG("Target name = [%s]", p_chip_id_str);
+        /* Fetch next filename in patchfile directory */
+        while ((dp = readdir(dirp)) != NULL)
+        {
+            /* Check if filename starts with chip-id name */
+            if ((hw_strncmp(dp->d_name, p_chip_id_str, strlen(p_chip_id_str)) \
+                ) == 0)
+            {
+                /* Check if it has .hcd extenstion */
+                filenamelen = strlen(dp->d_name);
+                if ((filenamelen >= FW_PATCHFILE_EXTENSION_LEN) &&
+                    ((hw_strncmp(
+                          &dp->d_name[filenamelen-FW_PATCHFILE_EXTENSION_LEN], \
+                          FW_PATCHFILE_EXTENSION, \
+                          FW_PATCHFILE_EXTENSION_LEN) \
+                     ) == 0))
+                {
+                    UIM_DBG("Found patchfile: %s", dp->d_name);
+                    /* Make sure length does not exceed maximum */
+                    if (filenamelen >= FW_PATCH_FILENAME_MAXLEN)
+                    {
+                        UIM_ERR("Invalid patchfile name (too long) %s",
+                            dp->d_name);
+                        UIM_ERR("Max patchfile name length supported = %d",
+                            FW_PATCH_FILENAME_MAXLEN-1);
+                        break;
+                    }
+
+                    strcpy(p_chip_id_str, dp->d_name);
+                    retval = TRUE;
+                    break;
+                }
+            }
+        }
+
+        closedir(dirp);
+
+        if (retval == FALSE)
+        {
+            /* Try again chip name without revision info */
+            UIM_DBG("retval is FALSE");
+
+            int len = strlen(p_chip_id_str);
+            char *p = p_chip_id_str + len - 1;
+
+            /* Scan backward and look for the first alphabet
+               which is not M or m
+            */
+            while (len > 3) // BCM****
+            {
+                if ((isdigit(*p)==0) && (*p != 'M') && (*p != 'm'))
+                    break;
+
+                p--;
+                len--;
+            }
+
+            if (len > 3)
+            {
+                *p = 0;
+                retval = hw_config_findpatch(p_chip_id_str);
+            }
+        }
+    }
+    else
+    {
+        UIM_ERR("Could not open %s", fw_patchfile_path);
+    }
+
+    return (retval);
+}
+
+
+/*******************************************************************************
+**
+** Function         proc_read_local_name
+**
+** Description      Read local name of the chip. Find the correct patchram filename.
+**                       Patchram filename is written to same input argument.
+**
+** Returns          0: match, otherwise: not match
+**
+*******************************************************************************/
+
+static uint8_t proc_read_local_name(char* p_chip_id_str)
+{
+    unsigned char hci_read_localname[] = { 0x01, 0x14, 0x0C, 0x00 };
+    unsigned char buff[READ_LOCALNAME_RESP_BUFF_SIZE];
+    char *p_name, *p_tmp;
+    int len, i;
+
+    memset(buff, 0, sizeof(buff));
+
+    len = write(dev_fd, hci_read_localname, 4);
+    if (len < 0) {
+        UIM_ERR(" request hci_read_localname failed");
+        return FALSE;
+    }
+
+    if(read_hci_event(dev_fd, buff, FW_PATCH_FILENAME_MAXLEN) < 0) {
+        UIM_ERR(" Invalid response for hci_read_localname");
+        return FALSE;
+    }
+
+    p_name = p_tmp = buff + HCI_EVT_CMD_CMPL_LOCAL_NAME_STRING;
+    UIM_DBG("readlocalname = %s", p_name);
+
+    /* convert localname to upper case */
+    for (i=0; (i < FW_PATCH_FILENAME_MAXLEN)||(*(p_name+i) != 0); i++)
+        *(p_name+i) = toupper(*(p_name+i));
+
+    /* Perform various checks on chip localname*/
+    if ((p_name = strstr(p_name, "BCM")) != NULL)
+    {
+        strncpy(p_chip_id_str, p_name, \
+                         FW_PATCH_FILENAME_MAXLEN-1);
+                }
+    else if((p_name = strstr(p_tmp,"4343")) != NULL)
+    {
+        snprintf(p_chip_id_str, FW_PATCH_FILENAME_MAXLEN-1, "BCM%s", p_name);
+        strncpy(p_name, p_chip_id_str, FW_PATCH_FILENAME_MAXLEN-1);
+    }
+    else
+    {
+        strncpy(p_chip_id_str, "UNKNOWN", \
+                    FW_PATCH_FILENAME_MAXLEN-1);
+        return FALSE;
+    }
+
+    p_chip_id_str[FW_PATCH_FILENAME_MAXLEN-1] = 0;
+
+    UIM_VER("Chipset %s", p_chip_id_str);
+
+    return hw_config_findpatch(p_chip_id_str);
+}
+
+
+/*****************************************************************************
+* Function to initialize UART
+*****************************************************************************/
+void proc_init_uart(int uart_fd, struct termios *termios)
+{
+    UIM_START_FUNC();
+    tcflush(uart_fd, TCIOFLUSH);
+    tcgetattr(uart_fd, termios);
+
+    termios->c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP
+                | INLCR | IGNCR | ICRNL | IXON);
+    termios->c_oflag &= ~OPOST;
+    termios->c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
+    termios->c_cflag &= ~(CSIZE | PARENB);
+    termios->c_cflag |= CS8;
+
+    termios->c_cflag |= CRTSCTS;
+    tcsetattr(uart_fd, TCSANOW, termios);
+    tcflush(uart_fd, TCIOFLUSH);
+    tcsetattr(uart_fd, TCSANOW, termios);
+    tcflush(uart_fd, TCIOFLUSH);
+    tcflush(uart_fd, TCIOFLUSH);
+    cfsetospeed(termios, B115200);
+    cfsetispeed(termios, B115200);
+    tcsetattr(uart_fd, TCSANOW, termios);
+
+    UIM_END_FUNC();
+    return;
+}
+
+
+/*****************************************************************************
+ * This Function handles the Signals sent from the Kernel Init Manager.
+ * After receiving the indication from rfkill subsystem, configure the
+ * baud rate, flow control and Install the N_BRCM_HCI line discipline
+ *
+ * returns error code on failure, 0 on success.
+ *****************************************************************************/
+int st_uart_config(unsigned char install)
+{
+    int ldisc, proto;
+    char local_chip_name[FW_PATCH_FILENAME_MAXLEN];
+    int fw_fd;
+
+    UIM_START_FUNC();
+
+    if (install == V4L2_STATUS_ON) {
+        UIM_DBG("install set to 1");
+
+        if (dev_fd != -1) {
+            UIM_ERR("opening %s, while already open", uart_port_name);
+            return UIM_FAIL;
+        }
+
+        dev_fd = open((const char*) uart_port_name, O_RDWR);
+        if (dev_fd < 0) {
+            UIM_ERR(" Can't open %s", uart_port_name);
+            UIM_ERR("read err (%s)", strerror(errno));
+            return UIM_FAIL;
+        }
+
+        if (proc_bdaddr())
+        {
+            UIM_ERR("%s BD Address processing failed!!", __func__);
+            return UIM_FAIL;
+        }
+
+        /* Perform UART initialization */
+        proc_init_uart(dev_fd, &termios);
+
+        /* Perform HCI reset */
+        if(proc_hci_reset())
+        {
+            UIM_ERR("%s HCI RESET failed!!", __func__);
+            return UIM_FAIL;
+        }
+
+        /* Set custom baud rate */
+        if(proc_set_custom_baud_rate()) {
+            UIM_ERR("Unable to set custom baud rate. Invalid baudrate!");
+            return UIM_FAIL;
+        }
+
+        /* find patchram filename */
+        if (strlen(fw_patchfile_name)> 0) {
+            UIM_DBG("complete fw file name = %s", fw_patchfile_name);
+        }
+        else if(proc_read_local_name(local_chip_name) == TRUE) {
+            UIM_DBG("complete fw file name = %s", local_chip_name);
+            strcpy(fw_patchfile_name, local_chip_name);
+        }
+        else {
+            UIM_ERR(" Can't get FW patchfile name");
+            strcpy(fw_patchfile_name, "UNKNOWN");
+        }
+
+        UIM_VER("fw_patchfile_name = %s", fw_patchfile_name);
+        /* write patchram filename to sysfs entry and pass to ldisc */
+        fw_fd = open(FW_PATCHFILE_SYSFS_ENTRY, O_WRONLY);
+        if (fw_fd < 0) {
+            UIM_ERR(" Can't open %s", FW_PATCHFILE_SYSFS_ENTRY);
+            return UIM_FAIL;
+        }
+        write(fw_fd, &fw_patchfile_name, strlen(fw_patchfile_name));
+        UIM_DBG("writing to FW_PATCHFILE_SYSFS_ENTRY completed");
+        close(fw_fd);
+
+        /* After the UART speed has been changed, the IOCTL is called to set the
+               *   line discipline to N_BRCM_HCI                                                     */
+        ldisc = N_BRCM_HCI;
+        proto = HCI_UART_H4;
+        if (ioctl(dev_fd, TIOCSETD, &ldisc) < 0) {
+            UIM_ERR(" Can't set line discipline N_BRCM_HCI=%d", N_BRCM_HCI);
+            return UIM_FAIL;
+        }
+
+        if (ioctl(dev_fd, HCIUARTSETPROTO, proto) < 0) {
+            UIM_ERR("Can't set hci protocol\n");
+            return UIM_FAIL;
+        }
+        UIM_DBG("value of dev_fd = %d", dev_fd);
+        UIM_DBG(" Installed N_BRCM_HCI=%d Line displine", N_BRCM_HCI);
+    }
+
+    UIM_END_FUNC();
+    return 0;
+}
+
+
+/*****************************************************************************
+* Function to process BD ADDRESS
+*****************************************************************************/
+int proc_bdaddr()
+{
+    bdstr_t bdstr;
+    int fd =-1,res=0;
+
+    /*Read BD Addr*/
+    read_default_bdaddr(&bd_addr);
+
+    /* pass bd_address to ldisc */
+    bd2str(&bd_addr, &bdstr);
+    UIM_DBG("%s, bdstr=%s", __func__, bdstr);
+
+    fd = open(BDADDR_SYSFS_ENTRY, O_RDWR);
+    if ((fd < 0)|| (write(fd, &bdstr, 18)<=0)){
+        UIM_ERR("unable to open %s (%s)", BDADDR_SYSFS_ENTRY,strerror(errno));
+        res =  UIM_FAIL;
+    }
+    if( fd )
+        close(fd);
+    return res;
+}
+
+
+/*****************************************************************************
+* Function to perform HCI Reset
+ *****************************************************************************/
+int proc_hci_reset()
+{
+    const char hci_reset_cmd[] = {0x01, 0x03, 0x0C, 0x00};
+    int len;
+
+    UIM_START_FUNC();
+
+    /* Perform HCI reset */
+    len = write(dev_fd, hci_reset_cmd, 4);
+    if (len < 0) {
+        UIM_ERR(" failed to write HCI reset\n");
+        cleanup();
+        return -1;
+    }
+
+    /* Read the response for the HCI reset command */
+    if (read_command_complete(dev_fd, HCI_RSP_OPCODE_HCI_RST) < 0) {
+        UIM_ERR(" Invalid response to HCI Reset");
+        cleanup();
+        return -1;
+    }
+
+    UIM_END_FUNC();
+    return 0;
+
+}
+
+/*****************************************************************************
+* Function to convert the BD address from ascii to hex value
+*****************************************************************************/
+int str2bd(char *str, bdaddr_t *addr)
+    {
+        int32_t i = 0;
+        for (i = 0; i < 6; i++)
+        {
+           addr->address[i] = (uint8_t)strtoul(str, &str, 16);
+           str++;
+        }
+        return 0;
+    }
+
+/*****************************************************************************
+* Function to read default bdaddress
+*****************************************************************************/
+#ifdef ANDROID
+void read_default_bdaddr(bdaddr_t *local_addr)
+{
+    char val[256];
+    uint8_t valid_bda = FALSE;
+
+    const uint8_t null_bdaddr[BD_ADDR_LEN] = {0,0,0,0,0,0};
+
+    /* Get local bdaddr storage path from property */
+    if (property_get(PROPERTY_BT_BDADDR_PATH, val, NULL))
+    {
+        int addr_fd;
+
+        UIM_VER("local bdaddr is stored in %s", val);
+
+        if ((addr_fd = open(val, O_RDONLY)) != -1)
+        {
+            memset(val, 0, sizeof(val));
+            read(addr_fd, val, FACTORY_BT_BDADDR_STORAGE_LEN);
+            str2bd(val, local_addr);
+            /* If this is not a reserved/special bda, then use it */
+            if (memcmp(local_addr->address, null_bdaddr, BD_ADDR_LEN) != 0)
+            {
+                valid_bda = TRUE;
+                UIM_DBG("Got Factory BDA %02X:%02X:%02X:%02X:%02X:%02X",
+                    local_addr->address[0], local_addr->address[1],
+                    local_addr->address[2], local_addr->address[3],
+                    local_addr->address[4], local_addr->address[5]);
+            }
+
+            close(addr_fd);
+        }
+    }
+
+    /* No factory BDADDR found. Look for previously generated random BDA */
+    if ((!valid_bda) && \
+        (property_get(PERSIST_BDADDR_PROPERTY, val, NULL)))
+    {
+        UIM_VER("local bdaddr is stored in %s", PERSIST_BDADDR_PROPERTY);
+        str2bd(val, local_addr);
+        valid_bda = TRUE;
+        UIM_DBG("Got prior random BDA %02X:%02X:%02X:%02X:%02X:%02X",
+            local_addr->address[0], local_addr->address[1], local_addr->address[2],
+            local_addr->address[3], local_addr->address[4], local_addr->address[5]);
+    }
+
+    /* Generate new BDA if necessary */
+    if (!valid_bda)
+    {
+        bdstr_t bdstr;
+        /* Seed the random number generator */
+        srand((unsigned int) (time(0)));
+
+        /* No autogen BDA. Generate one now. */
+        local_addr->address[0] = 0x22;
+        local_addr->address[1] = 0x22;
+        local_addr->address[2] = (uint8_t) ((rand() >> 8) & 0xFF);
+        local_addr->address[3] = (uint8_t) ((rand() >> 8) & 0xFF);
+        local_addr->address[4] = (uint8_t) ((rand() >> 8) & 0xFF);
+        local_addr->address[5] = (uint8_t) ((rand() >> 8) & 0xFF);
+
+        /* Convert to ascii, and store as a persistent property */
+        bd2str(local_addr, &bdstr);
+
+        UIM_ERR("No preset BDA. Generating BDA: %s for prop %s",
+             (char*)bdstr, PERSIST_BDADDR_PROPERTY);
+
+        if (property_set(PERSIST_BDADDR_PROPERTY, (char*)bdstr) < 0)
+            UIM_ERR("Failed to set random BDA in prop %s",PERSIST_BDADDR_PROPERTY);
+    }
+
+    UIM_DBG("BDA to be set to %02X:%02X:%02X:%02X:%02X:%02X",
+        local_addr->address[0], local_addr->address[1], local_addr->address[2],
+        local_addr->address[3], local_addr->address[4], local_addr->address[5]);
+
+    return;
+}
+#endif
+
+
+/*****************************************************************************
+* Main function
+*****************************************************************************/
+int main(void)
+{
+    int st_fd, err;
+    struct stat file_stat;
+    char kmodule_path[MAX_KMODULE_PATH_SIZE] = {0};
+    struct pollfd p;
+    unsigned char install;
+
+    UIM_START_FUNC();
+    err = 0;
+
+    /* Read configuration parameters for hardware config */
+    if (vnd_load_conf(VENDOR_LIB_CONF_FILE, &vendor_conf_table))
+    {
+        return UIM_FAIL;
+    }
+
+#if V4L2_SNOOP_ENABLE
+    /* Read configuration parameters for hci snoop */
+    if (vnd_load_conf(STACK_CONF_FILE, &stack_conf_table))
+    {
+        return UIM_FAIL;
+    }
+#endif
+
+    //Set the LPM command parameters based on config entries
+    proc_set_lpm_param();
+
+    /* rfkill device's open/poll/read */
+    UIM_DBG("Opening install before start of Polling");
+    st_fd = open(INSTALL_SYSFS_ENTRY, O_RDONLY);
+    if (st_fd < 0) {
+        UIM_ERR("unable to open %s (%s)", INSTALL_SYSFS_ENTRY,
+        strerror(errno));
+        UIM_ERR("restarting uim");
+        return UIM_FAIL;
+    }
+
+    /* pass parameters from bt_vendor.conf to ldisc for patchram download */
+    if (pass_vendor_params())
+    {
+        UIM_ERR("unable to write vendor params to %s", LDISC_VENDOR_PARAMS);
+        UIM_ERR("restarting uim");
+        return UIM_FAIL;
+    }
+
+    UIM_DBG("first time polling");
+    err = read(st_fd, &install, 1);
+    if ((err > 0) && (install == V4L2_STATUS_ON)) {
+        UIM_DBG("install already set");
+        upio_set_bluetooth_power(1);
+        // handle HCI snoop
+        int fd_hcisnoop = -1;
+        unsigned char snoop_enable = '0';
+        if ((fd_hcisnoop = open(LDISC_SYSFS_SNOOP, O_RDONLY))< 0) {
+            UIM_ERR("unable to open %s", LDISC_SYSFS_SNOOP);
+        }
+        else {
+            read(fd_hcisnoop, &snoop_enable, 1);
+            UIM_DBG("snoop_enable = %c", snoop_enable);
+            close(fd_hcisnoop);
+        }
+        if ((hci_snoop_enable == 1) || (snoop_enable=='1'))
+            v4l2_start_hci_snoop();
+        if (st_uart_config(install) != 0)
+        {
+            UIM_ERR("st_uart_config failed");
+            // cleanup as UIM failed to initialize uart
+            err_cleanup(st_fd);
+            return UIM_FAIL;
+        }
+    }
+
+RE_POLL:
+
+    UIM_DBG("begin polling");
+    memset(&p, 0, sizeof(p));
+    p.fd = st_fd;
+    /* sysfs entries can only break poll for following events */
+    p.events = POLLERR | POLLHUP;
+
+RE_POLL_TILL_POLL_ERR:
+
+    while (!exiting) {
+        p.revents = 0;
+        UIM_DBG("Polling to check POLLERR | POLLHUP on install fd");
+        err = poll(&p, 1, -1);
+        UIM_DBG("After Polling to check POLLERR | POLLHUP erro = %d", err);
+        if (err < 0 && errno == EINTR){
+            continue;
+        }
+        if (err) {
+            UIM_DBG("Breaking out from RE_POLL_TILL_POLL_ERR while loop with err=%d", err);
+            break;
+        }
+    }
+
+    close(st_fd);
+    st_fd = open(INSTALL_SYSFS_ENTRY, O_RDONLY);
+    if (st_fd < 0) {
+        UIM_ERR("re-opening %s failed: %s", INSTALL_SYSFS_ENTRY,
+        strerror(errno));
+        return UIM_FAIL;
+    }
+
+    if (!exiting)
+    {
+        err = read(st_fd, &install, 1);
+        if (err <= 0) {
+            UIM_ERR("reading %s failed: %s", INSTALL_SYSFS_ENTRY,
+            strerror(errno));
+            goto RE_POLL;
+        }
+        UIM_DBG("value of install = %c", install);
+        UIM_DBG("value of dev_fd = %d",dev_fd);
+
+        if ((install == V4L2_STATUS_ON) && (dev_fd == -1)) {
+            UIM_DBG("set UART");
+            upio_set_bluetooth_power(1);
+            /* start hci snoop thread */
+            // handle HCI snoop
+            int fd_hcisnoop = -1;
+            unsigned char snoop_enable = '0';
+            if ((fd_hcisnoop = open(LDISC_SYSFS_SNOOP, O_RDONLY)) < 0){
+                UIM_ERR("unable to open %s", LDISC_SYSFS_SNOOP);
+            }
+            else {
+                read(fd_hcisnoop, &snoop_enable, 1);
+                UIM_DBG("snoop_enable = %c", snoop_enable);
+                close(fd_hcisnoop);
+            }
+            if ((hci_snoop_enable == 1) || (snoop_enable=='1'))
+                v4l2_start_hci_snoop();
+            if (st_uart_config(install)!=0)
+            {
+                UIM_ERR("st_uart_config failed");
+                // cleanup as UIM failed to initialize uart
+                err_cleanup(st_fd);
+                return UIM_FAIL;
+            }
+            UIM_DBG("set UART done");
+            goto RE_POLL_TILL_POLL_ERR;
+        }
+        else if (install == V4L2_STATUS_OFF) {
+                // handle HCI snoop
+                int fd_hcisnoop;
+                unsigned char snoop_enable;
+                fd_hcisnoop = open(LDISC_SYSFS_SNOOP, O_RDONLY);
+                read(fd_hcisnoop, &snoop_enable, 1);
+                UIM_DBG("snoop_enable = %c", snoop_enable);
+                close(fd_hcisnoop);
+                if(hci_snoop_enable == 1 || snoop_enable=='1'
+                    || (v4l2_get_hci_snoop_status() == HCI_SNOOP_RUNNING))
+                    v4l2_stop_hci_snoop();
+
+                cleanup();
+                UIM_VER("setting upio power to 0");
+                upio_set_bluetooth_power(0);
+                goto RE_POLL;
+        }
+        else if (install == V4L2_STATUS_ERR){
+            /* In case of err (HCI timeout or Hardware error) in BT/FM/Ant,
+               the application will write 0x02 to install sysfs entry. UIM upon
+               detecting this value will restart UIM process. */
+            cleanup();
+            UIM_ERR("setting upio power to 0 for error recovery");
+            upio_set_bluetooth_power(0);
+            UIM_ERR("Closing shared transport fd - st_fd");
+            close(st_fd);
+            UIM_ERR("Restarting UIM due to error!");
+            return UIM_FAIL;
+        }
+    }
+
+    close(st_fd);
+    UIM_END_FUNC();
+
+    return 0;
+}
+
+

--- a/brcm_fmradio/brcm-uim-sysfs/upio.c
+++ b/brcm_fmradio/brcm-uim-sysfs/upio.c
@@ -1,0 +1,221 @@
+/*
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program;if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+  *  Copyright (C) 2009-2015 Broadcom Corporation
+ */
+
+
+/******************************************************************************
+ *
+ *  Filename:      upio.c
+ *
+ *  Description:   Contains I/O functions, like
+ *                      rfkill control
+ *                      BT_WAKE/HOST_WAKE control
+ *
+ ******************************************************************************/
+
+#define LOG_TAG "bt_upio"
+
+#include <utils/Log.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <malloc.h>
+#include <string.h>
+#include <cutils/properties.h>
+
+#define UPIO_BT_POWER_OFF 0
+#define UPIO_BT_POWER_ON  1
+
+/* UPIO signals */
+enum {
+    UPIO_BT_WAKE = 0,
+    UPIO_HOST_WAKE,
+    UPIO_LPM_MODE,
+    UPIO_MAX_COUNT
+};
+
+
+
+/******************************************************************************
+**  Constants & Macros
+******************************************************************************/
+
+#ifndef UPIO_DBG
+#define UPIO_DBG TRUE
+#endif
+
+#if (UPIO_DBG == TRUE)
+#define UPIODBG(param, ...) {ALOGD(param, ## __VA_ARGS__);}
+#else
+#define UPIODBG(param, ...) {}
+#endif
+
+
+/******************************************************************************
+**  Static variables
+******************************************************************************/
+
+static int rfkill_id = -1;
+static int bt_emul_enable = 0;
+static char *rfkill_state_path = NULL;
+
+
+/*****************************************************************************
+**   Bluetooth On/Off Static Functions
+*****************************************************************************/
+static int is_emulator_context(void)
+{
+    char value[PROPERTY_VALUE_MAX];
+
+    property_get("ro.kernel.qemu", value, "0");
+    UPIODBG("is_emulator_context : %s", value);
+    if (strcmp(value, "1") == 0) {
+        return 1;
+    }
+    return 0;
+}
+
+static int is_rfkill_disabled(void)
+{
+    char value[PROPERTY_VALUE_MAX];
+
+    property_get("ro.rfkilldisabled", value, "0");
+    UPIODBG("is_rfkill_disabled ? [%s]", value);
+
+    if (strcmp(value, "1") == 0) {
+        return UPIO_BT_POWER_ON;
+    }
+    UPIODBG("is_rfkill_disabled returned");
+
+    return UPIO_BT_POWER_OFF;
+}
+
+static int init_rfkill()
+{
+    char path[64];
+    char buf[16];
+    int fd, sz, id;
+
+    if (is_rfkill_disabled())
+        return -1;
+
+    for (id = 0; ; id++)
+    {
+        snprintf(path, sizeof(path), "/sys/class/rfkill/rfkill%d/type", id);
+        fd = open(path, O_RDONLY);
+        if (fd < 0)
+        {
+            ALOGE("init_rfkill : open(%s) failed: %s (%c)\n", \
+                 path, strerror(errno), errno);
+            return -1;
+        }
+
+        sz = read(fd, &buf, sizeof(buf));
+        close(fd);
+
+        if (sz >= 9 && memcmp(buf, "bluetooth", 9) == 0)
+        {
+            rfkill_id = id;
+            break;
+        }
+    }
+
+    asprintf(&rfkill_state_path, "/sys/class/rfkill/rfkill%d/state", rfkill_id);
+    return 0;
+}
+
+
+/*******************************************************************************
+**
+** Function        upio_set_bluetooth_power
+**
+** Description     Interact with low layer driver to set Bluetooth power
+**                 on/off.
+**
+** Returns         0  : SUCCESS or Not-Applicable
+**                 <0 : ERROR
+**
+*******************************************************************************/
+int upio_set_bluetooth_power(int on)
+{
+    int sz;
+    int fd = -1;
+    int ret = -1;
+    char buffer = '0';
+
+    switch(on)
+    {
+        case UPIO_BT_POWER_OFF:
+            buffer = '0';
+            break;
+
+        case UPIO_BT_POWER_ON:
+            buffer = '1';
+            break;
+    }
+
+    UPIODBG("upio_set_bluetooth_power(on: %d)", on);
+
+    if (is_emulator_context())
+    {
+        /* if new value is same as current, return -1 */
+        if (bt_emul_enable == on)
+            return ret;
+
+        UPIODBG("set_bluetooth_power [emul] %d", on);
+
+        bt_emul_enable = on;
+        return 0;
+    }
+
+    /* check if we have rfkill interface */
+    if (is_rfkill_disabled())
+        return 0;
+
+    if (rfkill_id == -1)
+    {
+        if (init_rfkill())
+            return ret;
+    }
+
+    fd = open(rfkill_state_path, O_WRONLY);
+
+    if (fd < 0)
+    {
+        ALOGE("set_bluetooth_power : open(%s) for write failed: %s (%c)",
+            rfkill_state_path, strerror(errno), errno);
+        return ret;
+    }
+
+    sz = write(fd, &buffer, 1);
+
+    if (sz < 0) {
+        ALOGE("set_bluetooth_power : write(%s) failed: %s (%c)",
+            rfkill_state_path, strerror(errno),errno);
+    }
+    else
+        ret = 0;
+
+    if (fd >= 0)
+        close(fd);
+    UPIODBG("is_rfkill_disabled returned ret %d",ret);
+
+    return ret;
+}
+
+
+

--- a/brcm_fmradio/brcm-uim-sysfs/utils.c
+++ b/brcm_fmradio/brcm-uim-sysfs/utils.c
@@ -1,0 +1,391 @@
+/*
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program;if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+  *  Copyright (C) 2009-2015 Broadcom Corporation
+ */
+
+
+/******************************************************************************
+ *
+ *  Filename:      utils.c
+ *
+ *  Description:   Contains helper functions
+ *
+ ******************************************************************************/
+
+#include <errno.h>
+#include <pthread.h>
+#include <time.h>
+#include <malloc.h>
+#include <string.h>
+#include "utils.h"
+
+/******************************************************************************
+**  Static variables
+******************************************************************************/
+
+static pthread_mutex_t utils_mutex;
+
+static BUFFER_Q acl_rx_q;
+
+
+/*****************************************************************************
+**   UTILS INTERFACE FUNCTIONS
+*****************************************************************************/
+
+/*******************************************************************************
+**
+** Function        utils_init
+**
+** Description     Utils initialization
+**
+** Returns         None
+**
+*******************************************************************************/
+void utils_init (void)
+{
+    pthread_mutex_init(&utils_mutex, NULL);
+    utils_queue_init (&acl_rx_q);
+}
+
+/*******************************************************************************
+**
+** Function        utils_cleanup
+**
+** Description     Utils cleanup
+**
+** Returns         None
+**
+*******************************************************************************/
+void utils_cleanup (void)
+{
+    pthread_mutex_destroy(&utils_mutex);
+}
+
+/*******************************************************************************
+**
+** Function        utils_queue_init
+**
+** Description     Initialize the given buffer queue
+**
+** Returns         None
+**
+*******************************************************************************/
+static void utils_queue_init (BUFFER_Q *p_q)
+{
+    p_q->p_first = p_q->p_last = NULL;
+    p_q->count = 0;
+}
+
+/*******************************************************************************
+**
+** Function        utils_get_count
+**
+** Description     Get number of allocated buffers
+**
+** Returns         None
+**
+*******************************************************************************/
+uint16_t utils_get_count ()
+{
+    return acl_rx_q.count;
+}
+
+/*******************************************************************************
+**
+** Function        utils_get_count
+**
+** Description     Get number of allocated buffers
+**
+** Returns         None
+**
+*******************************************************************************/
+void* utils_get_first ()
+{
+    return acl_rx_q.p_first;
+}
+
+
+
+/*******************************************************************************
+**
+** Function        utils_alloc
+**
+** Description     allocate memory for buffer
+**
+** Returns         None
+**
+*******************************************************************************/
+uint8_t* utils_alloc (int size)
+{
+    uint8_t* p;
+
+    if(size > MAX_ACL_PKT_SIZE)
+        return NULL;
+
+    p = malloc(size + BT_HC_BUFFER_HDR_SIZE);
+    if(p)
+    {
+        ((HC_BUFFER_HDR_T *)p)->p_next = NULL;
+        return (uint8_t*) p + BT_HC_BUFFER_HDR_SIZE;
+    }
+    else
+        return NULL;
+}
+
+/*******************************************************************************
+**
+** Function        utils_alloc
+**
+** Description     allocate memory for buffer
+**
+** Returns         None
+**
+*******************************************************************************/
+void utils_release(uint8_t* ptr)
+{
+    uint8_t* p;
+
+    p = (uint8_t*)ptr - BT_HC_BUFFER_HDR_SIZE;
+    free(p);
+}
+
+/*******************************************************************************
+**
+** Function        utils_enqueue
+**
+** Description     Enqueue a buffer at the tail of the given queue
+**
+** Returns         None
+**
+*******************************************************************************/
+void utils_enqueue (void *p_buf)
+{
+    HC_BUFFER_HDR_T    *p_hdr;
+    BUFFER_Q *p_q = &acl_rx_q;
+
+    p_hdr = (HC_BUFFER_HDR_T *) ((uint8_t *) p_buf - BT_HC_BUFFER_HDR_SIZE);
+
+    pthread_mutex_lock(&utils_mutex);
+
+    if (p_q->p_last)
+    {
+        HC_BUFFER_HDR_T *p_last_hdr = \
+          (HC_BUFFER_HDR_T *)((uint8_t *)p_q->p_last - BT_HC_BUFFER_HDR_SIZE);
+
+        p_last_hdr->p_next = p_hdr;
+    }
+    else
+        p_q->p_first = p_buf;
+
+    p_q->p_last = p_buf;
+    p_q->count++;
+
+    p_hdr->p_next = NULL;
+
+    pthread_mutex_unlock(&utils_mutex);
+}
+/*******************************************************************************
+**
+** Function        utils_dequeue
+**
+** Description     Dequeues a buffer from the head of the given queue
+**
+** Returns         NULL if queue is empty, else buffer
+**
+*******************************************************************************/
+void *utils_dequeue (BUFFER_Q *p_q)
+{
+    pthread_mutex_lock(&utils_mutex);
+    void* p_buf =  utils_dequeue_unlocked(p_q);
+    pthread_mutex_unlock(&utils_mutex);
+    return p_buf;
+}
+
+/*******************************************************************************
+**
+** Function        utils_dequeue_unlocked
+**
+** Description     Dequeues a buffer from the head of the given queue without lock
+**
+** Returns         NULL if queue is empty, else buffer
+**
+*******************************************************************************/
+void *utils_dequeue_unlocked (BUFFER_Q *p_q)
+{
+    HC_BUFFER_HDR_T    *p_hdr;
+
+
+    if (!p_q || !p_q->count)
+    {
+        return (NULL);
+    }
+
+    p_hdr=(HC_BUFFER_HDR_T *)((uint8_t *)p_q->p_first-BT_HC_BUFFER_HDR_SIZE);
+
+    if (p_hdr->p_next)
+        p_q->p_first = ((uint8_t *)p_hdr->p_next + BT_HC_BUFFER_HDR_SIZE);
+    else
+    {
+        p_q->p_first = NULL;
+        p_q->p_last  = NULL;
+    }
+
+    p_q->count--;
+
+    p_hdr->p_next = NULL;
+    return ((uint8_t *)p_hdr + BT_HC_BUFFER_HDR_SIZE);
+}
+
+/*******************************************************************************
+**
+** Function        utils_getnext
+**
+** Description     Return a pointer to the next buffer linked to the given
+**                 buffer
+**
+** Returns         NULL if the given buffer does not point to any next buffer,
+**                 else next buffer address
+**
+*******************************************************************************/
+void *utils_getnext (void *p_buf)
+{
+    HC_BUFFER_HDR_T    *p_hdr;
+
+    p_hdr = (HC_BUFFER_HDR_T *) ((uint8_t *) p_buf - BT_HC_BUFFER_HDR_SIZE);
+
+    if (p_hdr->p_next)
+        return ((uint8_t *)p_hdr->p_next + BT_HC_BUFFER_HDR_SIZE);
+    else
+        return (NULL);
+}
+
+/*******************************************************************************
+**
+** Function        utils_remove_from_queue
+**
+** Description     Dequeue the given buffer from the middle of the given queue
+**
+** Returns         NULL if the given queue is empty, else the given buffer
+**
+*******************************************************************************/
+void *utils_remove_from_queue (void *p_buf)
+{
+    BUFFER_Q *p_q = &acl_rx_q;
+    pthread_mutex_lock(&utils_mutex);
+    p_buf = utils_remove_from_queue_unlocked(p_q, p_buf);
+    pthread_mutex_unlock(&utils_mutex);
+    return p_buf;
+}
+/*******************************************************************************
+**
+** Function        utils_remove_from_queue_unlocked
+**
+** Description     Dequeue the given buffer from the middle of the given queue
+**
+** Returns         NULL if the given queue is empty, else the given buffer
+**
+*******************************************************************************/
+void *utils_remove_from_queue_unlocked (BUFFER_Q *p_q, void *p_buf)
+{
+    HC_BUFFER_HDR_T    *p_prev;
+    HC_BUFFER_HDR_T    *p_buf_hdr;
+
+
+    if (p_buf == p_q->p_first)
+    {
+        return (utils_dequeue_unlocked (p_q));
+    }
+
+    p_buf_hdr = (HC_BUFFER_HDR_T *)((uint8_t *)p_buf - BT_HC_BUFFER_HDR_SIZE);
+    p_prev=(HC_BUFFER_HDR_T *)((uint8_t *)p_q->p_first-BT_HC_BUFFER_HDR_SIZE);
+
+    for ( ; p_prev; p_prev = p_prev->p_next)
+    {
+        /* If the previous points to this one, move the pointers around */
+        if (p_prev->p_next == p_buf_hdr)
+        {
+            p_prev->p_next = p_buf_hdr->p_next;
+
+            /* If we are removing the last guy in the queue, update p_last */
+            if (p_buf == p_q->p_last)
+                p_q->p_last = p_prev + 1;
+
+            /* One less in the queue */
+            p_q->count--;
+
+            /* The buffer is now unlinked */
+            p_buf_hdr->p_next = NULL;
+
+            return (p_buf);
+        }
+    }
+    return (NULL);
+}
+
+/*******************************************************************************
+**
+** Function        utils_delay
+**
+** Description     sleep unconditionally for timeout milliseconds
+**
+** Returns         None
+**
+*******************************************************************************/
+void utils_delay (uint32_t timeout)
+{
+    struct timespec delay;
+    int err;
+
+    delay.tv_sec = timeout / 1000;
+    delay.tv_nsec = 1000 * 1000 * (timeout%1000);
+
+    /* [u]sleep can't be used because it uses SIGALRM */
+    do {
+        err = nanosleep(&delay, &delay);
+    } while (err < 0 && errno ==EINTR);
+}
+
+/*******************************************************************************
+**
+** Function        utils_lock
+**
+** Description     application calls this function before entering critical
+**                 section
+**
+** Returns         None
+**
+*******************************************************************************/
+void utils_lock (void)
+{
+    pthread_mutex_lock(&utils_mutex);
+}
+
+/*******************************************************************************
+**
+** Function        utils_unlock
+**
+** Description     application calls this function when leaving critical
+**                 section
+**
+** Returns         None
+**
+*******************************************************************************/
+void utils_unlock (void)
+{
+    pthread_mutex_unlock(&utils_mutex);
+}
+

--- a/brcm_fmradio/fmradio.v4l2-fm/Android.mk
+++ b/brcm_fmradio/fmradio.v4l2-fm/Android.mk
@@ -1,0 +1,12 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := libfmradio.v4l2-fm
+LOCAL_MODULE_SUFFIX := .so
+LOCAL_MODULE_CLASS := SHARED_LIBRARIES
+LOCAL_MODULE_TAG := optional
+LOCAL_SHARED_LIBRARIES := liblog
+LOCAL_SRC_FILES := v4l2_fm.c v4l2_ioctl.c
+include $(BUILD_SHARED_LIBRARY)
+

--- a/brcm_fmradio/fmradio.v4l2-fm/Android.mk
+++ b/brcm_fmradio/fmradio.v4l2-fm/Android.mk
@@ -9,4 +9,3 @@ LOCAL_MODULE_TAG := optional
 LOCAL_SHARED_LIBRARIES := liblog
 LOCAL_SRC_FILES := v4l2_fm.c v4l2_ioctl.c
 include $(BUILD_SHARED_LIBRARY)
-

--- a/brcm_fmradio/fmradio.v4l2-fm/v4l2_fm.c
+++ b/brcm_fmradio/fmradio.v4l2-fm/v4l2_fm.c
@@ -1,0 +1,602 @@
+/*
+ * Copyright (C) CSR plc 2011
+ * Copyright 2010, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: marco.sinigaglia@csr.com for CSR plc
+ */
+
+#define LOG_TAG "V4l2_handler_Fm"
+#define LOG_NDEBUG 1
+
+#ifdef LINUX
+#define ALOGI printf
+#define ALOGE printf
+#else
+#include "utils/Log.h"
+#endif
+
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <ctype.h>
+#include "../libfmjni/android_fm.h"
+#include "v4l2_ioctl.h"
+
+//RDS 
+#define RDS_THREAD_ON                    1
+#define RDS_THREAD_OFF                   0
+#define BUFFER_RDS_SIZE                  300                // rds buff size
+#define GROUP_SIZE                       8                  // group is composed by 2byte * 4 packets
+#define GROUP_EMPTY                      0
+#define GROUP_INCOMPLETE                 1
+#define GROUP_0A                         0
+#define GROUP_0B                         1
+#define GETBYTE(blockNuber,byteNum)      blockNuber*2+byteNum
+#define CLEAN_RDS                        last_block_num= -1; next_expected_block= 0; group_status = GROUP_EMPTY;
+//Mute
+#define DEFAULT_VOLUME                  34000
+#define MUTE_OFF                        0
+#define MUTE_ON                         1
+//Scan
+#define SCAN_RUN                        1
+#define SCAN_STOP                       0
+#define LOCKTIME                        40000           // wait 40ms for card to lock on
+#define MAX_FREQS                       50              // number of max freq buffer for a full scan
+#define DEFAULT_THRESHOLD               500             // threshold for scan
+
+/* session struct holded by the FM SE stack */
+typedef struct fm_v4l2_data_t {
+  int low_freq;
+  int high_freq;
+  int grid;
+  int fd;
+  int threshold;
+  int freq;
+  float fact;
+  struct v4l2_tuner vt;
+  pthread_t thread_rds;                                 /* thread used to read rds data */
+  char scan_band_run;                                   /* flag to stop the scan*/	
+  char thread_rds_run;                                  /* flag to stop the rds thread*/  
+  const struct fmradio_vendor_callbacks_t* callbacks;
+} fm_v4l2_data;
+
+
+fm_v4l2_data* get_session_data(void **data) {return *data;}
+int get_standard_freq(int freq, int fact) {return freq / fact;}
+int get_proprietary_freq(int freq, int fact) {return freq * fact;}
+
+void* th_read_rds(void *thread_rds_info);
+int kill_rds_thread(fm_v4l2_data* session);
+int start_rds_thread(fm_v4l2_data* session);
+
+
+static int v4l2_rx_start_func (void **data, const struct fmradio_vendor_callbacks_t* callbacks, int low_freq, int high_freq, int default_freq, int grid)
+{  
+  char	*dev = DEFAULT_DEVICE;
+  fm_v4l2_data* session;
+
+  ALOGI("%s:\n", __FUNCTION__);
+  ALOGI("low_freq %d, high_freq %d, default_freq %d, grid %d\n", low_freq, high_freq, default_freq, grid);
+
+  session = malloc(sizeof(fm_v4l2_data));
+  if (session== NULL){
+      ALOGE("error on malloc");
+      return -1;
+  }
+
+  memset(session, 0, sizeof(fm_v4l2_data));
+  *data =  session;
+
+  session->fd = open_dev(dev);
+  if (session->fd < 0){
+      ALOGE("error on open dev\n");
+      return -1;
+  }
+
+  if (get_tun_radio_cap(session->fd) !=1) {
+      ALOGE("error on check tunner radio capability");
+      return -1;
+  }
+
+  session->vt.index=0;
+  if ( get_v4l2_tuner(session->fd,  &session->vt) <0 ){
+      ALOGE("error on get V4L tuner\n");
+      return -1;
+  }
+
+  session->fact = get_fact(session->fd, &session->vt);
+  if ( session->fact < 0) {
+      ALOGE("error on get fact\n");
+      return -1;
+  }
+
+  session->freq = get_proprietary_freq(default_freq, session->fact);      
+  session->low_freq =  get_proprietary_freq(low_freq,  session->fact); 
+  session->high_freq =  get_proprietary_freq(high_freq,  session->fact); 
+  session->grid = get_proprietary_freq(grid,  session->fact);
+  session->threshold = DEFAULT_THRESHOLD;
+  session->callbacks = callbacks;
+
+  if (set_freq(session->fd, session->freq) < 0 ){
+      ALOGE("error on set freq\n");
+      return -1;
+  }
+
+  if (set_volume(session->fd, DEFAULT_VOLUME)<0){
+      ALOGE("error on set volume\n");
+      return -1;
+  }
+
+  if (set_mute(session->fd, MUTE_OFF) <0){
+      ALOGE("error on mute\n");
+      return -1;
+  }
+
+  start_rds_thread(session);
+    
+  return 0;
+}
+
+int v4l2_reset(void** session_data)
+{
+  fm_v4l2_data* session;
+  int ret;
+
+  ALOGI("%s:\n", __FUNCTION__);
+  session = get_session_data(session_data);  
+
+  kill_rds_thread(session);
+  ret = set_mute(session->fd, MUTE_ON);
+  if (ret < 0)
+    return -1;
+
+  ret = close(session->fd);
+  if (ret < 0)
+    return -1;
+
+  free(session);
+  return 0;
+}
+
+int v4l2_pause(void** session_data){
+  fm_v4l2_data* session;
+
+  ALOGI("%s:\n", __FUNCTION__);
+  session = get_session_data(session_data);
+
+  kill_rds_thread(session);
+  return set_mute(session->fd, MUTE_ON);
+}
+
+int v4l2_resume(void** session_data){
+  fm_v4l2_data* session;
+
+  ALOGI("%s:\n", __FUNCTION__);
+  session = get_session_data(session_data);
+
+  start_rds_thread(session);
+  return set_mute(session->fd, MUTE_OFF);
+}
+
+int v4l2_set_frequency(void** session_data, int frequency){
+  fm_v4l2_data* session;  
+  int ret;
+
+  ALOGI("%s:\n", __FUNCTION__);
+  session = get_session_data(session_data);
+
+  session->freq = get_proprietary_freq( frequency, session->fact);
+  ret= set_freq(session->fd,  session->freq);  
+  if (ret < 0)
+      return -1;
+
+  return frequency;      
+}
+
+int v4l2_get_frequency (void ** session_data){
+  fm_v4l2_data* session;  
+  int ret;
+
+  ALOGI("%s:\n", __FUNCTION__);
+  session = get_session_data(session_data);  
+
+  ret = get_freq(session->fd);
+  if (ret < 0)
+      return -1;
+  
+  session->freq = get_standard_freq(ret, session->fact);
+  
+  return session->freq;
+}
+
+int v4l2_get_threshold (void ** session_data){   
+  fm_v4l2_data* session;
+
+  ALOGI("%s:\n", __FUNCTION__);
+  session = get_session_data(session_data);
+  
+  return session->threshold;
+ }
+
+int v4l2_set_threshold (void ** session_data, int threshold){
+   fm_v4l2_data* session;
+
+   ALOGI("%s:\n", __FUNCTION__);
+   session = get_session_data(session_data);
+   
+   session->threshold = threshold;
+   return 0;
+}
+
+int v4l2_get_signal_strength (void ** session_data){
+    fm_v4l2_data* session;  
+    int ret;
+
+    ALOGI("%s:\n", __FUNCTION__);   
+    session = get_session_data(session_data);   
+
+    ret = get_signal_strength(session->fd, &session->vt);    
+    return ret;
+}
+
+int v4l2_is_playing_in_stereo (void ** session_data){
+    fm_v4l2_data* session;  
+    int ret;
+
+    ALOGI("%s:\n", __FUNCTION__);
+    session = get_session_data(session_data);
+
+    ret = get_stereo(session->fd, &session->vt);
+    return ret;
+}
+
+int v4l2_scan (void ** session_data, enum fmradio_seek_direction_t direction){
+   fm_v4l2_data* session;
+   int increment, rate, freqi, ret;
+
+   ALOGI("%s:\n", __FUNCTION__);  
+   session = get_session_data(session_data);
+
+   session->scan_band_run=SCAN_RUN;
+   if (direction==FMRADIO_SEEK_DOWN)
+     increment = -  session->grid;
+   else                                      //FMRADIO_SEEK_UP
+     increment =  session->grid;
+
+  freqi = session->freq + increment;         //drop the current frequency
+  ALOGI("Starting scanning...\n");
+  while (session->scan_band_run==SCAN_RUN){
+
+      ret= set_freq(session->fd, freqi);    
+      if (ret<0)
+          return -1;
+
+      usleep(LOCKTIME);                       // let it lock on
+      rate= get_signal_strength( session->fd,  &session->vt);
+      if (rate < 0)
+         return -1;
+
+      ALOGI("final rate %d > %d \n", rate , session->threshold);
+
+      if (rate >  session->threshold){
+      ALOGI("Found freq, %d\n", freqi);
+      session->scan_band_run=SCAN_STOP;	
+      session->freq = freqi;
+      return get_standard_freq(freqi, session->fact);
+      }
+
+      freqi +=  increment;
+      if ( freqi >  session->high_freq)
+         freqi =  session->low_freq;
+      if ( freqi <  session->low_freq)
+          freqi =  session->high_freq;
+  }
+  ALOGI("End scan\n");
+  return 0;
+}
+
+int v4l2_full_scan (void ** session_data, int ** found_freqs, int ** signal_strenghts){
+  fm_v4l2_data* session;
+  int founded, i, ret;
+  int freqi, rate;
+  int *temp_freq, *temp_strenght;
+
+  ALOGI("%s:\n", __FUNCTION__);  
+  session = get_session_data(session_data);
+
+  session->scan_band_run=SCAN_RUN; 
+
+  temp_freq = (int *) malloc(sizeof(int) *MAX_FREQS);      
+  temp_strenght = (int *) malloc(sizeof(int) *MAX_FREQS);
+  if (temp_freq == NULL || temp_strenght==NULL){
+    ALOGE("error on allocate");
+    return -1;
+  }
+
+  ALOGI("Starting full scanning...low freq:%d, high freq:%d\n", session->low_freq, session->high_freq);    
+
+  for (freqi =  session->low_freq, founded=0 ; ((freqi < session->high_freq)  && (founded < MAX_FREQS) && (session->scan_band_run==SCAN_RUN)) ; freqi += session->grid){	  		
+
+      ret = set_freq(session->fd, freqi);
+      if (ret<0) 
+         return -1;
+
+      usleep(LOCKTIME);		/* let it lock on */
+      rate= get_signal_strength(session->fd, &session->vt);
+      if (rate < 0)
+          return -1;
+
+      ALOGI("final rate %d > %d \n", rate ,session->threshold);
+
+      if (rate > session->threshold){
+          ALOGI("Founded index %d, freq %d\n", founded, freqi);
+          temp_freq[founded]= freqi;
+          temp_strenght[founded]= rate;
+          founded++;
+      }
+  }
+
+  *found_freqs = (int *) malloc(sizeof(int) * founded);
+  *signal_strenghts = (int *) malloc(sizeof(int) * founded);
+  if (*found_freqs == NULL || *signal_strenghts==NULL){
+    ALOGE("error on allocate");
+    return -1;
+  }
+
+  //copy founded frequencies
+  for (i=0; i<founded; i++){
+      (*found_freqs)[i] = get_standard_freq(temp_freq[i], session->fact);
+      (*signal_strenghts)[i] = temp_strenght[i];
+      ALOGI("Copied index %d, freq %d, signal %d\n",i, (*found_freqs)[i], (*signal_strenghts)[i] );
+  }
+
+  ALOGI("End full scan\n");
+  free(temp_freq);
+  free(temp_strenght);
+  session->scan_band_run=SCAN_STOP;
+
+  return i;    
+}
+
+int v4l2_stop_scan(void ** session_data){
+  fm_v4l2_data* session;
+
+  ALOGI("%s:\n", __FUNCTION__);  
+  session = get_session_data(session_data);
+  session->scan_band_run=SCAN_STOP;
+  ALOGI("Stop scan value is %d\n", session->scan_band_run);  
+
+  return 1;
+}
+
+int v4l2_set_force_mono (void ** session_data, int force_mono){
+  fm_v4l2_data* session;    
+  int ret;
+
+  ALOGI("%s:\n", __FUNCTION__);  
+  session = get_session_data(session_data);
+
+  ret = set_force_mono(session->fd, &session->vt, force_mono);  
+  return ret;
+}
+
+int v4l2_is_rds_data_supported (void ** session_data){  
+  fm_v4l2_data* session;  
+  int ret;
+
+  ALOGI("%s:\n", __FUNCTION__);  
+  session = get_session_data(session_data);
+
+  ret = get_RDS_cap(session->fd);  
+  return ret;
+}
+
+int v4l2_is_tuned_to_valid_channel (void ** session_data){
+  fm_v4l2_data* session;  
+  int signal;  
+
+  ALOGI("%s:\n", __FUNCTION__);  
+  session = get_session_data(session_data);      
+
+  signal = get_signal_strength(session->fd, &session->vt);          
+  if ( signal > session->threshold )
+    return 1;
+  else 
+    return 0;  
+}
+
+void* th_read_rds(void *thread_session_data){
+  int ret, i, j,blocknum,last_block_num, next_expected_block, group_status, group_type; 
+  char *buf, *group;
+  char b0, b1, b2, b1_l5;
+  struct fmradio_rds_bundle_t fmradio_rds_bundle;
+  int index;
+  fm_v4l2_data* session;  
+
+  session = (fm_v4l2_data*) thread_session_data;
+  buf = malloc (sizeof(char) * BUFFER_RDS_SIZE);
+  group = malloc (sizeof(char) * GROUP_SIZE);  
+  CLEAN_RDS 
+
+  ALOGI("Thread RDS read started..\n");
+  
+  while (session->thread_rds_run == RDS_THREAD_ON){
+
+      ret = read( session->fd, buf, BUFFER_RDS_SIZE);          
+      if (ret == -1 && errno == EINTR){
+          ALOGE("Error on RDS read\n");
+          pthread_exit(&ret);
+      }
+
+      if (ret>0){
+           ALOGI ("read num bytes %d\n", ret);	//assuming to have always multiple of 3
+
+      for (i =0; i< ret; i+=3){
+        b0 = buf[i];
+        b1 = buf[i+1];
+        b2 = buf[i+2];
+
+        if ((b2 & 0x80)!=0){
+        CLEAN_RDS
+        continue;
+        }
+
+        blocknum = b2 & 0x07; // What's the differnce between "Received Offset"            
+
+        if (blocknum == 4) blocknum = 2; // Treat C' as C
+        if ((blocknum == 5)||(blocknum==6)) continue; // ignore E Blocks
+
+        if (blocknum == 7){ //invalid block	
+        CLEAN_RDS
+        continue;
+        }
+
+        if (blocknum == last_block_num) continue;
+
+        if ((group_status == GROUP_EMPTY)&&(blocknum != 0)) continue; 
+
+        if (blocknum != next_expected_block){
+          CLEAN_RDS
+          continue;
+        }
+
+        if (blocknum == 1){
+          group_type = (b1 >> 3);
+         }
+
+         group[2*blocknum] = b0;
+         group[2*blocknum+1] = b1;
+         group_status=GROUP_INCOMPLETE;
+
+         last_block_num = blocknum;
+         next_expected_block = blocknum+1;
+
+         if (next_expected_block <= 3) continue;
+
+         // PI code in block 0:
+        fmradio_rds_bundle.pi = ( group[GETBYTE(0,1)] << 8) | group[GETBYTE(0,0)];
+
+         //some other info common in all groups:
+        fmradio_rds_bundle.tp = group[GETBYTE(1,1)] & 0x04;
+        fmradio_rds_bundle.pty= (((group[GETBYTE(1,1)] << 3) & 0x18) | ((group[GETBYTE(1,0)] >> 5) & 0x07));
+        // special
+        b1_l5 = (group[GETBYTE(1,0)] & 0x1F);
+
+        switch (group_type){
+          case GROUP_0A:
+          case GROUP_0B:
+
+          fmradio_rds_bundle.ta = (b1_l5 & 0x10);
+          fmradio_rds_bundle.ms = (b1_l5 & 0x08);
+
+                  index = (b1_l5 & 0x03) << 1;
+
+          if ( isprint(group[GETBYTE(3,1)]) && isprint(group[GETBYTE(3,0)]) ){
+              fmradio_rds_bundle.psn[index]   = group[GETBYTE(3,1)];
+              fmradio_rds_bundle.psn[index+1] = group[GETBYTE(3,0)];
+          }
+          else break;
+
+          if (index==6){
+            fmradio_rds_bundle.psn[8] = '\0';
+            ALOGI("Event Rds called!\n");
+            (session->callbacks)->on_rds_data_found(&fmradio_rds_bundle, session->freq);
+          }
+          break;
+        }
+        CLEAN_RDS
+    }
+      }
+      if (session->thread_rds_run != RDS_THREAD_ON)
+        continue;
+      sleep(2);
+  }
+
+  free(buf);
+  free(group); 
+  ALOGI("Thread RDS read End\n");
+  pthread_exit(&ret);
+  return 0;
+}
+
+int kill_rds_thread(fm_v4l2_data* session){
+  int ret;  
+
+  if (session->thread_rds_run == RDS_THREAD_OFF){
+    ALOGE("thread RDS is already stopped!\n"); 
+    return 0;
+  }
+
+  session->thread_rds_run = RDS_THREAD_OFF;  
+
+  ALOGI("joining RDS thread...\n");
+  ret = pthread_join(session->thread_rds, NULL);
+    if (ret<0)      
+      ALOGE("pthread_join error \n"); 
+      
+  ALOGI("joined RDS thread\n");        
+  
+  return ret;
+}
+
+int start_rds_thread(fm_v4l2_data* session){
+  int ret;
+  pthread_attr_t attr;
+
+  if (session->thread_rds_run == RDS_THREAD_ON){
+    ALOGI("thread RDS is already running!\n");
+    return 0;
+  }
+
+   pthread_attr_init(&attr);
+   pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
+
+  session->thread_rds_run = RDS_THREAD_ON;
+  ret = pthread_create( &session->thread_rds, &attr, th_read_rds, (void*) session);
+  if (ret<0)
+     ALOGE("error on creating RDS thread\n"); 
+
+  return ret;  
+}
+
+
+int register_fmradio_functions(long *signature, struct fmradio_vendor_methods_t *vendor_methods)
+{
+    memset(vendor_methods, 0, sizeof(vendor_methods));
+
+    vendor_methods->set_frequency = v4l2_set_frequency;
+    vendor_methods->get_frequency = v4l2_get_frequency;
+    vendor_methods->get_threshold = v4l2_get_threshold;
+    vendor_methods->set_threshold = v4l2_set_threshold;
+    vendor_methods->is_rds_data_supported = v4l2_is_rds_data_supported;
+    vendor_methods->scan = v4l2_scan;
+    vendor_methods->is_tuned_to_valid_channel = v4l2_is_tuned_to_valid_channel;
+    vendor_methods->full_scan = v4l2_full_scan;
+    vendor_methods->stop_scan = v4l2_stop_scan;
+    vendor_methods->is_playing_in_stereo = v4l2_is_playing_in_stereo;
+    vendor_methods->get_signal_strength = v4l2_get_signal_strength;    
+    vendor_methods->rx_start = v4l2_rx_start_func;
+    vendor_methods->pause=v4l2_pause;
+    vendor_methods->resume=v4l2_resume;
+    vendor_methods->reset=v4l2_reset;
+    vendor_methods->set_frequency=v4l2_set_frequency;
+    vendor_methods->set_force_mono=v4l2_set_force_mono;
+
+    *signature = FMRADIO_SIGNATURE;
+    return 0;
+}

--- a/brcm_fmradio/fmradio.v4l2-fm/v4l2_ioctl.c
+++ b/brcm_fmradio/fmradio.v4l2-fm/v4l2_ioctl.c
@@ -36,7 +36,7 @@
 #include <string.h>
 
 int get_v4l2_tuner(int fd, struct v4l2_tuner *vt){
-    int ret; 
+    int ret;
 
     vt->index=0;
 
@@ -49,7 +49,7 @@ int get_v4l2_tuner(int fd, struct v4l2_tuner *vt){
 }
 
 int set_v4l2_tuner(int fd, struct v4l2_tuner *vt){
-    int ret; 
+    int ret;
 
     vt->index=0;
 
@@ -62,15 +62,15 @@ int set_v4l2_tuner(int fd, struct v4l2_tuner *vt){
 }
 
 float get_fact(int fd, struct v4l2_tuner *vt){
-  
+
     if (get_v4l2_tuner(fd, vt)<0)
         return -1;
 
     if ((vt->capability & V4L2_TUNER_CAP_LOW) == 0)
-        return 0.016; 
+        return 0.016;
     else
         return 16.;
-    
+
     return -1;
 }
 
@@ -99,7 +99,7 @@ int get_tun_radio_cap(int fd){
     struct v4l2_capability vc;
 
     ret = ioctl(fd, VIDIOC_QUERYCAP, &vc);
-    
+
     if (ret < 0) {
         ALOGE("ioctl VIDIOC_QUERYCAP\n");
         return -1;
@@ -108,15 +108,15 @@ int get_tun_radio_cap(int fd){
 }
 
 int open_dev(char *dev){
-    int fd; 
+    int fd;
 
     ALOGI("Open default device %s\n", dev);
-    fd = open(dev, O_RDONLY | O_NONBLOCK); 
+    fd = open(dev, O_RDONLY | O_NONBLOCK);
     if (fd < 0) {
         ALOGE("Unable to open %s: %s\n", dev, strerror(errno));
         return -1;
     }
-    
+
     return fd;
 }
 
@@ -124,7 +124,7 @@ int close_dev(int fd){
     int ret;
 
     ALOGI("Close radio device fd %d\n", fd);
-    ret = close(fd); 
+    ret = close(fd);
     if (ret < 0) {
         ALOGE("Unable to close radio dev fd %d\n", fd);
         return -1;
@@ -138,17 +138,17 @@ int set_volume(int fd, int vol){
     struct  v4l2_control vc;
 
     vc.id = V4L2_CID_AUDIO_VOLUME;
-    vc.value = vol;  
+    vc.value = vol;
 
     ret = ioctl(fd, VIDIOC_S_CTRL, &vc);
     if (ret < 0) {
         ALOGE("ioctl V4L2_CID_AUDIO_VOLUME \n");
         return -1;
     }
-    
+
     ALOGI("Radio on at %2.2f%% volume\n", (vol / 655.36));
 
-    return 0;  
+    return 0;
 }
 
 int set_mute(int fd, int value){
@@ -167,8 +167,8 @@ int set_mute(int fd, int value){
     return 0;
 }
 
-int  set_freq(int fd, int freq){       
-    int ret; 
+int  set_freq(int fd, int freq){
+    int ret;
     struct v4l2_frequency vf;
 
     vf.tuner=0;
@@ -185,7 +185,7 @@ int  set_freq(int fd, int freq){
     return freq;
 }
 
-int get_freq(int fd){  
+int get_freq(int fd){
     int ret;
     struct v4l2_frequency vf;
 
@@ -201,7 +201,7 @@ int get_freq(int fd){
     return vf.frequency;
 }
 
-int get_signal_strength(int fd, struct v4l2_tuner *vt){ 
+int get_signal_strength(int fd, struct v4l2_tuner *vt){
     int totsig, rate, i;
     float perc;
 
@@ -211,7 +211,7 @@ int get_signal_strength(int fd, struct v4l2_tuner *vt){
 
         if (i>0)
             usleep(SAMPLEDELAY);
-    
+
         if (get_v4l2_tuner(fd, vt) < 0) {
         return -1;
         }
@@ -224,7 +224,7 @@ int get_signal_strength(int fd, struct v4l2_tuner *vt){
     perc = (totsig / (65535.0 * TRIES));
     rate = perc * 1000.0;   // changed in 0 - 1000 scale
 
-    ALOGI("signal strenght in SE scale %d \n", rate); 
+    ALOGI("signal strenght in SE scale %d \n", rate);
 
     return rate;
 }
@@ -238,6 +238,3 @@ int set_force_mono(int fd, struct v4l2_tuner *vt, int force_mono){
 
     return set_v4l2_tuner(fd, vt);
 }
-
-
-

--- a/brcm_fmradio/fmradio.v4l2-fm/v4l2_ioctl.c
+++ b/brcm_fmradio/fmradio.v4l2-fm/v4l2_ioctl.c
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) CSR plc 2011
+ * Copyright 2010, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: marco.sinigaglia@csr.com for CSR plc
+ */
+
+#define LOG_TAG "fm_api.cpp"
+#define LINUX
+#ifdef LINUX
+#define ALOGI printf
+#define ALOGE printf
+#else
+#include "utils/Log.h"
+#endif
+
+#include "v4l2_ioctl.h"
+#include <errno.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <string.h>
+
+int get_v4l2_tuner(int fd, struct v4l2_tuner *vt){
+    int ret; 
+
+    vt->index=0;
+
+    ret = ioctl(fd, VIDIOC_G_TUNER, vt);
+    if (ret < 0) {
+        ALOGE("ioctl VIDIOC_G_TUNER\n");
+        return -1;
+    }
+    return 0;
+}
+
+int set_v4l2_tuner(int fd, struct v4l2_tuner *vt){
+    int ret; 
+
+    vt->index=0;
+
+    ret = ioctl(fd, VIDIOC_S_TUNER, vt);
+    if (ret < 0) {
+        ALOGE("ioctl VIDIOC_S_TUNER\n");
+        return -1;
+    }
+    return 0;
+}
+
+float get_fact(int fd, struct v4l2_tuner *vt){
+  
+    if (get_v4l2_tuner(fd, vt)<0)
+        return -1;
+
+    if ((vt->capability & V4L2_TUNER_CAP_LOW) == 0)
+        return 0.016; 
+    else
+        return 16.;
+    
+    return -1;
+}
+
+int get_stereo(int fd, struct v4l2_tuner *vt){
+    if (get_v4l2_tuner(fd, vt)<0)
+        return -1;
+
+    return ((vt->audmode & V4L2_TUNER_MODE_STEREO) ==1);
+}
+
+int get_RDS_cap(int fd){
+    int ret;
+    struct v4l2_capability vc;
+
+    ret = ioctl(fd, VIDIOC_QUERYCAP, &vc);
+
+    if (ret < 0) {
+        ALOGE("ioctl VIDIOC_QUERYCAP\n");
+        return -1;
+    }
+    return (vc.capabilities & V4L2_CAP_RDS_CAPTURE);
+}
+
+int get_tun_radio_cap(int fd){
+    int ret;
+    struct v4l2_capability vc;
+
+    ret = ioctl(fd, VIDIOC_QUERYCAP, &vc);
+    
+    if (ret < 0) {
+        ALOGE("ioctl VIDIOC_QUERYCAP\n");
+        return -1;
+    }
+    return ((vc.capabilities & V4L2_CAP_TUNER) && (vc.capabilities & V4L2_CAP_RADIO));
+}
+
+int open_dev(char *dev){
+    int fd; 
+
+    ALOGI("Open default device %s\n", dev);
+    fd = open(dev, O_RDONLY | O_NONBLOCK); 
+    if (fd < 0) {
+        ALOGE("Unable to open %s: %s\n", dev, strerror(errno));
+        return -1;
+    }
+    
+    return fd;
+}
+
+int close_dev(int fd){
+    int ret;
+
+    ALOGI("Close radio device fd %d\n", fd);
+    ret = close(fd); 
+    if (ret < 0) {
+        ALOGE("Unable to close radio dev fd %d\n", fd);
+        return -1;
+    }
+
+    return ret;
+}
+
+int set_volume(int fd, int vol){
+    int ret;
+    struct  v4l2_control vc;
+
+    vc.id = V4L2_CID_AUDIO_VOLUME;
+    vc.value = vol;  
+
+    ret = ioctl(fd, VIDIOC_S_CTRL, &vc);
+    if (ret < 0) {
+        ALOGE("ioctl V4L2_CID_AUDIO_VOLUME \n");
+        return -1;
+    }
+    
+    ALOGI("Radio on at %2.2f%% volume\n", (vol / 655.36));
+
+    return 0;  
+}
+
+int set_mute(int fd, int value){
+        int ret;
+    struct  v4l2_control vc;
+
+    vc.value = value;
+    vc.id = V4L2_CID_AUDIO_MUTE;
+
+    ret = ioctl(fd, VIDIOC_S_CTRL, &vc);
+    if (ret < 0) {
+        ALOGE("ioctl V4L2_CID_AUDIO_MUTE \n");
+        return -1;
+    }
+
+    return 0;
+}
+
+int  set_freq(int fd, int freq){       
+    int ret; 
+    struct v4l2_frequency vf;
+
+    vf.tuner=0;
+    vf.frequency=freq;
+    vf.type=V4L2_TUNER_RADIO;
+
+    ret = ioctl(fd, VIDIOC_S_FREQUENCY, &vf);
+    if (ret < 0) {
+        ALOGE("ioctl VIDIOC_S_FREQUENCY, %d\n", ret);
+        return -1;
+    }
+
+    ALOGI("Radio set freq to propretary %d\n", freq);
+    return freq;
+}
+
+int get_freq(int fd){  
+    int ret;
+    struct v4l2_frequency vf;
+
+    vf.tuner=0;
+
+    ret = ioctl(fd, VIDIOC_G_FREQUENCY, &vf);
+    if (ret < 0) {
+        ALOGE("ioctl VIDIOC_G_FREQUENCY\n");
+        return -1;
+    }
+
+    ALOGI("Radio get frequency propretary %d \n", vf.frequency);
+    return vf.frequency;
+}
+
+int get_signal_strength(int fd, struct v4l2_tuner *vt){ 
+    int totsig, rate, i;
+    float perc;
+
+    totsig=0;
+
+    for (i = 0; i < TRIES; i++) {
+
+        if (i>0)
+            usleep(SAMPLEDELAY);
+    
+        if (get_v4l2_tuner(fd, vt) < 0) {
+        return -1;
+        }
+
+        totsig += vt->signal;
+        perc = (totsig / (65535.0 * i));
+        //ALOGI("checking: %3.1f%% (%d/%d), vt.signal %d  \n", perc * 100.0, i, TRIES,  vt->signal);
+        }
+
+    perc = (totsig / (65535.0 * TRIES));
+    rate = perc * 1000.0;   // changed in 0 - 1000 scale
+
+    ALOGI("signal strenght in SE scale %d \n", rate); 
+
+    return rate;
+}
+
+int set_force_mono(int fd, struct v4l2_tuner *vt, int force_mono){
+
+    if (force_mono ==1)
+        vt->audmode = V4L2_TUNER_MODE_MONO;
+    else
+        vt->audmode = V4L2_TUNER_MODE_STEREO;
+
+    return set_v4l2_tuner(fd, vt);
+}
+
+
+

--- a/brcm_fmradio/fmradio.v4l2-fm/v4l2_ioctl.h
+++ b/brcm_fmradio/fmradio.v4l2-fm/v4l2_ioctl.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) CSR plc 2011
+ * Copyright 2010, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: marco.sinigaglia@csr.com for CSR plc
+ */
+
+#include "linux/videodev2.h"
+
+#define     DEFAULT_DEVICE     "/dev/radio0"
+//SCAN PARAMETER
+#define     SAMPLEDELAY         15000       /* wait 15ms between samples */
+#define     TRIES               1           /* number of times of test signal */
+
+
+int get_v4l2_tuner(int fd, struct v4l2_tuner *vt);
+float get_fact(int fd, struct v4l2_tuner *vt);
+int get_stereo(int fd, struct v4l2_tuner *vt);
+int open_dev(char *dev);
+int close_dev(int fd);
+int set_freq(int fd, int freq);
+int get_freq(int fd);
+int set_volume(int fd, int vol);
+int get_signal_strength(int fd, struct v4l2_tuner *vt);
+int set_force_mono(int fd, struct v4l2_tuner *vt, int force_mono);
+int get_RDS_cap(int fd);
+int get_tun_radio_cap(int fd);
+int set_mute(int fd, int value);
+int set_volume(int fd, int vol);
+

--- a/brcm_fmradio/fmradio.v4l2-fm/v4l2_ioctl.h
+++ b/brcm_fmradio/fmradio.v4l2-fm/v4l2_ioctl.h
@@ -39,4 +39,3 @@ int get_RDS_cap(int fd);
 int get_tun_radio_cap(int fd);
 int set_mute(int fd, int value);
 int set_volume(int fd, int vol);
-

--- a/brcm_fmradio/libfmjni/Android.mk
+++ b/brcm_fmradio/libfmjni/Android.mk
@@ -1,0 +1,26 @@
+# Copyright (C) 2014 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE    := libfmjni
+LOCAL_SRC_FILES := android_fm.cpp \
+                   android_fmradio_Receiver.cpp
+
+LOCAL_REQUIRED_MODULES := libfmradio.v4l2-fm brcm-uim-sysfs
+LOCAL_SHARED_LIBRARIES += liblog libnativehelper
+
+include $(BUILD_SHARED_LIBRARY)

--- a/brcm_fmradio/libfmjni/android_fm.cpp
+++ b/brcm_fmradio/libfmjni/android_fm.cpp
@@ -1,0 +1,1186 @@
+/*
+ * Copyright (C) ST-Ericsson SA 2010
+ * Copyright 2010, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: johan.xj.palmaeus@stericsson.com for ST-Ericsson
+ */
+
+/*
+ * Native part of the generic TX-RX common FmRadio inteface
+ */
+
+
+#define ALOG_TAG "FmServiceNative"
+
+// #define ALOG_NDEBUG 1
+
+#include <dlfcn.h>
+#include <string.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <errno.h>
+
+#include "jni.h"
+
+#include <utils/Log.h>
+#include "android_fmradio_Receiver.h"
+
+#ifndef LIBRARY_PATH
+#define LIBRARY_PATH "/system/lib64/"
+#endif
+
+#ifndef LIBRARY_PREFIX
+#define LIBRARY_PREFIX "libfmradio."
+#endif
+
+#ifndef LIBRARY_SUFFIX
+#define LIBRARY_SUFFIX ".so"
+#endif
+
+#ifndef LIBRARY_SUFFIX_RX
+#define LIBRARY_SUFFIX_RX "_rx.so"
+#endif
+
+#ifndef LIBRARY_SUFFIX_TX
+#define LIBRARY_SUFFIX_TX "_tx.so"
+#endif
+
+/* structs for passing startup arguments to threads */
+
+struct FmRadioStartAsyncParameters {
+    int (*startFunc) (void **, const struct fmradio_vendor_callbacks_t*, int, int, int,
+                      int);
+    struct FmSession_t *session_p;
+    const struct fmradio_vendor_callbacks_t *callbacks_p;
+    int lowFreq;
+    int highFreq;
+    int defaultFreq;
+    int grid;
+};
+
+struct FmRadioSendExtraCommandParameters {
+    struct FmSession_t *session_p;
+    char* c_command;
+    char ** cparams;
+};
+
+
+pthread_mutex_t rx_tx_common_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+jobject extraCommandRetList2Bundle(JNIEnv * env_p, struct bundle_descriptor_offsets_t
+*bundleOffsets_p,
+                                   struct fmradio_extra_command_ret_item_t *itemList)
+{
+    struct fmradio_extra_command_ret_item_t *listIterator = itemList;
+
+    jobject bundle = env_p->NewObject(bundleOffsets_p->mClass,
+                                      bundleOffsets_p->mConstructor);
+
+    while (listIterator && listIterator->key != NULL) {
+        switch (listIterator->type) {
+            case FMRADIO_TYPE_INT:
+                env_p->CallVoidMethod(bundle, bundleOffsets_p->mPutInt,
+                                      env_p->NewStringUTF(listIterator->key),
+                                      listIterator->data.int_value);
+                break;
+            case FMRADIO_TYPE_STRING:
+                env_p->CallVoidMethod(bundle, bundleOffsets_p->mPutString,
+                                      env_p->NewStringUTF(listIterator->key),
+                                      env_p->NewStringUTF(listIterator->data.string_value));
+                break;
+            default:
+                ALOGE("warning. Unknown command ret item type %d\n",
+                      listIterator->type);
+                break;
+        }
+
+        listIterator++;
+    }
+    return bundle;
+}
+
+void freeExtraCommandRetList(struct fmradio_extra_command_ret_item_t *itemList)
+{
+    struct fmradio_extra_command_ret_item_t *listIterator = itemList;
+
+    while (listIterator && listIterator->key != NULL) {
+        free(listIterator->key);
+        if (listIterator->type == FMRADIO_TYPE_STRING) {
+            free(listIterator->data.string_value);
+        }
+        listIterator++;
+    }
+    free(itemList);
+
+}
+
+static bool jstringArray2cstringArray(JNIEnv * env_p, jobjectArray jarray,
+                                      char ***carray_p)
+{
+    int arrayLength;
+
+    if (jarray != NULL &&
+        (arrayLength = env_p->GetArrayLength(jarray)) > 0) {
+        int d;
+
+        char **carray = (char **) calloc(arrayLength + 1, sizeof(*carray));
+
+        if (carray == NULL) {
+            ALOGE("malloc failed\n");
+            return false;
+        }
+
+        for (d = 0; d < arrayLength; d++) {
+            const char *itemstr = env_p->GetStringUTFChars((jstring)
+                                                                   env_p->GetObjectArrayElement
+                                                                           (jarray, d),
+                                                           NULL);
+
+            carray[d] = strdup(itemstr);
+            env_p->ReleaseStringUTFChars((jstring)
+                                                 env_p->GetObjectArrayElement
+                                                         (jarray, d), itemstr);
+            if (carray[d] == NULL) {
+                ALOGE("strdup failed\n");
+                /* free any arrays already allocated, free the array pointer
+                 * and exit */
+                while (--d >= 0) {
+                    free(carray[d]);
+                }
+                free(carray);
+                return false;
+            }
+        }
+        carray[arrayLength] = NULL;     /* to be able to detect end of array */
+        *carray_p = carray;
+    } else {
+        *carray_p = NULL;
+    }
+
+    return true;
+}
+
+static void freeCstringArray(char **cstringarray)
+{
+    if (cstringarray != NULL && *cstringarray != NULL) {
+        char **iterator = cstringarray;
+
+        while (*iterator != NULL) {
+            free(*iterator);
+            iterator++;
+        }
+        free(cstringarray);
+
+    }
+}
+
+/*
+ * Function to temporary resume a paused device for executing command
+ */
+void androidFmRadioTempResumeIfPaused(struct FmSession_t *session_p)
+{
+    if (session_p->state == FMRADIO_STATE_PAUSED) {
+        /* no need to handle error here, the main command will fail anyway */
+        (void)session_p->vendorMethods_p->resume(&session_p->vendorData_p);
+    }
+}
+
+/*
+ * Function to pause device after a temporary resume
+ */
+void androidFmRadioPauseIfTempResumed(struct FmSession_t *session_p)
+{
+    if (session_p->state == FMRADIO_STATE_PAUSED) {
+        if (session_p->vendorMethods_p->pause(&session_p->vendorData_p)
+            != FMRADIO_OK)  {
+            ALOGE("androidFmRadioPauseIfTempResumed: pause failed, force "
+                          "resetting");
+            /*
+             * Failed to set pause again. Since the device is supposed to be
+             * paused we can't leave it this way, our best choice is to issue
+             * a force reset to put the device in a known idle state. Temporary
+             * drop locks since we might trigger callbacks.
+             */
+            FMRADIO_SET_STATE(session_p, FMRADIO_STATE_IDLE);
+            /* temporary drop lock to allow reset triggered callbacks */
+            pthread_mutex_unlock(session_p->dataMutex_p);
+            int retval = session_p->vendorMethods_p->reset(&session_p->vendorData_p);
+            pthread_mutex_lock(session_p->dataMutex_p);
+
+            if (retval != FMRADIO_OK) {
+                ALOGE("androidFmRadioPauseIfTempResumed: CRITICAL ERROR: "
+                              "can't reset device");
+                /* if we can't even reset we have a critical problem */
+                session_p->callbacks_p->onForcedReset(FMRADIO_RESET_CRITICAL);
+            } else {
+                /* now we are in known state */
+                session_p->callbacks_p->onForcedReset(FMRADIO_RESET_NON_CRITICAL);
+            }
+
+            /* unload vendor driver */
+            androidFmRadioUnLoadFmLibrary(session_p);
+            session_p->isRegistered = false;
+        }
+    }
+}
+
+bool
+androidFmRadioIsValidEventForState(struct FmSession_t *session_p,
+                                   enum FmRadioCommand_t event)
+{
+    bool retval;
+
+    if (!session_p->isRegistered && (event != FMRADIO_EVENT_RESET) &&
+        (event != FMRADIO_EVENT_START) && (event != FMRADIO_EVENT_START_ASYNC)) {
+        ALOGE("ERROR - library not loaded, only reset, start and start async are valid events");
+        retval = false;
+    } else if (session_p->ongoingReset && (event != FMRADIO_EVENT_RESET)) {
+        ALOGE("ERROR - ongoing reset invalidates state changes");
+        retval = false;
+    } else if (!(*session_p->validEventsForStates_p)[event][session_p->state]) {
+        ALOGE("ERROR - Invalid event %u for state %u", event,
+              session_p->state);
+        retval = false;
+    } else {
+        retval = true;
+    }
+
+    return retval;
+}
+
+void
+androidFmRadioThrowException(struct FmSession_t *session_p,
+                             const char *exception,
+                             const char *message, const char *file,
+                             int line, const char *function)
+{
+    bool reAttached = false;
+
+    JNIEnv *env;
+
+    ALOGI("androidFmRadioThrowException, %s ('%s') @ %s %d (%s)\n",
+          exception, message, file, line, function);
+
+
+    if (session_p->jvm_p->GetEnv((void **) &env, JNI_VERSION_1_4) !=
+        JNI_OK) {
+        /* we are probably a subthread. Attach instead */
+        if (session_p->jvm_p->AttachCurrentThread(&env, NULL) != JNI_OK) {
+            ALOGE("Error, can't attch current thread\n");
+            return;
+        }
+        reAttached = true;
+    }
+
+    if (reAttached) {
+        session_p->jvm_p->DetachCurrentThread();
+    }
+
+}
+
+
+/*
+ *  Functions for loading and unloading the vendor dynamic library
+ *   (libfmradio.xxxxxx.so)
+ */
+
+static bool
+androidFmRadioGetLibraryName(enum RadioMode_t mode,
+                             char *libraryName)
+{
+    DIR *dirp;
+    struct dirent *dp;
+    char foundName[sizeof(dp->d_name)] = "";
+
+    if ((dirp = opendir(LIBRARY_PATH)) == NULL) {
+        ALOGE("couldn't open path '%s'", LIBRARY_PATH);
+        return false;
+    }
+
+    errno = 0;
+
+    while ((dp = readdir(dirp)) != NULL) {
+        char *name = dp->d_name;
+        size_t nameLength = strlen(name);
+
+        /*
+         * since prefix end with . and suffix start with . we need to make sure
+         * we don't get a match on something that is shorter than the two
+         * strings concatinated
+         */
+        if (nameLength < sizeof(LIBRARY_PREFIX) + sizeof(LIBRARY_SUFFIX) - 2) {
+            continue;
+        }
+
+        if ((nameLength > sizeof(LIBRARY_SUFFIX) -1) &&
+            (strcmp(name + nameLength - sizeof(LIBRARY_SUFFIX) + 1,
+                    LIBRARY_SUFFIX) == 0)) {
+        } else {
+            continue;
+        }
+
+        if (strncmp(name, LIBRARY_PREFIX, sizeof(LIBRARY_PREFIX) - 1) != 0) {
+            /* prefix doesn't match, this is not our file */
+            continue;
+        }
+
+
+        /* check if it is RX/TX specific or general */
+
+        if ((nameLength > sizeof(LIBRARY_SUFFIX_RX) -1) &&
+            (strcmp(name + nameLength - sizeof(LIBRARY_SUFFIX_RX) + 1,
+                    LIBRARY_SUFFIX_RX) == 0)) {
+            if (mode == FMRADIO_RX) {
+                strcpy(foundName, name);
+                break;
+            }
+        } else if ((nameLength > sizeof(LIBRARY_SUFFIX_TX) -1) &&
+                   (strcmp(name + nameLength - sizeof(LIBRARY_SUFFIX_TX) + 1,
+                           LIBRARY_SUFFIX_TX) == 0)) {
+            if (mode == FMRADIO_TX) {
+                strcpy(foundName, name);
+                break;
+            }
+        } else {
+            strcpy(foundName, name);
+            /* do not break, if there is a rx/tx specific name we prefer it */
+        }
+    }
+
+    (void)closedir(dirp);
+
+    if (dp == NULL && errno != 0) {
+        ALOGE("error reading directory, errno = %d\n", errno);
+        return false;
+    }
+
+    if (foundName[0] == '\0') {
+        ALOGE("No matching library found in path %s\n", LIBRARY_PATH);
+        return false;
+    }
+
+    // copy name with file path
+    strcpy(libraryName, LIBRARY_PATH);
+    // add slash if not last of path
+    if (libraryName[strlen(libraryName) -1] != '/') {
+        strcat(libraryName, "/");
+    }
+    strcat(libraryName, foundName);
+    return true;
+}
+
+bool
+androidFmRadioLoadFmLibrary(struct FmSession_t * session_p,
+                            enum RadioMode_t mode)
+{
+    char fmLibName[FM_LIBRARY_NAME_MAX_LENGTH + 1] = "";
+    fmradio_reg_func_t fmRegFunc = NULL;
+    unsigned int magicVal = 0;
+    bool retval = false;
+    bool missingMandatoryFunctions = false;
+
+    // read library directory and find matching library
+
+    if (!androidFmRadioGetLibraryName(mode, fmLibName)) {
+        goto funcret;
+    }
+
+    // load the library
+    session_p->fmLibrary_p = dlopen(fmLibName, RTLD_LAZY);
+    if (session_p->fmLibrary_p == NULL) {
+        ALOGI("Could not load library '%s'\n", fmLibName);
+        goto funcret;
+    } else {
+        ALOGI("Loaded library %s\n", fmLibName);
+    }
+
+    // now we have loaded the library, check for function
+    fmRegFunc = (fmradio_reg_func_t) dlsym(session_p->fmLibrary_p,
+                                           FMRADIO_REGISTER_FUNC);
+
+    if (fmRegFunc == NULL) {
+        ALOGE("Could not find symbol '%s' in loaded library '%s'\n",
+              FMRADIO_REGISTER_FUNC, fmLibName);
+        goto closelib;
+    }
+
+    // call function
+    if (fmRegFunc(&magicVal, session_p->vendorMethods_p) != 0) {
+        ALOGE("Loaded function '%s' returned unsuccessful\n",
+              FMRADIO_REGISTER_FUNC);
+        goto closelib;
+    }
+
+    // just to make sure correct function was called
+    if (magicVal != FMRADIO_SIGNATURE) {
+        ALOGE("Loaded function '%s' returned successful but failed setting magic value\n", FMRADIO_REGISTER_FUNC);
+        goto closelib;
+    }
+
+    // some methods are considered mandatory to implement, check them
+
+    if(mode == FMRADIO_RX && session_p->vendorMethods_p->rx_start == NULL) {
+        missingMandatoryFunctions = true;
+        ALOGE("Mandatory method rx_start is not implemented\n");
+    }
+    if(mode == FMRADIO_TX && session_p->vendorMethods_p->tx_start == NULL) {
+        missingMandatoryFunctions = true;
+        ALOGE("Mandatory method tx_start is not implemented\n");
+    }
+    if(session_p->vendorMethods_p->pause == NULL) {
+        missingMandatoryFunctions = true;
+        ALOGE("Mandatory method pause is not implemented\n");
+    }
+    if(session_p->vendorMethods_p->resume == NULL) {
+        missingMandatoryFunctions = true;
+        ALOGE("Mandatory method resume is not implemented\n");
+    }
+    if(session_p->vendorMethods_p->reset == NULL) {
+        missingMandatoryFunctions = true;
+        ALOGE("Mandatory method reset is not implemented\n");
+    }
+    if(missingMandatoryFunctions) {
+        goto closelib;
+    }
+
+    retval = true;
+    goto funcret;
+    closelib:
+    dlclose(session_p->fmLibrary_p);
+    funcret:
+    return retval;
+}
+
+void
+androidFmRadioUnLoadFmLibrary(struct FmSession_t * session_p)
+{
+
+    if (session_p->fmLibrary_p != NULL) {
+        dlclose(session_p->fmLibrary_p);
+        free(session_p->vendorMethods_p);
+        session_p->vendorMethods_p = NULL;
+    }
+}
+
+/* methods common for both RX and TX */
+
+static bool androidFmRadioStartSyncPartner(struct FmSession_t *session_p)
+{
+    /* lock is held when entering this mehod */
+    int maxTime = 5000;    /* in ms */
+
+    /* if partner has ongoing reset await it finishing */
+    while (session_p->partnerSession_p->ongoingReset && maxTime > 0) {
+        pthread_mutex_unlock(session_p->dataMutex_p);
+        usleep(250000);
+        pthread_mutex_lock(session_p->dataMutex_p);
+        maxTime -= 250;
+    }
+
+    if (session_p->partnerSession_p->ongoingReset) {
+        ALOGE("partner session stale reset");
+        return false;
+    }
+
+    /* if partner has any other state than IDLE it should be stoped */
+    if (session_p->partnerSession_p->state != FMRADIO_STATE_IDLE) {
+        /* if partner is starting it must be allowed to finish */
+
+        session_p->partnerSession_p->ongoingReset = true; /* to make sure it doesn't do anything else */
+
+        while (!session_p->ongoingReset &&
+               (session_p->partnerSession_p->state == FMRADIO_STATE_STARTING && maxTime > 0)){
+            pthread_mutex_unlock(session_p->dataMutex_p);
+            usleep(250000);
+            pthread_mutex_lock(session_p->dataMutex_p);
+            maxTime -= 250;
+        }
+
+        session_p->partnerSession_p->ongoingReset = false;
+
+        /* if we now have a ongoing reset on our own session just exit */
+
+        if (session_p->ongoingReset) {
+            return false;
+        }
+
+        /* if partner is still starting we should exist */
+        if (session_p->partnerSession_p->state == FMRADIO_STATE_STARTING) {
+            ALOGE("time-out waiting for partner startup");
+            return false;
+        }
+
+        /* unless partner already is IDLE, reset and send forced reset */
+        if (session_p->partnerSession_p->state != FMRADIO_STATE_IDLE) {
+            /* temporary drop lock to allow reset triggered callbacks */
+            pthread_mutex_unlock(session_p->dataMutex_p);
+            session_p->partnerSession_p->vendorMethods_p->reset(&session_p->partnerSession_p->vendorData_p);
+            pthread_mutex_lock(session_p->dataMutex_p);
+            FMRADIO_SET_STATE(session_p->partnerSession_p, FMRADIO_STATE_IDLE);
+            session_p->partnerSession_p->callbacks_p->onForcedReset(FMRADIO_RESET_OTHER_IN_USE);
+        }
+        /* unload partner vendor driver */
+        if (session_p->partnerSession_p->isRegistered) {
+            androidFmRadioUnLoadFmLibrary(session_p->partnerSession_p);
+            session_p->partnerSession_p->isRegistered = false;
+        }
+    }
+
+    return true;
+}
+
+static void *execute_androidFmRadioStartAsync(void *args)
+{
+    struct FmRadioStartAsyncParameters *inArgs_p = (struct FmRadioStartAsyncParameters *)args;
+
+    int (*startFunc) (void **, const struct fmradio_vendor_callbacks_t *, int, int, int,
+                      int) = inArgs_p->startFunc;
+    struct FmSession_t *session_p = inArgs_p->session_p;
+
+    const struct fmradio_vendor_callbacks_t *callbacks_p = inArgs_p->callbacks_p;
+
+    int lowFreq = inArgs_p->lowFreq;
+    int highFreq = inArgs_p->highFreq;
+    int defaultFreq = inArgs_p->defaultFreq;
+    int grid = inArgs_p->grid;
+    int retval = 0;
+
+    free(inArgs_p);
+
+    pthread_mutex_lock(session_p->dataMutex_p);
+
+    /*
+     * if other session is starting should wait for them to finish unless we
+     * get a ongoing reset
+     */
+
+    if (!androidFmRadioStartSyncPartner(session_p)) {
+        retval = -1;
+        goto fix_state_and_send_retval;
+    }
+
+    pthread_mutex_unlock(session_p->dataMutex_p);
+
+    retval =
+            startFunc(&session_p->vendorData_p, callbacks_p, lowFreq, highFreq,
+                      defaultFreq, grid);
+
+    pthread_mutex_lock(session_p->dataMutex_p);
+    /* sanity check, not even reset should alter the state when starting */
+    if (session_p->state != FMRADIO_STATE_STARTING) {
+        ALOGE("state not starting when going to started...");
+        retval = -1;
+    }
+
+    fix_state_and_send_retval:
+    if (retval >= 0) {
+        FMRADIO_SET_STATE(session_p, FMRADIO_STATE_STARTED);
+    } else {
+        FMRADIO_SET_STATE(session_p, FMRADIO_STATE_IDLE);
+        /* unload vendor driver */
+        androidFmRadioUnLoadFmLibrary(session_p);
+        session_p->isRegistered = false;
+    }
+
+    /*
+     * these need to be called after state is updated and after the lock
+     * has been dropped
+     */
+    if (retval >= 0) {
+        session_p->callbacks_p->onStarted();
+    } else {
+        session_p->callbacks_p->onError();
+    }
+
+    pthread_mutex_unlock(session_p->dataMutex_p);
+
+    pthread_exit(NULL);
+    return NULL;
+}
+
+int
+androidFmRadioStart(struct FmSession_t *session_p, enum RadioMode_t mode,
+                    const struct fmradio_vendor_callbacks_t *callbacks_p,
+                    bool async, int lowFreq, int highFreq, int defaultFreq,
+                    int grid)
+{
+    int retval = 0;
+
+    int (*startFunc) (void **, const struct fmradio_vendor_callbacks_t *,
+                      int, int, int, int) = NULL;
+
+    pthread_mutex_lock(session_p->dataMutex_p);
+    if (!androidFmRadioIsValidEventForState
+            (session_p, FMRADIO_EVENT_START)) {
+        retval = FMRADIO_INVALID_STATE;
+        goto drop_lock;
+    }
+    // set our state to STARTING here to make sure the partner session
+    // can't start again after it is finished
+    FMRADIO_SET_STATE(session_p, FMRADIO_STATE_STARTING);
+
+    // if we haven't registred the library yet do it
+
+    if (!session_p->isRegistered) {
+        session_p->vendorMethods_p = (fmradio_vendor_methods_t *)
+                malloc(sizeof(*session_p->vendorMethods_p));
+        if (session_p->vendorMethods_p == NULL) {
+            ALOGE("malloc failed");
+            retval = FMRADIO_IO_ERROR;
+            goto early_exit;
+        } else if (androidFmRadioLoadFmLibrary(session_p, mode)) {
+            session_p->isRegistered = true;
+        } else {
+            ALOGE("vendor registration failed");
+            free(session_p->vendorMethods_p);
+            retval = FMRADIO_IO_ERROR;
+            goto early_exit;
+        }
+    }
+
+    if (mode == FMRADIO_RX) {
+        startFunc = session_p->vendorMethods_p->rx_start;
+    } else if (mode == FMRADIO_TX) {
+        startFunc = session_p->vendorMethods_p->tx_start;
+    }
+
+    if (!startFunc) {
+        ALOGE("androidFmRadioStart - ERROR - No valid start function found.");
+        retval = FMRADIO_UNSUPPORTED_OPERATION;
+        goto early_exit;
+    }
+
+    if (async) {
+        pthread_t execute_thread;
+
+        struct FmRadioStartAsyncParameters *args_p = (struct FmRadioStartAsyncParameters *)
+                malloc(sizeof(struct FmRadioStartAsyncParameters));    /* freed in created thread */
+
+        if (args_p == NULL) {
+            ALOGE("malloc failed");
+            retval = FMRADIO_IO_ERROR;
+            goto early_exit;
+        }
+
+        args_p->startFunc = startFunc;
+        args_p->session_p = session_p;
+        args_p->callbacks_p = callbacks_p;
+        args_p->lowFreq = lowFreq;
+        args_p->highFreq = highFreq;
+        args_p->defaultFreq = defaultFreq;
+        args_p->grid = grid;
+
+        // we need to create a new thread actually executing the command
+        if (pthread_create
+                    (&execute_thread, NULL, execute_androidFmRadioStartAsync,
+                     (void *) args_p) != 0) {
+            ALOGE("pthread_create failure...");
+            free(args_p);
+            retval = FMRADIO_IO_ERROR;
+        } else {
+            pthread_detach(execute_thread);
+        }
+    } else {
+        if (!androidFmRadioStartSyncPartner(session_p)) {
+            retval = -1;
+            goto early_exit;
+        }
+
+        /*
+         * drop lock during long time call but set state to make sure no other
+         * process tries to start while we are starting. Do not use
+         * FMRADIO_SET_STATE macro since it will trigger a onStateChanged
+         * callback
+         */
+        pthread_mutex_unlock(session_p->dataMutex_p);
+        retval =
+                startFunc(&session_p->vendorData_p, callbacks_p, lowFreq,
+                          highFreq, defaultFreq, grid);
+        /* regain lock */
+        pthread_mutex_lock(session_p->dataMutex_p);
+        /* check that nothing has happened before we regained the lock */
+        if (session_p->state != FMRADIO_STATE_STARTING) {
+            ALOGE("Error, radio not in IDLE when about to set started mode");
+        }
+    }
+
+    // if successful syncronous start update state
+    if (retval == 0 && !async) {
+        FMRADIO_SET_STATE(session_p, FMRADIO_STATE_STARTED);
+    }
+
+    early_exit:
+
+    if (retval < 0) {
+        if (session_p->state != FMRADIO_STATE_IDLE) {
+            FMRADIO_SET_STATE(session_p, FMRADIO_STATE_IDLE);
+        }
+
+        if (retval != FMRADIO_INVALID_STATE && session_p->isRegistered) {
+            androidFmRadioUnLoadFmLibrary(session_p);
+            session_p->isRegistered = false;
+        }
+    }
+
+    drop_lock:
+
+    if (retval == FMRADIO_INVALID_STATE) {
+        THROW_INVALID_STATE(session_p);
+    } else if ((retval == FMRADIO_INVALID_PARAMETER) ||
+               (retval == FMRADIO_UNSUPPORTED_OPERATION)) {
+        THROW_UNSUPPORTED_OPERATION(session_p);
+    } else if (retval < 0) {
+        THROW_IO_ERROR(session_p);
+    }
+
+    pthread_mutex_unlock(session_p->dataMutex_p);
+
+    return retval;
+}
+
+int androidFmRadioPause(struct FmSession_t *session_p)
+{
+    int retval;
+
+    pthread_mutex_lock(session_p->dataMutex_p);
+    if (!androidFmRadioIsValidEventForState
+            (session_p, FMRADIO_EVENT_PAUSE)) {
+        retval = FMRADIO_INVALID_STATE;
+        goto drop_lock;
+    }
+
+    if (session_p->state == FMRADIO_STATE_PAUSED) {
+        // already paused, just return
+        retval = FMRADIO_OK;
+        goto drop_lock;
+    }
+
+
+    retval =  session_p->vendorMethods_p->pause(&session_p->vendorData_p);
+
+    if (retval == 0) {
+        FMRADIO_SET_STATE(session_p, FMRADIO_STATE_PAUSED);
+    }
+
+    drop_lock:
+    if (retval == FMRADIO_INVALID_STATE) {
+        THROW_INVALID_STATE(session_p);
+    } else if (retval < 0) {
+        THROW_IO_ERROR(session_p);
+    }
+
+    pthread_mutex_unlock(session_p->dataMutex_p);
+
+    return retval;
+}
+
+int androidFmRadioResume(struct FmSession_t *session_p)
+{
+    int retval = 0;
+
+    pthread_mutex_lock(session_p->dataMutex_p);
+
+    if (!androidFmRadioIsValidEventForState
+            (session_p, FMRADIO_EVENT_RESUME)) {
+        retval = FMRADIO_INVALID_STATE;
+        goto drop_lock;
+    }
+
+    if (session_p->state == FMRADIO_STATE_STARTED) {
+        //already started, just return
+        retval = FMRADIO_OK;
+        goto drop_lock;
+    }
+
+    retval = session_p->vendorMethods_p->resume(&session_p->vendorData_p);
+
+    // if successful update state
+    if (retval == 0) {
+        FMRADIO_SET_STATE(session_p, FMRADIO_STATE_STARTED);
+    }
+    // nothing on failure
+
+    drop_lock:
+    if (retval == FMRADIO_INVALID_STATE) {
+        THROW_INVALID_STATE(session_p);
+    } else if (retval < 0) {
+        THROW_IO_ERROR(session_p);
+    }
+
+    pthread_mutex_unlock(session_p->dataMutex_p);
+    return retval;
+}
+
+int androidFmRadioReset(struct FmSession_t *session_p)
+{
+    int retval = FMRADIO_OK;
+    int oldState = session_p->state;
+
+    pthread_mutex_lock(session_p->dataMutex_p);
+
+    if (!androidFmRadioIsValidEventForState
+            (session_p, FMRADIO_EVENT_RESET)) {
+        retval = FMRADIO_INVALID_STATE;
+        goto drop_lock;
+    }
+
+    /* Worker threads must be cleaned up before sending reset */
+    if(session_p->state == FMRADIO_STATE_SCANNING){
+        pthread_mutex_unlock(session_p->dataMutex_p);
+        androidFmRadioStopScan(session_p);
+        pthread_mutex_lock(session_p->dataMutex_p);
+        /* Waiting for worker thread to exit gracefully */
+        pthread_cond_wait(&session_p->sync_cond,
+                          session_p->dataMutex_p);
+    }
+    /* idle or about to be reset, just return state */
+    if (session_p->ongoingReset || oldState == FMRADIO_STATE_IDLE) {
+        retval = oldState;
+        goto drop_lock;
+    }
+    session_p->ongoingReset = true;
+
+    /* if we are in starting state we must await the start finishing */
+    if (oldState == FMRADIO_STATE_STARTING) {
+        /* we need to await end of start before starting */
+        int maxTime = 5000;    /* in ms */
+        do {
+            pthread_mutex_unlock(session_p->dataMutex_p);
+            usleep(250000);
+            pthread_mutex_lock(session_p->dataMutex_p);
+            maxTime -= 250;
+        } while (maxTime > 0 && (session_p->state == FMRADIO_STATE_STARTING));
+    }
+
+    /* if we still are in STARTING state we must fail now */
+    if (session_p->state == FMRADIO_STATE_STARTING) {
+        retval = FMRADIO_IO_ERROR;
+        goto drop_ongoing_reset;
+    }
+
+    /*
+     * we need to temporary release lock since reset might trigger
+     * callbacks. Set flag to not allow any state changing command
+     */
+    FMRADIO_SET_STATE(session_p, FMRADIO_STATE_IDLE);
+
+    pthread_mutex_unlock(session_p->dataMutex_p);
+    retval = session_p->vendorMethods_p->
+            reset(&session_p->vendorData_p);
+    pthread_mutex_lock(session_p->dataMutex_p);
+
+    // if successful unload vendor driver
+    if (retval >= 0) {
+        retval = oldState;
+        if (session_p->isRegistered) {
+            androidFmRadioUnLoadFmLibrary(session_p);
+            session_p->isRegistered = false;
+        }
+    } else {
+        ALOGE("androidFmRadioReset failed");
+    }
+    // nothing on failure
+    drop_ongoing_reset:
+    session_p->ongoingReset = false;
+    drop_lock:
+    if (retval == FMRADIO_INVALID_STATE) {
+        THROW_INVALID_STATE(session_p);
+    } else if (retval < 0) {
+        THROW_IO_ERROR(session_p);
+    }
+
+    pthread_mutex_unlock(session_p->dataMutex_p);
+
+    return retval;
+}
+
+void
+androidFmRadioSetFrequency(struct FmSession_t *session_p, int frequency)
+{
+    int retval = 0;
+
+    pthread_mutex_lock(session_p->dataMutex_p);
+    if (!androidFmRadioIsValidEventForState
+            (session_p, FMRADIO_EVENT_SET_FREQUENCY)) {
+        retval = FMRADIO_INVALID_STATE;
+        goto drop_lock;
+    }
+
+    if (session_p->vendorMethods_p->set_frequency) {
+        /* if in pause state temporary resume */
+        androidFmRadioTempResumeIfPaused(session_p);
+
+        retval =
+                session_p->vendorMethods_p->set_frequency(&session_p->
+                                                                  vendorData_p,
+                                                          frequency);
+
+        androidFmRadioPauseIfTempResumed(session_p);
+    } else {
+        retval = FMRADIO_UNSUPPORTED_OPERATION;
+    }
+
+    // no state is ever updated
+    if (retval < 0) {
+        ALOGE("androidFmRadioSetFrequency failed\n");
+    }
+
+    drop_lock:
+    if (retval == FMRADIO_INVALID_STATE) {
+        THROW_INVALID_STATE(session_p);
+    } else if (retval == FMRADIO_INVALID_PARAMETER) {
+        THROW_ILLEGAL_ARGUMENT(session_p);
+    } else if (retval < 0) {
+        THROW_IO_ERROR(session_p);
+    }
+
+    pthread_mutex_unlock(session_p->dataMutex_p);
+}
+
+int androidFmRadioGetFrequency(struct FmSession_t *session_p)
+{
+    int retval = 0;
+
+    pthread_mutex_lock(session_p->dataMutex_p);
+
+    if (!androidFmRadioIsValidEventForState
+            (session_p, FMRADIO_EVENT_GET_FREQUENCY)) {
+        retval = FMRADIO_INVALID_STATE;
+        goto drop_lock;
+    }
+
+    if (session_p->vendorMethods_p->get_frequency) {
+        /* if in pause state temporary resume */
+        androidFmRadioTempResumeIfPaused(session_p);
+
+        retval =
+                session_p->vendorMethods_p->get_frequency(&session_p->
+                        vendorData_p);
+
+        androidFmRadioPauseIfTempResumed(session_p);
+    } else {
+        retval = FMRADIO_UNSUPPORTED_OPERATION;
+    }
+
+    drop_lock:
+    if (retval == FMRADIO_INVALID_STATE) {
+        THROW_INVALID_STATE(session_p);
+    } else if (retval < 0) {
+        THROW_IO_ERROR(session_p);
+    }
+
+    pthread_mutex_unlock(session_p->dataMutex_p);
+
+    return retval;
+}
+
+void androidFmRadioStopScan(struct FmSession_t *session_p)
+{
+    int retval = 0;
+
+    pthread_mutex_lock(session_p->dataMutex_p);
+
+    if (!androidFmRadioIsValidEventForState
+            (session_p, FMRADIO_EVENT_STOP_SCAN)) {
+        goto drop_lock;
+    }
+
+    if (session_p->state != FMRADIO_STATE_SCANNING) {
+        /* if we're not in scanning, don't attempt anything just return */
+        goto drop_lock;
+    }
+
+    if (session_p->vendorMethods_p->stop_scan) {
+        retval =
+                session_p->vendorMethods_p->stop_scan(&session_p->vendorData_p);
+    } else {
+        retval = FMRADIO_UNSUPPORTED_OPERATION;
+    }
+
+    if (retval == 0) {
+        session_p->lastScanAborted = true;
+    }
+
+    retval = FMRADIO_OK;
+    drop_lock:
+    /* note - no exceptions. Just return */
+
+    if (retval != FMRADIO_OK) {
+        ALOGE("androidFmRadioStopScan failed (%d), ignored.\n", retval);
+    }
+    pthread_mutex_unlock(session_p->dataMutex_p);
+}
+
+static void *execute_androidFmRadioSendExtraCommand(void *args_p)
+{
+    struct FmRadioSendExtraCommandParameters* inArgs_p = (struct FmRadioSendExtraCommandParameters*)args_p;
+    struct FmSession_t *session_p = inArgs_p->session_p;
+    char *c_command = inArgs_p->c_command;
+    char **parameter = inArgs_p->cparams;
+    struct fmradio_extra_command_ret_item_t *returnParam = NULL;
+    int retval;
+
+    free(inArgs_p);
+
+    pthread_mutex_lock(session_p->dataMutex_p);
+
+    // we should be in state EXTRA_COMMAND
+    if (session_p->state != FMRADIO_STATE_EXTRA_COMMAND) {
+        ALOGE("execute_androidFmRadioSendExtraCommand - warning, state not extra commands\n");
+    }
+
+    if (session_p->vendorMethods_p->send_extra_command != NULL) {
+        pthread_mutex_unlock(session_p->dataMutex_p);
+        retval =
+                session_p->vendorMethods_p->send_extra_command(&session_p->
+                                                                       vendorData_p,
+                                                               c_command,
+                                                               parameter,
+                                                               &returnParam);
+        pthread_mutex_lock(session_p->dataMutex_p);
+        freeCstringArray(parameter);
+    } else {
+        retval = FMRADIO_UNSUPPORTED_OPERATION;
+    }
+
+    if (session_p->state != FMRADIO_STATE_EXTRA_COMMAND) {
+        ALOGE("State changed while executing extra commands (state now %d), keeping\n", session_p->state);
+    } else {
+        if (session_p->pendingPause) {
+            session_p->vendorMethods_p->pause(&session_p->
+                    vendorData_p);
+            FMRADIO_SET_STATE(session_p, FMRADIO_STATE_PAUSED);
+        } else {
+            FMRADIO_SET_STATE(session_p, session_p->oldState);
+        }
+    }
+
+    session_p->pendingPause = false;
+
+    if (retval >= 0) {
+        session_p->callbacks_p->onSendExtraCommand(c_command, returnParam);
+    } else {
+        session_p->callbacks_p->onError();
+    }
+
+    if (returnParam != NULL) {
+        freeExtraCommandRetList(returnParam);
+    }
+
+    if (c_command != NULL) {
+        free(c_command);
+    }
+
+    pthread_mutex_unlock(session_p->dataMutex_p);
+    pthread_exit(NULL);
+    return NULL;
+}
+
+void
+androidFmRadioSendExtraCommand(struct FmSession_t *session_p,
+                               JNIEnv * env_p, jstring jcommand,
+                               jobjectArray parameter)
+{
+    int retval = FMRADIO_OK;
+    char **cparams;
+    struct FmRadioSendExtraCommandParameters *args_p = NULL;
+    pthread_t execute_thread;
+
+    pthread_mutex_lock(session_p->dataMutex_p);
+
+    if (!androidFmRadioIsValidEventForState
+            (session_p, FMRADIO_EVENT_EXTRA_COMMAND)) {
+        retval = FMRADIO_INVALID_STATE;
+        goto drop_lock;
+    }
+
+    if (!jstringArray2cstringArray(env_p, parameter, &cparams)) {
+        retval = FMRADIO_IO_ERROR;
+        goto drop_lock;
+    }
+
+    session_p->oldState = session_p->state;
+
+    args_p = (struct FmRadioSendExtraCommandParameters *) malloc(sizeof(struct FmRadioSendExtraCommandParameters));     /* freed in created thread */
+    if (args_p == NULL) {
+        ALOGE("malloc failed\n");
+        retval = FMRADIO_IO_ERROR;
+    }
+
+    if (retval == FMRADIO_OK) {
+        const char* c_command = env_p->GetStringUTFChars(jcommand, 0);
+
+        args_p->session_p = session_p;
+        args_p->c_command = strdup(c_command);
+        args_p->cparams = cparams;
+
+        env_p->ReleaseStringUTFChars(jcommand, c_command);
+
+        // we need to create a new thread actually executing the command
+        if (pthread_create
+                    (&execute_thread, NULL, execute_androidFmRadioSendExtraCommand,
+                     args_p) != 0) {
+            ALOGE("pthread_create failed\n");
+            free(args_p->c_command);
+            free(args_p);
+            retval = FMRADIO_IO_ERROR;
+        } else {
+            pthread_detach(execute_thread);
+        }
+
+    }
+
+    if (retval == FMRADIO_OK) {
+        FMRADIO_SET_STATE(session_p, FMRADIO_STATE_EXTRA_COMMAND);
+    }
+
+    drop_lock:
+
+    if (retval == FMRADIO_INVALID_STATE) {
+        THROW_INVALID_STATE(session_p);
+    } else if (retval < 0) {
+        THROW_IO_ERROR(session_p);
+    }
+
+    pthread_mutex_unlock(session_p->dataMutex_p);
+}
+
+
+namespace android {
+int registerAndroidFmRadioReceiver(JavaVM* vm, JNIEnv *env);
+//int registerAndroidFmRadioTransmitter(JavaVM* vm, JNIEnv *env);
+};
+
+using namespace android;
+
+extern "C" jint JNI_OnLoad(JavaVM* vm, void* reserved)
+{
+    JNIEnv* env = NULL;
+    jint result = -1;
+
+    if (vm->GetEnv((void**) &env, JNI_VERSION_1_4) != JNI_OK) {
+        ALOGE("GetEnv failed!");
+        return result;
+    }
+    //ALOGE("Could not retrieve the env!");
+
+    registerAndroidFmRadioReceiver(vm, env);
+    //registerAndroidFmRadioTransmitter(vm, env);
+
+    return JNI_VERSION_1_4;
+}
+

--- a/brcm_fmradio/libfmjni/android_fm.h
+++ b/brcm_fmradio/libfmjni/android_fm.h
@@ -1,0 +1,140 @@
+#ifndef BROADCOMFMAPP_FM_JNI_H
+#define BROADCOMFMAPP_FM_JNI_H
+
+#define FMRADIO_REGISTER_FUNC "register_fmradio_functions"
+
+#define FMRADIO_SIGNATURE 0xDEADBABE
+
+#define FMRADIO_CAPABILITY_RECEIVER 0x0001
+#define FMRADIO_CAPABILITY_TRANSMITTER 0x0002
+#define FMRADIO_CAPABILITY_TUNER_WRAP_AROUND 0x0004
+#define FMRADIO_CAPABILITY_RDS_SUPPORTED 0x0008
+
+/*
+ * return values. Not defined as enum since some functions either
+ * return a positive value or these codes, like getFrequency.
+ */
+#define  FMRADIO_OK 0
+#define  FMRADIO_INVALID_STATE -1       /* internally in jni layer */
+#define  FMRADIO_UNSUPPORTED_OPERATION -2
+#define  FMRADIO_IO_ERROR -3
+#define  FMRADIO_INVALID_PARAMETER -4
+#define  FMRADIO_FORCED_RESET -5
+
+/* RDS */
+#define RDS_MAX_AFS 25
+#define RDS_PSN_MAX_LENGTH 8
+#define RDS_RT_MAX_LENGTH 64
+#define RDS_CT_MAX_LENGTH 14
+#define RDS_PTYN_MAX_LENGTH 8
+#define RDS_NUMBER_OF_TMC 3
+
+enum fmradio_band_t {
+    FMRADIO_BAND_US,
+    FMRADIO_BAND_EU,
+    FMRADIO_BAND_JAPAN,
+    FMRADIO_BAND_CHINA
+};
+
+enum fmradio_seek_direction_t {
+    FMRADIO_SEEK_DOWN,
+    FMRADIO_SEEK_UP
+};
+
+enum fmradio_reset_reason_t {
+    FMRADIO_RESET_NON_CRITICAL = 0,
+    FMRADIO_RESET_CRITICAL,
+    FMRADIO_RESET_OTHER_IN_USE,    /* internally in jni layer */
+            FMRADIO_RESET_RADIO_FORBIDDEN, /* internally in java layer */
+};
+
+enum fmradio_extra_command_type_t {
+    FMRADIO_TYPE_INT,
+    FMRADIO_TYPE_STRING
+};
+
+enum fmradio_switch_reason_t {
+    FMRADIO_SWITCH_AF,
+    FMRADIO_SWITCH_TA,
+    FMRADIO_SWITCH_TA_END
+};
+
+union fmradio_extra_data_t {
+    int int_value;
+    char *string_value;
+};
+
+struct fmradio_rds_bundle_t {
+    unsigned short pi;
+    short tp;
+    short pty;
+    short ta;
+    short ms;
+    short num_afs;
+    int af[RDS_MAX_AFS];
+    char psn[RDS_PSN_MAX_LENGTH + 1];
+    char rt[RDS_RT_MAX_LENGTH + 1];
+    char ct[RDS_CT_MAX_LENGTH + 1];
+    char ptyn[RDS_PTYN_MAX_LENGTH + 1];
+    short tmc[RDS_NUMBER_OF_TMC];
+    int taf;
+};
+
+struct fmradio_extra_command_ret_item_t {
+    char *key;
+    enum fmradio_extra_command_type_t type;
+    union fmradio_extra_data_t data;
+};
+
+/* vendor callbacks only for RX */
+struct fmradio_vendor_callbacks_t {
+    void (*on_playing_in_stereo_changed) (int is_stereo);
+    void (*on_rds_data_found) (struct fmradio_rds_bundle_t * rds_bundle,
+                               int frequency);
+    void (*on_signal_strength_changed) (int new_level);
+    void (*on_automatic_switch) (int new_freq,
+                                 enum fmradio_switch_reason_t reason);
+    void (*on_forced_reset) (enum fmradio_reset_reason_t reason);
+};
+
+struct fmradio_vendor_methods_t {
+    int (*rx_start) (void ** session_data,
+                     const struct fmradio_vendor_callbacks_t * callbacks,
+                     int low_freq, int high_freq, int default_freq, int grid);
+    int (*tx_start) (void ** session_data,
+                     const struct fmradio_vendor_callbacks_t * callbacks,
+                     int low_freq, int high_freq, int default_freq, int grid);
+    int (*pause) (void ** session_data);
+    int (*resume) (void ** session_data);
+    int (*reset) (void ** session_data);
+    int (*set_frequency) (void ** session_data, int frequency);
+    int (*get_frequency) (void ** session_data);
+    int (*stop_scan) (void ** session_data);
+    int (*send_extra_command) (void ** session_data, const char * command,
+                               char ** parameters,
+                               struct fmradio_extra_command_ret_item_t ** out_parameters);
+    /* rx only */
+    int (*scan) (void ** session_data, enum fmradio_seek_direction_t direction);
+
+    int (*full_scan) (void ** session_data, int ** found_freqs,
+                      int ** signal_strenghts);
+    int (*get_signal_strength) (void ** session_data);
+    int (*is_playing_in_stereo) (void ** session_data);
+    int (*is_rds_data_supported) (void ** session_data);
+    int (*is_tuned_to_valid_channel) (void ** session_data);
+    int (*set_automatic_af_switching) (void ** session_data, int automatic);
+    int (*set_automatic_ta_switching) (void ** session_data, int automatic);
+    int (*set_force_mono) (void ** session_data, int force_mono);
+    int (*get_threshold) (void ** session_data);
+    int (*set_threshold) (void ** session_data, int threshold);
+    int (*set_rds_reception) (void ** session_data, int use_rds);
+    /* tx only */
+    int (*block_scan) (void ** session_data, int low_freq, int high_freq,
+                       int ** found_freqs, int ** signal_strenghts);
+    int (*set_rds_data) (void ** session_data, char * key, void * value);
+};
+
+typedef int (*fmradio_reg_func_t) (unsigned int * signature_p,
+                                   struct fmradio_vendor_methods_t * vendor_funcs_p);
+
+#endif //BROADCOMFMAPP_FM_JNI_H

--- a/brcm_fmradio/libfmjni/android_fm.h
+++ b/brcm_fmradio/libfmjni/android_fm.h
@@ -86,23 +86,10 @@ struct fmradio_extra_command_ret_item_t {
     union fmradio_extra_data_t data;
 };
 
-/* vendor callbacks only for RX */
-struct fmradio_vendor_callbacks_t {
-    void (*on_playing_in_stereo_changed) (int is_stereo);
-    void (*on_rds_data_found) (struct fmradio_rds_bundle_t * rds_bundle,
-                               int frequency);
-    void (*on_signal_strength_changed) (int new_level);
-    void (*on_automatic_switch) (int new_freq,
-                                 enum fmradio_switch_reason_t reason);
-    void (*on_forced_reset) (enum fmradio_reset_reason_t reason);
-};
-
 struct fmradio_vendor_methods_t {
     int (*rx_start) (void ** session_data,
-                     const struct fmradio_vendor_callbacks_t * callbacks,
                      int low_freq, int high_freq, int default_freq, int grid);
     int (*tx_start) (void ** session_data,
-                     const struct fmradio_vendor_callbacks_t * callbacks,
                      int low_freq, int high_freq, int default_freq, int grid);
     int (*pause) (void ** session_data);
     int (*resume) (void ** session_data);
@@ -122,8 +109,6 @@ struct fmradio_vendor_methods_t {
     int (*is_playing_in_stereo) (void ** session_data);
     int (*is_rds_data_supported) (void ** session_data);
     int (*is_tuned_to_valid_channel) (void ** session_data);
-    int (*set_automatic_af_switching) (void ** session_data, int automatic);
-    int (*set_automatic_ta_switching) (void ** session_data, int automatic);
     int (*set_force_mono) (void ** session_data, int force_mono);
     int (*get_threshold) (void ** session_data);
     int (*set_threshold) (void ** session_data, int threshold);
@@ -132,6 +117,8 @@ struct fmradio_vendor_methods_t {
     int (*block_scan) (void ** session_data, int low_freq, int high_freq,
                        int ** found_freqs, int ** signal_strenghts);
     int (*set_rds_data) (void ** session_data, char * key, void * value);
+    int (*mute)(void** session_data, int mute);
+    int (*get_rds)(void** session_data, struct fmradio_rds_bundle_t * fmradio_rds_bundle);
 };
 
 typedef int (*fmradio_reg_func_t) (unsigned int * signature_p,

--- a/brcm_fmradio/libfmjni/android_fmradio_Receiver.cpp
+++ b/brcm_fmradio/libfmjni/android_fmradio_Receiver.cpp
@@ -1,0 +1,1498 @@
+/*
+ * Copyright (C) ST-Ericsson SA 2010
+ * Copyright 2010, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors: johan.xj.palmaeus@stericsson.com
+ *          stuart.macdonald@stericsson.com
+ *          for ST-Ericsson
+ */
+
+/*
+ * Native part of the generic RX FmRadio inteface
+ */
+
+#define ALOG_TAG "FmReceiverServiceNative"
+
+// #define LOG_NDEBUG 1
+
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <termios.h>
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+#include <stdarg.h>
+#include <signal.h>
+#include <pthread.h>
+#include <math.h>
+
+
+#include "jni.h"
+#include "JNIHelp.h"
+#include "android_fmradio_Receiver.h"
+#include <utils/Log.h>
+
+
+/* *INDENT-OFF* */
+namespace android {
+
+
+// state machine
+
+static const ValidEventsForStates_t IsValidRxEventForState = {
+  /* this table defines valid transitions. (turn off indent, we want this easy readable) */
+             /* FMRADIO_STATE_ IDLE,STARTING,STARTED,PAUSED,SCANNING,EXTRA_COMMAND */
+
+   /* FMRADIO_EVENT_START */         {true ,false,false,false,false,false},
+   /* FMRADIO_EVENT_START_ASYNC */   {true ,false,false,false,false,false},
+   /* FMRADIO_EVENT_PAUSE */         {false,false,true, true, false,false},
+   /* FMRADIO_EVENT_RESUME */        {false,false,true, true, false,false},
+   /* FMRADIO_EVENT_RESET */         {true, true, true, true, true, true },
+   /* FMRADIO_EVENT_GET_FREQUENCY */ {false,false,true, true, false,false},
+   /* FMRADIO_EVENT_SET_FREQUENCY */ {false,false,true, true, false,false},
+   /* FMRADIO_EVENT_SET_PARAMETER */ {false,false,true, true, true, true },
+   /* FMRADIO_EVENT_STOP_SCAN */     {true, true, true, true, true, true },
+   /* FMRADIO_EVENT_EXTRA_COMMAND */ {true, true, true, true, true, true },
+   /* Rx Only */
+   /* FMRADIO_EVENT_GET_PARAMETER */ {false,false,true, true, true, true },
+   /* FMRADIO_EVENT_GET_SIGNAL_STRENGTH */{false,false,true,true,false,false},
+   /* FMRADIO_EVENT_SCAN */          {false,false,true, true, false,false},
+   /* FMRADIO_EVENT_FULL_SCAN */     {false,false,true, true, false,false},
+   // Tx Only - never allowed
+   /* FMRADIO_EVENT_BLOCK_SCAN */    {false,false,false,false,false,false},
+};
+/*  *INDENT-ON*  */
+
+/* Callbacks to java layer */
+
+static void androidFmRadioRxCallbackOnStateChanged(int oldState,
+                                                   int newState);
+static void androidFmRadioRxCallbackOnError(void);
+
+static void androidFmRadioRxCallbackOnStarted(void);
+
+static void androidFmRadioRxCallbackOnScan(int foundFreq,
+                                           int signalStrength,
+                                           int scanDirection,
+                                           bool aborted);
+static void androidFmRadioRxCallbackOnFullScan(int noItems,
+                                               int *frequencies,
+                                               int *sigStrengths,
+                                               bool aborted);
+static void androidFmRadioRxCallbackOnForcedReset(enum fmradio_reset_reason_t reason);
+
+static void androidFmRadioRxCallbackOnVendorForcedReset(enum fmradio_reset_reason_t reason);
+
+static void androidFmRadioRxCallbackOnSignalStrengthChanged(int newLevel);
+
+static void androidFmRadioRxCallbackOnRDSDataFound(struct
+                                                   fmradio_rds_bundle_t
+                                                   *t, int frequency);
+
+static void androidFmRadioRxCallbackOnPlayingInStereo(int
+                                                      isPlayingInStereo);
+
+static void androidFmRadioRxCallbackOnExtraCommand(char* command,
+                                                   struct
+                                                   fmradio_extra_command_ret_item_t
+                                                   *retItem);
+
+static void androidFmRadioRxCallbackOnAutomaticSwitch(int newFrequency, enum fmradio_switch_reason_t reason);
+
+static const FmRadioCallbacks_t FmRadioRxCallbacks = {
+    androidFmRadioRxCallbackOnStateChanged,
+    androidFmRadioRxCallbackOnError,
+    androidFmRadioRxCallbackOnStarted,
+    androidFmRadioRxCallbackOnScan,
+    androidFmRadioRxCallbackOnFullScan,
+    NULL,
+    androidFmRadioRxCallbackOnForcedReset,
+    androidFmRadioRxCallbackOnExtraCommand,
+};
+
+/* callbacks from vendor layer */
+
+static const fmradio_vendor_callbacks_t FmRadioRxVendorCallbacks = {
+    androidFmRadioRxCallbackOnPlayingInStereo,
+    androidFmRadioRxCallbackOnRDSDataFound,
+    androidFmRadioRxCallbackOnSignalStrengthChanged,
+    androidFmRadioRxCallbackOnAutomaticSwitch,
+    androidFmRadioRxCallbackOnVendorForcedReset
+};
+
+struct FmSession_t fmTransmitterSession;
+
+struct FmSession_t fmReceiverSession = {
+    NULL,
+    NULL,
+    false,
+    FMRADIO_STATE_IDLE,
+    NULL,
+    &IsValidRxEventForState,
+    &FmRadioRxCallbacks,
+    NULL,
+    NULL,
+    &fmTransmitterSession,
+    NULL,
+    FMRADIO_STATE_IDLE,
+    false,
+    false,
+    false,
+    &rx_tx_common_mutex,
+    PTHREAD_COND_INITIALIZER,
+    NULL,
+};
+
+// make sure we don't refer the TransmitterSession anymore from here
+#define fmTransmitterSession ERRORDONOTUSERECEIVERSESSIONINTRANSMITTER
+
+/*
+* Implementation of callbacks from within service layer. For these the
+*  mutex lock is always held on entry and need to be released before doing
+*  calls to java layer (env->Call*Method)  becasue these might trigger new
+*  calls from java and a deadlock would occure if lock was still held.
+*/
+
+static void androidFmRadioRxCallbackOnStateChanged(int oldState,
+                                                   int newState)
+{
+    jmethodID notifyOnStateChangedMethod;
+    JNIEnv *env;
+    jclass clazz;
+    bool reAttached = false;
+
+    ALOGI("androidFmRadioRxCallbackOnStateChanged: Old state %d, new state %d", oldState, newState);
+
+    /* since we might be both in main thread and subthread both test getenv
+     * and attach */
+    if (fmReceiverSession.jvm_p->GetEnv((void **) &env, JNI_VERSION_1_4) !=
+        JNI_OK) {
+        reAttached = true;
+        if (fmReceiverSession.jvm_p->AttachCurrentThread(&env, NULL) != JNI_OK) {
+            ALOGE("Error, can't attach current thread");
+            return;
+        }
+    }
+
+    clazz = env->GetObjectClass(fmReceiverSession.jobj);
+
+    notifyOnStateChangedMethod =
+        env->GetMethodID(clazz, "notifyOnStateChanged", "(II)V");
+    if (notifyOnStateChangedMethod != NULL) {
+        jobject jobj = fmReceiverSession.jobj;
+        pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+        env->CallVoidMethod(jobj,
+                            notifyOnStateChangedMethod, oldState,
+                            newState);
+        pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    } else {
+        ALOGE("ERROR - JNI can't find java notifyOnStateChanged method");
+    }
+
+    if (reAttached) {
+        fmReceiverSession.jvm_p->DetachCurrentThread();
+    }
+}
+
+static void androidFmRadioRxCallbackOnError(void)
+{
+    jmethodID notifyMethod;
+    JNIEnv *env;
+    jclass clazz;
+
+    ALOGI("androidFmRadioRxCallbackOnError");
+
+    if (fmReceiverSession.jvm_p->AttachCurrentThread(&env, NULL) != JNI_OK) {
+        ALOGE("Error, can't attch current thread");
+        return;
+    }
+
+    clazz = env->GetObjectClass(fmReceiverSession.jobj);
+    notifyMethod = env->GetMethodID(clazz, "notifyOnError", "()V");
+
+    if (notifyMethod != NULL) {
+        jobject jobj = fmReceiverSession.jobj;
+        pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+        env->CallVoidMethod(jobj, notifyMethod);
+        pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    } else {
+        ALOGE("ERROR - JNI can't find java notifyOnError method");
+    }
+
+    fmReceiverSession.jvm_p->DetachCurrentThread();
+}
+
+static void androidFmRadioRxCallbackOnStarted(void)
+{
+    jmethodID notifyMethod;
+    JNIEnv *env;
+    jclass clazz;
+
+    ALOGI("androidFmRadioRxCallbackOnStarted");
+
+    if (fmReceiverSession.jvm_p->AttachCurrentThread(&env, NULL) != JNI_OK) {
+        ALOGE("Error, can't attch current thread");
+        return;
+    }
+
+    clazz = env->GetObjectClass(fmReceiverSession.jobj);
+    notifyMethod = env->GetMethodID(clazz, "notifyOnStarted", "()V");
+
+    if (notifyMethod != NULL) {
+        jobject jobj = fmReceiverSession.jobj;
+        pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+        env->CallVoidMethod(jobj, notifyMethod);
+        pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    } else {
+        ALOGE("ERROR - JNI can't find java notifyOnStarted method");
+    }
+
+    fmReceiverSession.jvm_p->DetachCurrentThread();
+}
+
+
+static void androidFmRadioRxCallbackOnScan(int foundFreq,
+                                           int signalStrength,
+                                           int scanDirection,
+                                           bool aborted)
+{
+    jmethodID notifyMethod;
+    JNIEnv *env;
+    jclass clazz;
+
+    ALOGI("androidFmRadioRxCallbackOnScan: Callback foundFreq %d, signalStrength %d,"
+         " scanDirection %d, aborted %u", foundFreq, signalStrength, scanDirection,
+         aborted);
+
+    if (fmReceiverSession.jvm_p->AttachCurrentThread(&env, NULL) != JNI_OK) {
+        ALOGE("Error, can't attch current thread");
+        return;
+    }
+
+    clazz = env->GetObjectClass(fmReceiverSession.jobj);
+
+    notifyMethod = env->GetMethodID(clazz, "notifyOnScan", "(IIIZ)V");
+
+    if (notifyMethod != NULL) {
+        jobject jobj = fmReceiverSession.jobj;
+        pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+        env->CallVoidMethod(jobj, notifyMethod, foundFreq, signalStrength,
+                            scanDirection, aborted);
+        pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    } else {
+        ALOGE("ERROR - JNI can't find java notifyOnScan method");
+    }
+
+    fmReceiverSession.jvm_p->DetachCurrentThread();
+}
+
+static void androidFmRadioRxCallbackOnFullScan(int noItems,
+                                               int *frequencies,
+                                               int *sigStrengths,
+                                               bool aborted)
+{
+    jmethodID notifyMethod;
+    JNIEnv *env;
+    jclass clazz;
+    jintArray jFreqs;
+    jintArray jSigStrengths;
+
+    int d;
+
+    ALOGI("androidFmRadioRxCallbackOnFullScan: No items %d, aborted %d",
+         noItems, aborted);
+
+    for (d = 0; d < noItems; d++) {
+        ALOGI("%d -> %d", frequencies[d], sigStrengths[d]);
+    }
+
+    if (fmReceiverSession.jvm_p->AttachCurrentThread(&env, NULL) != JNI_OK) {
+        ALOGE("Error, can't attch current thread");
+        return;
+    }
+
+    jFreqs = env->NewIntArray(noItems);
+    jSigStrengths = env->NewIntArray(noItems);
+    clazz = env->GetObjectClass(fmReceiverSession.jobj);
+
+    env->SetIntArrayRegion(jFreqs, 0, noItems, frequencies);
+    env->SetIntArrayRegion(jSigStrengths, 0, noItems, sigStrengths);
+
+
+    notifyMethod = env->GetMethodID(clazz, "notifyOnFullScan", "([I[IZ)V");
+
+    if (notifyMethod != NULL) {
+        jobject jobj = fmReceiverSession.jobj;
+        pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+
+        env->CallVoidMethod(jobj, notifyMethod,
+                            jFreqs, jSigStrengths, aborted);
+        pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    } else {
+        ALOGE("ERROR - JNI can't find java notifyOnFullScan method");
+    }
+
+    fmReceiverSession.jvm_p->DetachCurrentThread();
+}
+
+static void androidFmRadioRxCallbackOnForcedReset(enum fmradio_reset_reason_t reason)
+{
+    jmethodID notifyMethod;
+    JNIEnv *env;
+    jclass clazz;
+    bool reAttached = false;
+
+    ALOGI("androidFmRadioRxCallbackOnForcedReset");
+
+    if (fmReceiverSession.jvm_p->GetEnv((void **) &env, JNI_VERSION_1_4) !=
+        JNI_OK) {
+        reAttached = true;
+        if (fmReceiverSession.jvm_p->AttachCurrentThread(&env, NULL) != JNI_OK) {
+            ALOGE("Error, can't attch current thread");
+            return;
+        }
+    }
+
+    clazz = env->GetObjectClass(fmReceiverSession.jobj);
+
+    notifyMethod = env->GetMethodID(clazz, "notifyOnForcedReset", "(I)V");
+    if (notifyMethod != NULL) {
+        jobject jobj = fmReceiverSession.jobj;
+        pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+        env->CallVoidMethod(jobj, notifyMethod,
+                            reason);
+        pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    }
+
+    if (reAttached) {
+        fmReceiverSession.jvm_p->DetachCurrentThread();
+    }
+}
+
+static void androidFmRadioRxCallbackOnVendorForcedReset(enum fmradio_reset_reason_t reason)
+{
+
+    ALOGI("androidFmRadioRxCallbackOnVendorForcedReset");
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    if (fmReceiverSession.state != FMRADIO_STATE_IDLE) {
+        FMRADIO_SET_STATE(&fmReceiverSession, FMRADIO_STATE_IDLE);
+        androidFmRadioUnLoadFmLibrary(&fmReceiverSession);
+        fmReceiverSession.isRegistered = false;
+    }
+    fmReceiverSession.callbacks_p->onForcedReset(reason);
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+}
+
+
+static void androidFmRadioRxCallbackOnExtraCommand(char* command,
+                                                   struct
+                                                   fmradio_extra_command_ret_item_t
+                                                   *retList)
+{
+    jmethodID notifyMethod;
+    JNIEnv *env;
+    jclass clazz;
+
+    struct bundle_descriptor_offsets_t *bundle_p =
+        fmReceiverSession.bundleOffsets_p;
+
+    ALOGI("androidFmRadioRxCallbackOnSendExtraCommand");
+
+    if (fmReceiverSession.jvm_p->AttachCurrentThread(&env, NULL) != JNI_OK) {
+        ALOGE("Error, can't attch current thread");
+        return;
+    }
+
+    clazz = env->GetObjectClass(fmReceiverSession.jobj);
+    jobject retBundle = extraCommandRetList2Bundle(env, bundle_p, retList);
+    jstring jcommand = env->NewStringUTF(command);
+
+    notifyMethod =
+        env->GetMethodID(clazz, "notifyOnExtraCommand",
+                         "(Ljava/lang/String;Landroid/os/Bundle;)V");
+    if (notifyMethod != NULL) {
+        jobject jobj = fmReceiverSession.jobj;
+        pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+
+        env->CallVoidMethod(jobj, notifyMethod, jcommand, retBundle);
+        pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    }
+
+    fmReceiverSession.jvm_p->DetachCurrentThread();
+}
+
+/*
+* Implementation of callbacks from vendor layer. For these the  mutex lock
+* is NOT held on entry and need to be taken and released before doing
+*  calls to java layer (env->Call*Method)  becasue these might trigger new
+*  calls from java and a deadlock would occure
+*/
+
+static void
+androidFmRadioRxCallbackOnRDSDataFound(struct fmradio_rds_bundle_t *t,
+                                       int frequency)
+{
+    jmethodID notifyMethod;
+    JNIEnv *env;
+    jclass clazz;
+    jobject bundle;
+    jshortArray jsArr;
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    struct bundle_descriptor_offsets_t *bundle_p =
+        fmReceiverSession.bundleOffsets_p;
+
+    if (fmReceiverSession.jvm_p->AttachCurrentThread(&env, NULL) != JNI_OK) {
+        ALOGE("Error, can't attch current thread");
+        goto drop_lock;
+    }
+    bundle = env->NewObject(bundle_p->mClass,
+                                    bundle_p->mConstructor);
+    /* note, these calls are to predefined methods, no need to release lock */
+    env->CallVoidMethod(bundle, bundle_p->mPutShort,
+                        env->NewStringUTF("PI"), t->pi);
+    env->CallVoidMethod(bundle, bundle_p->mPutShort,
+                        env->NewStringUTF("TP"), t->tp);
+    env->CallVoidMethod(bundle, bundle_p->mPutShort,
+                        env->NewStringUTF("PTY"), t->pty);
+    env->CallVoidMethod(bundle, bundle_p->mPutShort,
+                        env->NewStringUTF("TA"), t->ta);
+    env->CallVoidMethod(bundle, bundle_p->mPutShort,
+                        env->NewStringUTF("M/S"), t->ms);
+
+    if (t->num_afs > 0 && t->num_afs < RDS_MAX_AFS) {
+        jintArray jArr = env->NewIntArray(t->num_afs);
+        env->SetIntArrayRegion(jArr, 0, t->num_afs, t->af);
+        env->CallVoidMethod(bundle, bundle_p->mPutIntArray,
+                            env->NewStringUTF("AF"), jArr);
+    }
+    env->CallVoidMethod(bundle, bundle_p->mPutString,
+                        env->NewStringUTF("PSN"),
+                        env->NewStringUTF(t->psn));
+    env->CallVoidMethod(bundle, bundle_p->mPutString,
+                        env->NewStringUTF("RT"),
+                        env->NewStringUTF(t->rt));
+    env->CallVoidMethod(bundle, bundle_p->mPutString,
+                        env->NewStringUTF("CT"),
+                        env->NewStringUTF(t->ct));
+    env->CallVoidMethod(bundle, bundle_p->mPutString,
+                        env->NewStringUTF("PTYN"),
+                        env->NewStringUTF(t->ptyn));
+
+    jsArr = env->NewShortArray(3);
+
+    env->SetShortArrayRegion(jsArr, 0, 3, t->tmc);
+    env->CallVoidMethod(bundle, bundle_p->mPutShortArray,
+                        env->NewStringUTF("TMC"), jsArr);
+
+    env->CallVoidMethod(bundle, bundle_p->mPutInt,
+                        env->NewStringUTF("TAF"), t->taf);
+
+    clazz = env->GetObjectClass(fmReceiverSession.jobj);
+
+    notifyMethod =
+        env->GetMethodID(clazz, "notifyOnRDSDataFound",
+                         "(Landroid/os/Bundle;I)V");
+    if (notifyMethod != NULL) {
+        jobject jobj = fmReceiverSession.jobj;
+        pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+        env->CallVoidMethod(jobj, notifyMethod,
+                            bundle, frequency);
+        pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    }
+    fmReceiverSession.jvm_p->DetachCurrentThread();
+
+ drop_lock:
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+}
+
+static void androidFmRadioRxCallbackOnSignalStrengthChanged(int newLevel)
+{
+    jmethodID notifyMethod;
+    JNIEnv *env;
+    jclass clazz;
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    if (fmReceiverSession.jvm_p->AttachCurrentThread(&env, NULL) != JNI_OK) {
+        ALOGE("Error, can't attch current thread");
+        goto drop_lock;
+    }
+    clazz = env->GetObjectClass(fmReceiverSession.jobj);
+    notifyMethod =
+        env->GetMethodID(clazz, "notifyOnSignalStrengthChanged", "(I)V");
+    if (notifyMethod != NULL) {
+        jobject jobj = fmReceiverSession.jobj;
+        pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+        env->CallVoidMethod(jobj, notifyMethod,
+                            newLevel);
+        pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    }
+
+    fmReceiverSession.jvm_p->DetachCurrentThread();
+ drop_lock:
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+}
+
+static void androidFmRadioRxCallbackOnPlayingInStereo(int
+                                                      isPlayingInStereo)
+{
+    jmethodID notifyMethod;
+    JNIEnv *env;
+    jclass clazz;
+
+    ALOGI("androidFmRadioRxCallbackOnPlayingInStereo (%d)",
+         isPlayingInStereo);
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    if (fmReceiverSession.jvm_p->AttachCurrentThread(&env, NULL) != JNI_OK) {
+        ALOGE("Error, can't attch current thread");
+        goto drop_lock;
+    }
+    clazz = env->GetObjectClass(fmReceiverSession.jobj);
+    notifyMethod =
+        env->GetMethodID(clazz, "notifyOnPlayingInStereo", "(Z)V");
+    if (notifyMethod != NULL) {
+        jobject jobj = fmReceiverSession.jobj;
+        pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+        env->CallVoidMethod(jobj, notifyMethod,
+                            (bool) isPlayingInStereo);
+        pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    }
+
+    fmReceiverSession.jvm_p->DetachCurrentThread();
+ drop_lock:
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+}
+
+/*
+ * currently frequency changed event is not supported by interface, to be
+ * implemented quite soon...
+ */
+
+static void androidFmRadioRxCallbackOnAutomaticSwitch(int newFrequency, enum fmradio_switch_reason_t reason)
+{
+    jmethodID notifyMethod;
+    JNIEnv *env;
+    jclass clazz;
+
+    ALOGI("androidFmRadioRxCallbackOnAutomaticSwitch: new frequency %d, reason %d",
+         newFrequency, (int) reason);
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    if (fmReceiverSession.jvm_p->AttachCurrentThread(&env, NULL) != JNI_OK) {
+        ALOGE("Error, can't attch current thread");
+        goto drop_lock;
+    }
+    clazz = env->GetObjectClass(fmReceiverSession.jobj);
+    notifyMethod =
+        env->GetMethodID(clazz, "notifyOnAutomaticSwitching", "(II)V");
+    if (notifyMethod != NULL) {
+        jobject jobj = fmReceiverSession.jobj;
+        pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+        env->CallVoidMethod(jobj, notifyMethod, (jint)newFrequency,
+                            (jint)reason);
+        pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    }
+
+
+    fmReceiverSession.jvm_p->DetachCurrentThread();
+ drop_lock:
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+}
+
+/*
+ *  function calls from java layer.
+ */
+
+static jint androidFmRadioRxGetState(JNIEnv * env, jobject obj)
+{
+    FmRadioState_t state;
+
+    ALOGI("androidFmRadioRxGetState, state\n");
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    state = fmReceiverSession.state;
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+    return state;
+}
+
+/* common ones with tx, just forward to the generic androidFmRadioxxxxx version */
+
+static void
+androidFmRadioRxStart(JNIEnv * env, jobject obj, int lowFreq,
+                      int highFreq, int defaultFreq, int grid)
+{
+    ALOGI("androidFmRadioRxStart. LowFreq %d, HighFreq %d, DefaultFreq %d, grid %d.", lowFreq, highFreq, defaultFreq, grid);
+
+    if (fmReceiverSession.jobj == NULL)
+        fmReceiverSession.jobj = env->NewGlobalRef(obj);
+    (void) androidFmRadioStart(&fmReceiverSession, FMRADIO_RX,
+                               &FmRadioRxVendorCallbacks, false, lowFreq,
+                               highFreq, defaultFreq, grid);
+}
+
+
+static void
+androidFmRadioRxStartAsync(JNIEnv * env, jobject obj, int lowFreq,
+                           int highFreq, int defaultFreq, int grid)
+{
+    ALOGI("androidFmRadioRxStartAsync...");
+
+    if (fmReceiverSession.jobj == NULL)
+        fmReceiverSession.jobj = env->NewGlobalRef(obj);
+    (void) androidFmRadioStart(&fmReceiverSession, FMRADIO_RX,
+                               &FmRadioRxVendorCallbacks, true, lowFreq,
+                               highFreq, defaultFreq, grid);
+}
+
+static void androidFmRadioRxPause(JNIEnv * env, jobject obj)
+{
+    ALOGI("androidFmRadioRxPause\n");
+
+    (void)androidFmRadioPause(&fmReceiverSession);
+}
+
+static void androidFmRadioRxResume(JNIEnv * env, jobject obj)
+{
+    ALOGI("androidFmRadioRxResume\n");
+    (void)androidFmRadioResume(&fmReceiverSession);
+}
+
+static jint androidFmRadioRxReset(JNIEnv * env, jobject obj)
+{
+    int retval = 0;
+
+    ALOGI("androidFmRadioRxReset");
+    retval = androidFmRadioReset(&fmReceiverSession);
+
+    if (retval >= 0 && fmReceiverSession.state == FMRADIO_STATE_IDLE &&
+        fmReceiverSession.jobj != NULL) {
+        env->DeleteGlobalRef(fmReceiverSession.jobj);
+        fmReceiverSession.jobj = NULL;
+    }
+
+    return retval;
+}
+
+static void
+androidFmRadioRxSetFrequency(JNIEnv * env, jobject obj, jint frequency)
+{
+    ALOGI("androidFmRadioRxSetFrequency tuneTo:%d\n", (int) frequency);
+    return androidFmRadioSetFrequency(&fmReceiverSession, (int) frequency);
+}
+
+static jint androidFmRadioRxGetFrequency(JNIEnv * env, jobject obj)
+{
+    ALOGI("androidFmRadioRxGetFrequency:\n");
+    return androidFmRadioGetFrequency(&fmReceiverSession);
+}
+
+static void androidFmRadioRxStopScan(JNIEnv * env, jobject obj)
+{
+    ALOGI("androidFmRadioRxStopScan\n");
+    androidFmRadioStopScan(&fmReceiverSession);
+}
+
+/* the rest of the calls are specific for RX */
+
+static jint androidFmRadioRxGetSignalStrength(JNIEnv * env, jobject obj)
+{
+    int retval = SIGNAL_STRENGTH_UNKNOWN;
+
+    ALOGI("androidFmRadioRxGetSignalStrength\n");
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+
+    if (!androidFmRadioIsValidEventForState
+        (&fmReceiverSession, FMRADIO_EVENT_GET_SIGNAL_STRENGTH)) {
+        goto drop_lock;
+    }
+
+    if (fmReceiverSession.vendorMethods_p->get_signal_strength) {
+        /* if in pause state temporary resume */
+        androidFmRadioTempResumeIfPaused(&fmReceiverSession);
+
+        retval =
+            fmReceiverSession.vendorMethods_p->
+            get_signal_strength(&fmReceiverSession.vendorData_p);
+
+        if (retval < 0) {
+            retval = SIGNAL_STRENGTH_UNKNOWN;
+        } else if (retval > SIGNAL_STRENGTH_MAX) {
+            retval = SIGNAL_STRENGTH_MAX;
+        }
+        androidFmRadioPauseIfTempResumed(&fmReceiverSession);
+    }
+
+  drop_lock:
+
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+
+    return retval;
+}
+
+static jboolean
+androidFmRadioRxIsPlayingInStereo(JNIEnv * env, jobject obj)
+{
+    bool retval;
+
+    ALOGI("androidFmRadioRxIsPlayingInStereo:\n");
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+
+    /* if we haven't register we don't know yet */
+    if (!fmReceiverSession.isRegistered) {
+        retval = false;
+        goto drop_lock;
+    }
+    // valid in all states
+    if (fmReceiverSession.vendorMethods_p->is_playing_in_stereo != NULL) {
+        retval =
+            fmReceiverSession.vendorMethods_p->
+            is_playing_in_stereo(&fmReceiverSession.vendorData_p);
+    } else {
+        retval = false;
+    }
+
+  drop_lock:
+
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+
+    return retval;
+}
+
+static jboolean
+androidFmRadioRxIsRDSDataSupported(JNIEnv * env, jobject obj)
+{
+    bool retval;
+
+    ALOGI("androidFmRadioRxIsRDSDataSupported:\n");
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+
+    /* if we haven't register we don't know yet */
+    if (!fmReceiverSession.isRegistered) {
+        retval = false;
+        goto drop_lock;
+    }
+    // valid in all states
+    if (fmReceiverSession.vendorMethods_p->is_rds_data_supported != NULL) {
+        retval =
+            fmReceiverSession.vendorMethods_p->
+            is_rds_data_supported(&fmReceiverSession.vendorData_p);
+    } else {
+        retval = false;
+    }
+
+  drop_lock:
+
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+    return retval;
+}
+
+static jboolean
+androidFmRadioRxIsTunedToValidChannel(JNIEnv * env, jobject obj)
+{
+    bool retval;
+
+    ALOGI("androidFmRadioRxIsTunedToValidChannel:\n");
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+
+    /* if we haven't register we don't know yet */
+    if (!fmReceiverSession.isRegistered) {
+        retval = false;
+        goto drop_lock;
+    }
+    // valid in all states
+    if (fmReceiverSession.vendorMethods_p->is_tuned_to_valid_channel != NULL) {
+        retval =
+            fmReceiverSession.vendorMethods_p->
+            is_tuned_to_valid_channel(&fmReceiverSession.vendorData_p);
+    } else {
+        retval = false;
+    }
+
+  drop_lock:
+
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+    return retval;
+}
+
+static void *execute_androidFmRadioRxScan(void *args)
+{
+    enum fmradio_seek_direction_t scanDirection =
+        *(enum fmradio_seek_direction_t *) args;
+    int signalStrength = -1;
+    int retval;
+    enum FmRadioState_t oldState;
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    free(args);
+    // we should still be in SCANNING mode, but we can't be 100.00 % sure since main thread released lock
+    // before we could run
+
+    if (fmReceiverSession.state != FMRADIO_STATE_SCANNING) {
+        ALOGE("execute_androidFmRadioRxScan - warning, state not scanning");
+    }
+
+    /*
+     * if mode has been changed to IDLE in the mean time by main thread,
+     * exit the worker thread gracefully
+     */
+    if (fmReceiverSession.state == FMRADIO_STATE_IDLE) {
+        goto drop_lock;
+    }
+
+    oldState = fmReceiverSession.oldState;
+
+    // temporary resume chip if sleeping
+    if (oldState == FMRADIO_STATE_PAUSED) {
+        (void) fmReceiverSession.
+            vendorMethods_p->resume(&fmReceiverSession.vendorData_p);
+    }
+
+    if (pthread_cond_signal(&fmReceiverSession.sync_cond) != 0) {
+        ALOGE("execute_androidFmRadioRxScan - warning, signal failed");
+    }
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+
+    retval =
+        fmReceiverSession.vendorMethods_p->scan(&fmReceiverSession.
+                                                vendorData_p,
+                                                scanDirection);
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+
+    if (retval >= 0) {
+        // also get signal strength (if supported)
+        if (fmReceiverSession.vendorMethods_p->get_signal_strength)
+            signalStrength =
+                fmReceiverSession.vendorMethods_p->
+                get_signal_strength(&fmReceiverSession.vendorData_p);
+    }
+    /*
+     * if state has changed we should keep it, probably a forced reset
+     */
+    if (fmReceiverSession.state != FMRADIO_STATE_SCANNING) {
+        ALOGI("State changed while scanning (state now %d), keeping",
+             fmReceiverSession.state);
+        retval = -1;
+    } else {
+        // put back to sleep if we did a temporary wake-up
+        if ((oldState == FMRADIO_STATE_PAUSED
+             || fmReceiverSession.pendingPause))
+            (void) fmReceiverSession.
+                vendorMethods_p->pause(&fmReceiverSession.vendorData_p);
+        if (fmReceiverSession.pendingPause) {
+            FMRADIO_SET_STATE(&fmReceiverSession, FMRADIO_STATE_PAUSED);
+        } else {
+            FMRADIO_SET_STATE(&fmReceiverSession, oldState);
+        }
+
+        // if we failed but we have a pending abort just read the current frequency to give a proper
+        // onScan return
+
+        if (retval < 0 && fmReceiverSession.lastScanAborted &&
+            fmReceiverSession.vendorMethods_p->get_frequency) {
+            retval = fmReceiverSession.vendorMethods_p->get_frequency(&fmReceiverSession.vendorData_p);
+        }
+    }
+
+    fmReceiverSession.pendingPause = false;
+
+    if (retval >= 0) {
+        fmReceiverSession.callbacks_p->onScan(retval,
+                                              signalStrength,
+                                              scanDirection,
+                                              fmReceiverSession.
+                                              lastScanAborted);
+    } else {
+        fmReceiverSession.callbacks_p->onError();
+    }
+    drop_lock:
+    /* Wake up the main thread if it is currently waiting on the condition variable */
+    if (pthread_cond_signal(&fmReceiverSession.sync_cond) != 0) {
+        ALOGE("execute_androidFmRadioRxScan - signal failed\n");
+    }
+
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+
+    pthread_exit(NULL);
+    return NULL;
+}
+
+
+static void androidFmRadioRxScan(enum fmradio_seek_direction_t scanDirection)
+{
+    int retval = 0;
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+
+    if (!androidFmRadioIsValidEventForState
+        (&fmReceiverSession, FMRADIO_EVENT_SCAN)) {
+        retval = FMRADIO_INVALID_STATE;
+        goto drop_lock;
+    }
+
+    if (fmReceiverSession.vendorMethods_p->scan) {
+        enum fmradio_seek_direction_t *scanDirectionParam_p =
+            (enum fmradio_seek_direction_t *)
+            malloc(sizeof(*scanDirectionParam_p));
+
+        pthread_t execute_thread;
+
+        // we need to create a new thread actually executing the command
+
+        fmReceiverSession.oldState = fmReceiverSession.state;
+        FMRADIO_SET_STATE(&fmReceiverSession, FMRADIO_STATE_SCANNING);
+        *scanDirectionParam_p = scanDirection;
+
+        fmReceiverSession.lastScanAborted = false;
+
+        if (pthread_create
+            (&execute_thread, NULL, execute_androidFmRadioRxScan,
+             (void *) scanDirectionParam_p) != 0) {
+
+            ALOGE("pthread_create failure...\n");
+            free(scanDirectionParam_p);
+            FMRADIO_SET_STATE(&fmReceiverSession, fmReceiverSession.oldState);
+            retval = FMRADIO_IO_ERROR;
+        } else {
+            /* await thread startup, THREAD_WAIT_TIMEOUT_S sec timeout */
+            struct timespec ts;
+            clock_gettime(CLOCK_REALTIME, &ts);
+            ts.tv_sec += THREAD_WAIT_TIMEOUT_S;
+            if (pthread_cond_timedwait(&fmReceiverSession.sync_cond,
+                                       fmReceiverSession.dataMutex_p,
+                                       &ts) != 0) {
+                ALOGE("androidFmRadioRxScan: warning, wait failure\n");
+            }
+            pthread_detach(execute_thread);
+
+        }
+    } else {
+        retval = FMRADIO_UNSUPPORTED_OPERATION;
+    }
+
+  drop_lock:
+    if (retval == FMRADIO_INVALID_STATE) {
+        THROW_INVALID_STATE(&fmReceiverSession);
+    } else if (retval < 0) {
+        THROW_IO_ERROR(&fmReceiverSession);
+    }
+
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+
+    if (retval < 0) {
+        ALOGE("androidFmRadioRxScan failed\n");
+    }
+}
+
+static void
+androidFmRadioRxScanUp(JNIEnv * env, jobject obj, jlong * frequency)
+{
+    ALOGI("androidFmRadioRxScanUp\n");
+
+    androidFmRadioRxScan(FMRADIO_SEEK_UP);
+}
+
+static void
+androidFmRadioRxScanDown(JNIEnv * env, jobject obj, jlong * frequency)
+{
+    ALOGI("androidFmRadioRxScanDown\n");
+
+    androidFmRadioRxScan(FMRADIO_SEEK_DOWN);
+}
+
+static void *execute_androidFmRadioRxFullScan(void *args)
+{
+    int retval;
+    enum FmRadioState_t oldState = fmReceiverSession.oldState;
+    int *frequencies_p = NULL;
+    int *rssi_p = NULL;
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+
+    // we should still be in SCANNING mode, but we can't be 100.00 % sure since main thread released lock
+    // before we could run
+
+    if (fmReceiverSession.state != FMRADIO_STATE_SCANNING) {
+        ALOGE("execute_androidFmRadioRxFullScan - warning, state not scanning\n");
+    }
+
+    /*
+     * if mode has been changed to IDLE in the mean time by main thread,
+     * exit the worker thread gracefully
+     */
+    if (fmReceiverSession.state == FMRADIO_STATE_IDLE) {
+        goto drop_lock;
+    }
+    // temporary resume chip if sleeping
+    if (oldState == FMRADIO_STATE_PAUSED) {
+        (void) fmReceiverSession.
+            vendorMethods_p->resume(&fmReceiverSession.vendorData_p);
+    }
+
+    if (pthread_cond_signal(&fmReceiverSession.sync_cond) != 0) {
+        ALOGE("execute_androidFmRadioRxFullScan - warning, signal failed\n");
+    }
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+
+    retval =
+        fmReceiverSession.vendorMethods_p->full_scan(&fmReceiverSession.
+                                                    vendorData_p,
+                                                    &frequencies_p,
+                                                    &rssi_p);
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+
+    /*
+     * if state has changed we should keep it, probably a forced pause or
+     * forced reset
+     */
+    if (fmReceiverSession.state != FMRADIO_STATE_SCANNING) {
+        ALOGI("State changed while scanning (state now %d), keeping\n",
+             fmReceiverSession.state);
+        retval = -1;
+    } else {
+        if (fmReceiverSession.pendingPause) {
+            FMRADIO_SET_STATE(&fmReceiverSession, FMRADIO_STATE_PAUSED);
+        } else {
+            FMRADIO_SET_STATE(&fmReceiverSession, oldState);
+        }
+
+        fmReceiverSession.pendingPause = false;
+    }
+
+    if (retval >= 0) {
+        fmReceiverSession.callbacks_p->onFullScan(retval,
+                                                  frequencies_p,
+                                                  rssi_p,
+                                                  fmReceiverSession.
+                                                  lastScanAborted);
+    } else {
+        fmReceiverSession.callbacks_p->onError();
+    }
+
+    if (frequencies_p != NULL) {
+        free(frequencies_p);
+    }
+
+    if (rssi_p != NULL) {
+        free(rssi_p);
+    }
+
+    drop_lock:
+    /* Wake up the main thread if it is currently waiting on the condition variable */
+    if (pthread_cond_signal(&fmReceiverSession.sync_cond) != 0) {
+        ALOGE("execute_androidFmRadioRxFullScan - signal failed\n");
+    }
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+
+    pthread_exit(NULL);
+    return NULL;
+}
+
+static void androidFmRadioRxStartFullScan(JNIEnv * env, jobject obj)
+{
+    ALOGI("androidFmRadioRxStartFullScan\n");
+    int retval = 0;
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+
+    if (!androidFmRadioIsValidEventForState
+        (&fmReceiverSession, FMRADIO_EVENT_FULL_SCAN)) {
+        retval = FMRADIO_INVALID_STATE;
+        goto drop_lock;
+    }
+
+
+    if (fmReceiverSession.vendorMethods_p->full_scan) {
+        pthread_t execute_thread;
+
+        fmReceiverSession.oldState = fmReceiverSession.state;
+        FMRADIO_SET_STATE(&fmReceiverSession, FMRADIO_STATE_SCANNING);
+        fmReceiverSession.lastScanAborted = false;
+
+        if (pthread_create
+            (&execute_thread, NULL, execute_androidFmRadioRxFullScan,
+             NULL) != 0) {
+
+            ALOGE("pthread_create failure...\n");
+            FMRADIO_SET_STATE(&fmReceiverSession, fmReceiverSession.oldState);
+            retval = FMRADIO_IO_ERROR;
+        } else {
+            /* await thread startup, THREAD_WAIT_TIMEOUT_S sec timeout */
+            struct timespec ts;
+            clock_gettime(CLOCK_REALTIME, &ts);
+            ts.tv_sec += THREAD_WAIT_TIMEOUT_S;
+            if (pthread_cond_timedwait(&fmReceiverSession.sync_cond,
+                                       fmReceiverSession.dataMutex_p,
+                                       &ts) != 0) {
+                ALOGE("androidFmRadioRxStartFullScan: warning, wait failure\n");
+            }
+            pthread_detach(execute_thread);
+        }
+    } else {
+        retval = FMRADIO_UNSUPPORTED_OPERATION;
+    }
+
+  drop_lock:
+    if (retval == FMRADIO_INVALID_STATE) {
+        THROW_INVALID_STATE(&fmReceiverSession);
+    } else if (retval < 0) {
+        THROW_IO_ERROR(&fmReceiverSession);
+    }
+
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+}
+
+static void androidFmRadioRxSetAutomaticAFSwitching(JNIEnv * env,
+                                                  jobject obj,
+                                                  jboolean automatic)
+{
+    int retval = -1;
+
+    ALOGI("androidFmRadioRxSetAutomaticAFSwitching\n");
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+
+    if (!androidFmRadioIsValidEventForState
+        (&fmReceiverSession, FMRADIO_EVENT_SET_PARAMETER)) {
+        retval = FMRADIO_INVALID_STATE;
+        goto drop_lock;
+    }
+
+
+    if (fmReceiverSession.vendorMethods_p->set_automatic_af_switching) {
+        retval =
+            fmReceiverSession.vendorMethods_p->
+            set_automatic_af_switching(&fmReceiverSession.vendorData_p, automatic);
+    } else {
+        retval = FMRADIO_UNSUPPORTED_OPERATION;
+    }
+
+  drop_lock:
+    if (retval == FMRADIO_INVALID_STATE) {
+        THROW_INVALID_STATE(&fmReceiverSession);
+    } else if (retval < 0) {
+        THROW_IO_ERROR(&fmReceiverSession);
+    }
+
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+}
+
+static void androidFmRadioRxSetAutomaticTASwitching(JNIEnv * env, jobject obj,
+                                                    jboolean automatic)
+{
+    int retval = -1;
+
+    ALOGI("androidFmRadioRxSetAutomaticTASwitching\n");
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+
+    if (!androidFmRadioIsValidEventForState
+        (&fmReceiverSession, FMRADIO_EVENT_SET_PARAMETER)) {
+        retval = FMRADIO_INVALID_STATE;
+        goto drop_lock;
+    }
+
+
+    if (fmReceiverSession.vendorMethods_p->set_automatic_ta_switching) {
+        retval =
+            fmReceiverSession.vendorMethods_p->
+            set_automatic_ta_switching(&fmReceiverSession.vendorData_p, automatic);
+    } else {
+        retval = FMRADIO_UNSUPPORTED_OPERATION;
+    }
+
+  drop_lock:
+    if (retval == FMRADIO_INVALID_STATE) {
+        THROW_INVALID_STATE(&fmReceiverSession);
+    } else if (retval < 0) {
+        THROW_IO_ERROR(&fmReceiverSession);
+    }
+
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+}
+
+static void androidFmRadioRxSetForceMono(JNIEnv * env, jobject obj,
+                                         jboolean forceMono)
+{
+    int retval = -1;
+
+    ALOGI("androidFmRadioRxSetForceMono\n");
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+
+    if (!androidFmRadioIsValidEventForState
+        (&fmReceiverSession, FMRADIO_EVENT_SET_PARAMETER)) {
+        retval = FMRADIO_INVALID_STATE;
+        goto drop_lock;
+    }
+
+
+    if (fmReceiverSession.vendorMethods_p->set_force_mono) {
+        /* if in pause state temporary resume */
+        androidFmRadioTempResumeIfPaused(&fmReceiverSession);
+
+        retval =
+            fmReceiverSession.vendorMethods_p->
+            set_force_mono(&fmReceiverSession.vendorData_p, forceMono);
+
+        androidFmRadioPauseIfTempResumed(&fmReceiverSession);
+    } else {
+        retval = FMRADIO_UNSUPPORTED_OPERATION;
+    }
+
+  drop_lock:
+    if (retval == FMRADIO_INVALID_STATE) {
+        THROW_INVALID_STATE(&fmReceiverSession);
+    } else if (retval < 0) {
+        THROW_IO_ERROR(&fmReceiverSession);
+    }
+
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+}
+
+static void
+androidFmRadioRxSetThreshold(JNIEnv * env, jobject obj, jint threshold)
+{
+    int retval;
+
+    ALOGI("androidFmRadioRxSetThreshold threshold:%d\n", (int) threshold);
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    if (!androidFmRadioIsValidEventForState
+        (&fmReceiverSession, FMRADIO_EVENT_SET_PARAMETER)) {
+        retval = FMRADIO_INVALID_STATE;
+        goto drop_lock;
+    }
+
+
+    if (fmReceiverSession.vendorMethods_p->set_threshold) {
+        /* if in pause state temporary resume */
+        androidFmRadioTempResumeIfPaused(&fmReceiverSession);
+
+        retval =
+            fmReceiverSession.
+            vendorMethods_p->set_threshold(&fmReceiverSession.vendorData_p,
+                                          threshold);
+        /* if in pause state temporary resume */
+        androidFmRadioPauseIfTempResumed(&fmReceiverSession);
+    } else {
+        retval = FMRADIO_UNSUPPORTED_OPERATION;
+    }
+
+    if (retval == FMRADIO_INVALID_STATE) {
+        THROW_INVALID_STATE(&fmReceiverSession);
+    } else if (retval < 0) {
+        THROW_IO_ERROR(&fmReceiverSession);
+    }
+
+  drop_lock:
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+}
+
+static jint androidFmRadioRxGetThreshold(JNIEnv * env, jobject obj)
+{
+    int retval;
+
+    ALOGI("androidFmRadioRxGetThreshold\n");
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+
+    if (!androidFmRadioIsValidEventForState
+        (&fmReceiverSession, FMRADIO_EVENT_GET_PARAMETER)) {
+        retval = FMRADIO_INVALID_STATE;
+        goto drop_lock;
+    }
+
+    if (fmReceiverSession.vendorMethods_p->get_threshold) {
+        /* if in pause state temporary resume */
+        androidFmRadioTempResumeIfPaused(&fmReceiverSession);
+        retval =
+            fmReceiverSession.
+            vendorMethods_p->get_threshold(&fmReceiverSession.vendorData_p);
+        androidFmRadioPauseIfTempResumed(&fmReceiverSession);
+    } else {
+        retval = FMRADIO_UNSUPPORTED_OPERATION;
+    }
+  drop_lock:
+
+    if (retval == FMRADIO_INVALID_STATE) {
+        THROW_INVALID_STATE(&fmReceiverSession);
+    } else if (retval < 0) {
+        THROW_IO_ERROR(&fmReceiverSession);
+    }
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+
+    return retval;
+}
+
+static void androidFmRadioRxSetRDS(JNIEnv * env, jobject obj,
+                                   jboolean receiveRDS)
+{
+    int retval = -1;
+
+    ALOGI("androidFmRadioRxSetRDS(%d)", (int)receiveRDS);
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+
+    if (!androidFmRadioIsValidEventForState
+        (&fmReceiverSession, FMRADIO_EVENT_SET_PARAMETER)) {
+        retval = FMRADIO_INVALID_STATE;
+        goto drop_lock;
+    }
+
+    if (fmReceiverSession.vendorMethods_p->set_rds_reception) {
+        /* if in pause state temporary resume */
+        androidFmRadioTempResumeIfPaused(&fmReceiverSession);
+
+        /* temporary unlock to avoid deadlock with RDS callback */
+        pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+        retval = fmReceiverSession.vendorMethods_p->
+            set_rds_reception(&fmReceiverSession.vendorData_p, receiveRDS);
+        pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+
+        androidFmRadioPauseIfTempResumed(&fmReceiverSession);
+    } else {
+        retval = FMRADIO_UNSUPPORTED_OPERATION;
+    }
+
+  drop_lock:
+    /*
+     * Set rds is not executed by explicit command but rather triggered
+     * on startup and on adding and removal of listeners. Because of this
+     * it should not trigger exceptions, just ALOG any failure.
+     */
+
+    if (retval != FMRADIO_OK) {
+        ALOGE("androidFmRadioRxSetRDS failed, retval = %d.", retval);
+    }
+
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+}
+
+static jboolean androidFmRadioRxSendExtraCommand(JNIEnv * env, jobject obj,
+                                                 jstring command,
+                                                 jobjectArray parameters)
+{
+    ALOGI("androidFmRadioRxSendExtraCommand");
+
+/* we need to set jobj since this might be called before start */
+
+    if (fmReceiverSession.jobj == NULL)
+        fmReceiverSession.jobj = env->NewGlobalRef(obj);
+
+    androidFmRadioSendExtraCommand(&fmReceiverSession, env, command,
+                                   parameters);
+
+    return true;
+}
+
+
+static JNINativeMethod gMethods[] = {
+    {(char *)"_fm_receiver_getState", (char *)"()I",
+     (void *) androidFmRadioRxGetState},
+    {(char *)"_fm_receiver_start", (char *)"(IIII)V",
+     (void *) androidFmRadioRxStart},
+    {(char *)"_fm_receiver_startAsync", (char *)"(IIII)V",
+     (void *) androidFmRadioRxStartAsync},
+    {(char *)"_fm_receiver_pause", (char *)"()V",
+     (void *) androidFmRadioRxPause},
+    {(char *)"_fm_receiver_resume", (char *)"()V",
+     (void *) androidFmRadioRxResume},
+    {(char *)"_fm_receiver_reset", (char *)"()I",
+     (void *) androidFmRadioRxReset},
+    {(char *)"_fm_receiver_setFrequency", (char *)"(I)V",
+     (void *) androidFmRadioRxSetFrequency},
+    {(char *)"_fm_receiver_getFrequency", (char *)"()I",
+     (void *) androidFmRadioRxGetFrequency},
+    {(char *)"_fm_receiver_getSignalStrength", (char *)"()I",
+     (void *) androidFmRadioRxGetSignalStrength},
+    {(char *)"_fm_receiver_scanUp", (char *)"()V",
+     (void *) androidFmRadioRxScanUp},
+    {(char *)"_fm_receiver_scanDown", (char *)"()V",
+     (void *) androidFmRadioRxScanDown},
+    {(char *)"_fm_receiver_startFullScan", (char *)"()V",
+     (void *) androidFmRadioRxStartFullScan},
+    {(char *)"_fm_receiver_isPlayingInStereo", (char *)"()Z",
+     (void *) androidFmRadioRxIsPlayingInStereo},
+    {(char *)"_fm_receiver_isRDSDataSupported", (char *)"()Z",
+     (void *) androidFmRadioRxIsRDSDataSupported},
+    {(char *)"_fm_receiver_isTunedToValidChannel", (char *)"()Z",
+     (void *) androidFmRadioRxIsTunedToValidChannel},
+    {(char *)"_fm_receiver_stopScan", (char *)"()V",
+     (void *) androidFmRadioRxStopScan},
+    {(char *)"_fm_receiver_setAutomaticAFSwitching", (char *)"(Z)V",
+     (void *) androidFmRadioRxSetAutomaticAFSwitching},
+    {(char *)"_fm_receiver_setAutomaticTASwitching", (char *)"(Z)V",
+     (void *) androidFmRadioRxSetAutomaticTASwitching},
+    {(char *)"_fm_receiver_setForceMono", (char *)"(Z)V",
+     (void *) androidFmRadioRxSetForceMono},
+    {(char *)"_fm_receiver_sendExtraCommand",
+     (char *)"(Ljava/lang/String;[Ljava/lang/String;)Z",
+     (void *) androidFmRadioRxSendExtraCommand},
+    {(char *)"_fm_receiver_getThreshold", (char *)"()I",
+     (void *) androidFmRadioRxGetThreshold},
+    {(char *)"_fm_receiver_setThreshold", (char *)"(I)V",
+     (void *) androidFmRadioRxSetThreshold},
+    {(char *)"_fm_receiver_setRDS", (char *)"(Z)V",
+     (void *) androidFmRadioRxSetRDS},
+};
+
+
+
+
+int registerAndroidFmRadioReceiver(JavaVM * vm, JNIEnv * env)
+{
+    ALOGI("registerAndroidFmRadioReceiver\n");
+    jclass clazz;
+
+    pthread_mutex_lock(fmReceiverSession.dataMutex_p);
+    fmReceiverSession.jvm_p = vm;
+
+    struct bundle_descriptor_offsets_t *bundle_p =
+        (struct bundle_descriptor_offsets_t *)
+        malloc(sizeof(struct bundle_descriptor_offsets_t));
+#if 1
+    clazz = env->FindClass("android/os/Bundle");
+    bundle_p->mClass = (jclass) env->NewGlobalRef(clazz);
+    bundle_p->mConstructor = env->GetMethodID(clazz, "<init>", "()V");
+    bundle_p->mPutInt =
+        env->GetMethodID(clazz, "putInt", "(Ljava/lang/String;I)V");
+    bundle_p->mPutShort =
+        env->GetMethodID(clazz, "putShort", "(Ljava/lang/String;S)V");
+    bundle_p->mPutIntArray =
+        env->GetMethodID(clazz, "putIntArray", "(Ljava/lang/String;[I)V");
+    bundle_p->mPutShortArray =
+        env->GetMethodID(clazz, "putShortArray",
+                         "(Ljava/lang/String;[S)V");
+    bundle_p->mPutString =
+        env->GetMethodID(clazz, "putString",
+                         "(Ljava/lang/String;Ljava/lang/String;)V");
+
+    fmReceiverSession.bundleOffsets_p = bundle_p;
+#endif
+    pthread_mutex_unlock(fmReceiverSession.dataMutex_p);
+    return jniRegisterNativeMethods(env,
+                                    "com/android/fmradio/FmNative",
+                                    gMethods, NELEM(gMethods));
+}
+
+/* *INDENT-OFF* */
+};                              // namespace android

--- a/brcm_fmradio/libfmjni/android_fmradio_Receiver.h
+++ b/brcm_fmradio/libfmjni/android_fmradio_Receiver.h
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) ST-Ericsson SA 2010
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: johan.xj.palmaeus@stericsson.com for ST-Ericsson
+ */
+
+/*
+ * Internal stuff for android_fmradio(_Receiver/_Transmitter).cpp
+ */
+
+#ifndef ANDROID_FMRADIO_H
+#define ANDROID_FMRADIO_H
+
+#include <stdbool.h>
+#include "jni.h"
+#include "android_fm.h"
+#include "pthread.h"
+
+enum FmRadioState_t {
+    FMRADIO_STATE_IDLE,
+    FMRADIO_STATE_STARTING,
+    FMRADIO_STATE_STARTED,
+    FMRADIO_STATE_PAUSED,
+    FMRADIO_STATE_SCANNING,
+    FMRADIO_STATE_EXTRA_COMMAND,
+    /* sum up */
+            FMRADIO_NUMBER_OF_STATES
+};
+
+enum FmRadioCommand_t {
+    FMRADIO_EVENT_START,
+    FMRADIO_EVENT_START_ASYNC,
+    FMRADIO_EVENT_PAUSE,
+    FMRADIO_EVENT_RESUME,
+    FMRADIO_EVENT_RESET,
+    FMRADIO_EVENT_GET_FREQUENCY,
+    FMRADIO_EVENT_SET_FREQUENCY,
+    FMRADIO_EVENT_SET_PARAMETER,
+    FMRADIO_EVENT_STOP_SCAN,
+    FMRADIO_EVENT_EXTRA_COMMAND,
+    /* RX Only */
+            FMRADIO_EVENT_GET_PARAMETER,
+    FMRADIO_EVENT_GET_SIGNAL_STRENGTH,
+    FMRADIO_EVENT_SCAN,
+    FMRADIO_EVENT_FULL_SCAN,
+    /* TX Only */
+            FMRADIO_EVENT_BLOCK_SCAN,
+    /* sum up */
+            FMRADIO_NUMBER_OF_EVENTS
+};
+
+enum RadioMode_t {
+    FMRADIO_RX,
+    FMRADIO_TX
+};
+
+typedef bool ValidEventsForStates_t[FMRADIO_NUMBER_OF_EVENTS]
+[FMRADIO_NUMBER_OF_STATES];
+
+struct FmRadioCallbacks_t {
+    void (*onStateChanged) (int, int);
+    void (*onError) (void);
+    void (*onStarted) (void);
+    void (*onScan) (int, int, int, bool);    /* RX only */
+    void (*onFullScan) (int, int *, int *, bool);       /* RX only */
+    void (*onBlockScan) (int, int *, int *, bool);      /* TX only */
+    void (*onForcedReset) (enum fmradio_reset_reason_t);
+    void (*onSendExtraCommand) (char*, struct fmradio_extra_command_ret_item_t *);
+};
+
+struct bundle_descriptor_offsets_t {
+    jclass mClass;
+    jmethodID mConstructor;
+    jmethodID mGetInt;
+    jmethodID mGetIntArray;
+    jmethodID mGetShort;
+    jmethodID mGetShortArray;
+    jmethodID mGetString;
+    jmethodID mContainsKey;
+    jmethodID mSize;
+    jmethodID mKeySet;
+    jmethodID mPutInt;
+    jmethodID mPutShort;
+    jmethodID mPutIntArray;
+    jmethodID mPutShortArray;
+    jmethodID mPutString;
+};
+
+struct FmSession_t {
+    // vendor specific data, we do not know about this type
+    void *vendorData_p;
+    void *fmLibrary_p;
+    bool isRegistered;
+    enum FmRadioState_t state;
+    struct fmradio_vendor_methods_t *vendorMethods_p;
+    const ValidEventsForStates_t *validEventsForStates_p;
+    const struct FmRadioCallbacks_t *callbacks_p;
+    JavaVM *jvm_p;
+    jobject jobj;
+    struct FmSession_t *partnerSession_p;
+    struct bundle_descriptor_offsets_t *bundleOffsets_p;
+    enum FmRadioState_t oldState;    /* used when scanning */
+    bool lastScanAborted;            /* used when scanning */
+    bool pendingPause;               /* used when scanning & asyncStarting */
+    bool ongoingReset;               /* used during reset while waiting */
+    pthread_mutex_t *dataMutex_p;    /* data access to this struct */
+    pthread_cond_t  sync_cond;
+    struct ThreadCtrl_t *signalStrengthThreadCtrl_p;    /* RX Only */
+};
+
+#define FMRADIO_SET_STATE(_session_p,_newState) {int _oldState = (_session_p)->state; (_session_p)->state = _newState;(_session_p)->callbacks_p->onStateChanged(_oldState, _newState);}
+
+/* exceptions */
+
+#define THROW_ILLEGAL_ARGUMENT(_session_p) \
+      androidFmRadioThrowException(_session_p,\
+           "java/lang/IllegalArgumentException",\
+           "Illegal argument", __FILE__, __LINE__,\
+           __FUNCTION__)
+#define THROW_UNSUPPORTED_OPERATION(_session_p) \
+      androidFmRadioThrowException(_session_p,\
+           "java/lang/UnsupportedOperationException",\
+           "Unsupported operation", __FILE__, __LINE__,\
+            __FUNCTION__)
+#define THROW_INVALID_STATE(_session_p)	\
+      androidFmRadioThrowException(_session_p,\
+           "java/lang/IllegalStateException",\
+           "State is invalid", __FILE__, __LINE__,\
+           __FUNCTION__)
+#define THROW_IO_ERROR(_session_p) \
+      androidFmRadioThrowException(_session_p,\
+           "java/io/IOException",\
+           "IO Exception", __FILE__, __LINE__,\
+           __FUNCTION__)
+
+
+#define FM_LIBRARY_NAME_MAX_LENGTH 128
+
+#define THREAD_WAIT_TIMEOUT_S 2
+
+#define SIGNAL_STRENGTH_MAX 1000
+#define SIGNAL_STRENGTH_UNKNOWN -1
+
+extern pthread_mutex_t rx_tx_common_mutex;
+
+jobject extraCommandRetList2Bundle(JNIEnv * env_p, struct bundle_descriptor_offsets_t
+*bundleOffsets_p, struct fmradio_extra_command_ret_item_t *itemList);
+
+void freeExtraCommandRetList(struct extra_command_ret_item_t *itemList);
+
+void androidFmRadioTempResumeIfPaused(struct FmSession_t *session_p);
+
+void androidFmRadioPauseIfTempResumed(struct FmSession_t *session_p);
+
+bool androidFmRadioIsValidEventForState(struct FmSession_t *session_p,
+                                        enum FmRadioCommand_t event);
+
+void androidFmRadioThrowException(struct FmSession_t *session_p,
+                                  const char *exception,
+                                  const char *message, const char *file,
+                                  int line, const char *function);
+
+bool androidFmRadioLoadFmLibrary(struct FmSession_t *session_p,
+                                 enum RadioMode_t mode);
+
+void androidFmRadioUnLoadFmLibrary(struct FmSession_t *session_p);
+
+int
+        androidFmRadioStart(struct FmSession_t *session_p, enum RadioMode_t mode,
+                            const struct fmradio_vendor_callbacks_t *callbacks,
+                            bool async, int lowFreq, int highFreq, int defaultFreq,
+                            int grid);
+
+int androidFmRadioPause(struct FmSession_t *session_p);
+
+int androidFmRadioResume(struct FmSession_t *session_p);
+
+int androidFmRadioReset(struct FmSession_t *session_p);
+
+void androidFmRadioSetFrequency(struct FmSession_t *session_p,
+                                int frequency);
+
+int androidFmRadioGetFrequency(struct FmSession_t *session_p);
+
+void androidFmRadioStopScan(struct FmSession_t *session_p);
+
+void
+        androidFmRadioSendExtraCommand(struct FmSession_t *session_p, JNIEnv * env,
+                                       jstring command, jobjectArray parameter);
+
+void start(JNIEnv *env, jobject instance);
+
+#endif

--- a/brcm_fmradio/libfmjni/android_fmradio_Receiver.h
+++ b/brcm_fmradio/libfmjni/android_fmradio_Receiver.h
@@ -70,16 +70,6 @@ enum RadioMode_t {
 typedef bool ValidEventsForStates_t[FMRADIO_NUMBER_OF_EVENTS]
 [FMRADIO_NUMBER_OF_STATES];
 
-struct FmRadioCallbacks_t {
-    void (*onStateChanged) (int, int);
-    void (*onError) (void);
-    void (*onStarted) (void);
-    void (*onScan) (int, int, int, bool);    /* RX only */
-    void (*onFullScan) (int, int *, int *, bool);       /* RX only */
-    void (*onBlockScan) (int, int *, int *, bool);      /* TX only */
-    void (*onForcedReset) (enum fmradio_reset_reason_t);
-    void (*onSendExtraCommand) (char*, struct fmradio_extra_command_ret_item_t *);
-};
 
 struct bundle_descriptor_offsets_t {
     jclass mClass;
@@ -107,7 +97,6 @@ struct FmSession_t {
     enum FmRadioState_t state;
     struct fmradio_vendor_methods_t *vendorMethods_p;
     const ValidEventsForStates_t *validEventsForStates_p;
-    const struct FmRadioCallbacks_t *callbacks_p;
     JavaVM *jvm_p;
     jobject jobj;
     struct FmSession_t *partnerSession_p;
@@ -121,7 +110,7 @@ struct FmSession_t {
     struct ThreadCtrl_t *signalStrengthThreadCtrl_p;    /* RX Only */
 };
 
-#define FMRADIO_SET_STATE(_session_p,_newState) {int _oldState = (_session_p)->state; (_session_p)->state = _newState;(_session_p)->callbacks_p->onStateChanged(_oldState, _newState);}
+#define FMRADIO_SET_STATE(_session_p,_newState) {int _oldState = (_session_p)->state; (_session_p)->state = _newState;}
 
 /* exceptions */
 
@@ -178,9 +167,7 @@ bool androidFmRadioLoadFmLibrary(struct FmSession_t *session_p,
 
 void androidFmRadioUnLoadFmLibrary(struct FmSession_t *session_p);
 
-int
-        androidFmRadioStart(struct FmSession_t *session_p, enum RadioMode_t mode,
-                            const struct fmradio_vendor_callbacks_t *callbacks,
+int  androidFmRadioStart(struct FmSession_t *session_p, enum RadioMode_t mode,
                             bool async, int lowFreq, int highFreq, int defaultFreq,
                             int grid);
 
@@ -190,12 +177,12 @@ int androidFmRadioResume(struct FmSession_t *session_p);
 
 int androidFmRadioReset(struct FmSession_t *session_p);
 
-void androidFmRadioSetFrequency(struct FmSession_t *session_p,
+int androidFmRadioSetFrequency(struct FmSession_t *session_p,
                                 int frequency);
 
 int androidFmRadioGetFrequency(struct FmSession_t *session_p);
 
-void androidFmRadioStopScan(struct FmSession_t *session_p);
+int androidFmRadioStopScan(struct FmSession_t *session_p);
 
 void
         androidFmRadioSendExtraCommand(struct FmSession_t *session_p, JNIEnv * env,
@@ -203,4 +190,5 @@ void
 
 void start(JNIEnv *env, jobject instance);
 
+int androidFmRadioMute(struct FmSession_t *session_p, int mute);
 #endif


### PR DESCRIPTION
Needed for Broadcom BT/FM combo chip kernel driver.
Allow use FMRadio on devices with broadcom stack.

brcm-uim-sysfs from sony opensource package.
FMRadio-jni from https://android-review.googlesource.com/#/c/46100/
libfmradio.v4l2-fm, Author: marco.sinigaglia@csr.com