### PR TITLE
common: Rename adb over network com property

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -373,8 +373,8 @@ on property:init.svc.wpa_supplicant=stopped
     stop dhcpcd
 
 # adb over network
-on property:adb.network.port=*
-    setprop service.adb.tcp.port ${adb.network.port}
+on property:adb.network.port.es=*
+    setprop service.adb.tcp.port ${adb.network.port.es}
 
 on property:service.adb.tcp.port=5555
     stop adbd


### PR DESCRIPTION
this allows using ES alongside with the custom implementation some
custom roms use.