### PR TITLE
sony-common: creates fm directory

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -105,6 +105,9 @@ on post-fs-data
     mkdir /data/nfc 0770 nfc nfc
     mkdir /data/nfc/param 0770 nfc nfc
 
+    # FM Radio
+    mkdir /data/misc/fm 0770 system system
+
     chown system /dev/block/bootdevice/by-name
 
     setprop vold.post_fs_data_done 1


### PR DESCRIPTION
this is needed for fm downloaderPatch in CAF or AOSP

Signed-off-by: David Viteri <davidteri91@gmail.com>