### PR TITLE
sony-common: make common-headers repo not mandatory for build

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -66,7 +66,7 @@ ifeq ($(HOST_OS),linux)
 endif
 
 BUILD_KERNEL := true
-include device/sony/common-headers/KernelHeaders.mk
+-include device/sony/common-headers/KernelHeaders.mk
 -include device/sony/common-kernel/KernelConfig.mk
 
 # Include build helpers for QCOM proprietary


### PR DESCRIPTION
this makes more easy the build for CAF and AOSP building with inline kernel-headers build system

Signed-off-by: David Viteri <davidteri91@gmail.com>