### PR TITLE
sony: common: brcm fm: Fix library path for non 64 bits targets

### DIFF
--- a/brcm_fmradio/libfmjni/Android.mk
+++ b/brcm_fmradio/libfmjni/Android.mk
@@ -20,6 +20,11 @@ LOCAL_MODULE    := libfmjni
 LOCAL_SRC_FILES := android_fm.cpp \
                    android_fmradio_Receiver.cpp
 
+ifneq ($(strip $(TARGET_ARCH)),arm64)
+LIBRARY_PATH:="/system/lib/"
+LOCAL_CFLAGS:= -DLIBRARY_PATH=\"$(LIBRARY_PATH)\"
+endif
+
 LOCAL_REQUIRED_MODULES := libfmradio.v4l2-fm brcm-uim-sysfs
 LOCAL_SHARED_LIBRARIES += liblog libnativehelper
 


### PR DESCRIPTION
it is required for shinano devices.