### PR TITLE
sony-common: remove ADBoverWIFI prop

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -167,12 +167,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.data.qmi.adb_logmask=0
 
-# configure adb over wifi only on the eng build
-ifneq (,$(filter eng, $(TARGET_BUILD_VARIANT)))
-PRODUCT_PROPERTY_OVERRIDES += \
-    service.adb.tcp.port=5555
-endif
-
 # Enable MultiWindow
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.sys.debug.multi_window=true


### PR DESCRIPTION
will be replaced by ExtendedSettings

Signed-off-by: David Viteri <davidteri91@gmail.com>