### PR TITLE
Setup seccomp policy

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -57,6 +57,9 @@ BOARD_CHARGER_ENABLE_SUSPEND := true
 # Include an expanded selection of fonts
 EXTENDED_FONT_FOOTPRINT := true
 
+# Set seccomp policy for media server
+BOARD_SECCOMP_POLICY += device/sony/common/seccomp
+
 # Enable dex-preoptimization to speed up first boot sequence
 ifeq ($(HOST_OS),linux)
   ifneq ($(TARGET_BUILD_VARIANT),eng)

--- a/seccomp/mediacodec-seccomp.policy
+++ b/seccomp/mediacodec-seccomp.policy
@@ -1,0 +1,5 @@
+# device specific syscalls
+pselect6: 1
+eventfd2: 1
+sendto: 1
+recvfrom: 1


### PR DESCRIPTION
7.1 now makes use of minijail on kernel versions newer than 3.8, this seccomp policy allows mediaserver / meidacodecs access to the needed syscalls 