### PR TITLE
sony-common: add kernel-headers for inline kernel build system

### DIFF
--- a/fingerprint/Android.mk
+++ b/fingerprint/Android.mk
@@ -27,8 +27,14 @@ LOCAL_SRC_FILES := fingerprint.c \
 
 LOCAL_CFLAGS += -std=c99
 LOCAL_SHARED_LIBRARIES := liblog \
-			libdl \
-			libutils
+			  libdl \
+			  libutils
+
+ifeq ($(TARGET_COMPILE_WITH_MSM_KERNEL),true)
+LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
+LOCAL_ADDITIONAL_DEPENDENCIES := $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
+endif
+
 LOCAL_MODULE_TAGS := optional
 
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
This help us to keep inline with some external projects like CAF
this is needed for people building with kernel-headers isntad of common-kernel-headers repo

Signed-off-by: David Viteri <davidteri91@gmail.com>