### PR TITLE
sony-common: update debugfs mount as AOSP

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 on early-init
-    mount debugfs debugfs /sys/kernel/debug
+    mount debugfs /sys/kernel/debug /sys/kernel/debug mode=755
 
 on init
     # Enable subsystem restart


### PR DESCRIPTION
https://android.googlesource.com/platform/system/core/+/android-6.0.1_r68/rootdir/init.rc#21

why this .... Debugfs exists as a simple way for kernel developers to make information
available to user space also it is not enabled in android-6.0.1_r66 tag and not more in N but for
development purposes it is needed here .....

Signed-off-by: David Viteri <davidteri91@gmail.com>