### PR TITLE
sony-common: add build utils for HALs

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -2,6 +2,77 @@ ifneq ($(filter yukon rhine shinano kanuti kitakami loire tone,$(PRODUCT_PLATFOR
 
 LOCAL_PATH := $(call my-dir)
 
+# vars for use by utils
+empty :=
+space := $(empty) $(empty)
+colon := $(empty):$(empty)
+underscore := $(empty)_$(empty)
+
+# $(call match-word,w1,w2)
+# checks if w1 == w2
+# How it works
+#   if (w1-w2 not empty or w2-w1 not empty) then not_match else match
+#
+# returns true or empty
+#$(warning :$(1): :$(2): :$(subst $(1),,$(2)):) \
+#$(warning :$(2): :$(1): :$(subst $(2),,$(1)):) \
+#
+define match-word
+$(strip \
+  $(if $(or $(subst $(1),$(empty),$(2)),$(subst $(2),$(empty),$(1))),,true) \
+)
+endef
+
+# $(call find-word-in-list,w,wlist)
+# finds an exact match of word w in word list wlist
+#
+# How it works
+#   fill wlist spaces with colon
+#   wrap w with colon
+#   search word w in list wl, if found match m, return stripped word w
+#
+# returns stripped word or empty
+define find-word-in-list
+$(strip \
+  $(eval wl:= $(colon)$(subst $(space),$(colon),$(strip $(2)))$(colon)) \
+  $(eval w:= $(colon)$(strip $(1))$(colon)) \
+  $(eval m:= $(findstring $(w),$(wl))) \
+  $(if $(m),$(1),) \
+)
+endef
+
+# $(call match-word-in-list,w,wlist)
+# does an exact match of word w in word list wlist
+# How it works
+#   if the input word is not empty
+#     return output of an exact match of word w in wordlist wlist
+#   else
+#     return empty
+# returns true or empty
+define match-word-in-list
+$(strip \
+  $(if $(strip $(1)), \
+    $(call match-word,$(call find-word-in-list,$(1),$(2)),$(strip $(1))), \
+  ) \
+)
+endef
+
+# $(call is-board-platform-in-list,bpl)
+# returns true or empty
+define is-board-platform-in-list
+$(call match-word-in-list,$(TARGET_BOARD_PLATFORM),$(1))
+endef
+
+# $(call is-platform-sdk-version-at-least,version)
+# version is a numeric SDK_VERSION defined above
+define is-platform-sdk-version-at-least
+$(strip \
+  $(if $(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) >= $(1) ))" )), \
+    true, \
+  ) \
+)
+endef
+
 #List of targets that use video hw
 MSM_VIDC_TARGET_LIST := msm8226 msm8916 msm8952 msm8974 msm8994 msm8996
 


### PR DESCRIPTION
DisplayHAL and MediaHAL need this

needed by commits: 44ecd1d - 0e5dbd2

needed by: hardware/qcom/media/msm8996/mm-video-v4l2/vidc/vdec/Android.mk:ifeq ($(call is-platform-sdk-version-at-least, 22),true)

picked needed part from: https://source.codeaurora.org/quic/la/device/qcom/common/tree/utils.mk?h=LA.UM.5.5.c1-00600-8x96.0

Signed-off-by: David Viteri <davidteri91@gmail.com>