### PR TITLE
Fix bugs on loire fpc

### DIFF
--- a/fingerprint/fpc_imp_loire.c
+++ b/fingerprint/fpc_imp_loire.c
@@ -468,6 +468,11 @@ int fpc_capture_image()
         ret = 1000;
     }
 
+    if (device_disable() < 0) {
+        ALOGE("Error stopping device\n");
+        return -1;
+    }
+
     send_normal_command(mHandle, FPC_INIT);
     return ret;
 }
@@ -739,6 +744,11 @@ int fpc_init()
     if(result != 0)
     {
         return result;
+    }
+
+    if (device_disable() < 0) {
+        ALOGE("Error stopping device\n");
+        return -1;
     }
 
     return 1;

--- a/fingerprint/fpc_imp_loire.c
+++ b/fingerprint/fpc_imp_loire.c
@@ -409,7 +409,7 @@ int fpc_wait_finger_lost()
     if(result > 0)
         return 0;
 
-    return result;
+    return -1;
 }
 
 int fpc_wait_finger_down()


### PR DESCRIPTION
1. Disable device after init and capture
2. Fix "wait for finger lost"