### PR TITLE
sony-common: BCM-FM: allow only BCM devices

### DIFF
--- a/brcm_fmradio/Android.mk
+++ b/brcm_fmradio/Android.mk
@@ -1,4 +1,7 @@
+ifneq ($(filter shinano kitakami loire,$(PRODUCT_PLATFORM)),)
+
 LOCAL_PATH := $(call my-dir)
 
 include $(call all-makefiles-under,$(LOCAL_PATH))
 
+endif


### PR DESCRIPTION
this avoid errors with QCOM-FM lib

Signed-off-by: David Viteri <davidteri91@gmail.com>