### PR TITLE
sony-common: cleanup for N

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -166,16 +166,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.data.qmi.adb_logmask=0
 
-# configure adb over wifi only on the eng build
-ifneq (,$(filter eng, $(TARGET_BUILD_VARIANT)))
-PRODUCT_PROPERTY_OVERRIDES += \
-    service.adb.tcp.port=5555
-endif
-
-# Enable MultiWindow
-PRODUCT_PROPERTY_OVERRIDES += \
-    persist.sys.debug.multi_window=true
-
 # Default to LTE/GSM/WCDMA.
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.telephony.default_network=9


### PR DESCRIPTION
adboverwifi prop will be replaced by ExtendedSettings
multiwindow prop is not needed in N because this is a native feature now

Signed-off-by: David Viteri <davidteri91@gmail.com>