### PR TITLE
sony: common: brcm bt fm: Set 25 for N_BRCM_HCI

### DIFF
--- a/brcm_fmradio/brcm-uim-sysfs/include/uim.h
+++ b/brcm_fmradio/brcm-uim-sysfs/include/uim.h
@@ -166,7 +166,7 @@ typedef struct {
 #define MAX_KMODULE_PATH_SIZE 100
 #define UART_PORT_NAME_SIZE 20
 
-#define N_BRCM_HCI 26
+#define N_BRCM_HCI 25
 
 
 /* Functions to insert and remove the kernel modules from the system*/


### PR DESCRIPTION
Use the same AOSP value for UART ioctl line discipline (N_BRCM_HCI).

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I0f9fbeb9d406ffa9e28fef82aad81758650fd419