### PR TITLE
macaddr: remove dangerous sepolicy permissions

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -237,7 +237,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # BT address
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.bt.bdaddr_path=/data/etc/bluetooth_bdaddr
+    ro.bt.bdaddr_path=/data/misc/bluetooth/bluetooth_bdaddr
 
 # System prop for NFC DT
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
Write the bluetooth macaddr to a place that is natively readable
by bluetooth services, instead of creating new locations which
requires excessive permissions.

Signed-off-by: Adam Farden <adam@farden.cz>