### PR TITLE
common: Rename adb over network com property

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -338,8 +338,8 @@ on property:persist.radio.multisim.config=dsds
     enable ril-daemon2
 
 # adb over network
-on property:adb.network.port=*
-    setprop service.adb.tcp.port ${adb.network.port}
+on property:adb.network.port.es=*
+    setprop service.adb.tcp.port ${adb.network.port.es}
 
 on property:service.adb.tcp.port=5555
     stop adbd


### PR DESCRIPTION
this allows using ES alongside with the custom implementation some
custom roms use.