### PR TITLE
[m-mr1] sony: common: Enable sched_enable_power_aware at boot stage

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -22,6 +22,7 @@ BOARD_KERNEL_CMDLINE += user_debug=31 androidboot.selinux=permissive
 BOARD_KERNEL_CMDLINE += msm_rtb.filter=0x3F ehci-hcd.park=3
 BOARD_KERNEL_CMDLINE += dwc3.maximum_speed=high dwc3_msm.prop_chg_detect=Y
 BOARD_KERNEL_CMDLINE += coherent_pool=8M
+BOARD_KERNEL_CMDLINE += sched_enable_power_aware=1
 
 TARGET_USERIMAGES_USE_EXT4 := true
 BOARD_CACHEIMAGE_FILE_SYSTEM_TYPE := ext4


### PR DESCRIPTION
Controls whether or not per-CPU power values are used in determining
task placement. If this is disabled, tasks are simply placed on the
smallest capacity CPU that will adequately meet the task's needs as
determined by the task load tracking mechanism. If this is enabled,
after a set of CPUs are determined which will meet the task's
performance needs, a CPU is selected which is reported to have the
lowest power consumption at that time.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ia3f53b8c712f872a1029a9a401020a2e8263eac0