### PR TITLE
[NEED TEST]sony-common: bluetooth: enable Sim Access Profile (SAP)

### DIFF
--- a/overlay/packages/apps/Bluetooth/res/values/config.xml
+++ b/overlay/packages/apps/Bluetooth/res/values/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<resources>
+    <bool name="profile_supported_sap">true</bool>
+</resources>


### PR DESCRIPTION
read more about:
http://www.android-rsap.com/bluetooth-sim-access-profile.html
http://www.android-rsap.com/compatibility.html
http://www.android-rsap.com/41-support/139-compatibility-sony.html

Signed-off-by: David Viteri <davidteri91@gmail.com>