### PR TITLE
fmradio: fix library include on 32bit

### DIFF
--- a/brcm_fmradio/libfmjni/Android.mk
+++ b/brcm_fmradio/libfmjni/Android.mk
@@ -23,4 +23,9 @@ LOCAL_SRC_FILES := android_fm.cpp \
 LOCAL_REQUIRED_MODULES := libfmradio.v4l2-fm brcm-uim-sysfs
 LOCAL_SHARED_LIBRARIES += liblog libnativehelper
 
+ifneq ($(TARGET_ARCH),arm64)
+  LOCAL_CPPFLAGS=-DLIBRARY_PATH=\"/system/lib/\"
+  LOCAL_32_BIT_ONLY := true
+endif
+
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
- Include /system/lib instead of /system/lib64 for non 64bit arm.

actually fail on shinano (leo) with 

> I         : androidFmRadioRxGetState, state
> I         : androidFmRadioRxStart. LowFreq 87500, HighFreq 108000, DefaultFreq 100000, grid 100.
> E         : couldn't open path '/system/lib64/'
> E         : vendor registration failed
> I         : androidFmRadioThrowException, java/io/IOException ('IO Exception') @ device/sony/common/brcm_fmradio/libfmjni/android_fm.cpp 724 (androidFmRadioStart)