### PR TITLE
sony-common: add system group to netmgrd process

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -291,6 +291,7 @@ service qmuxd /system/vendor/bin/qmuxd
 # QCOM prop
 service netmgrd /system/vendor/bin/netmgrd
     class main
+    group system
     disabled
     writepid /dev/cpuset/system-background/tasks
 


### PR DESCRIPTION
To allow netmgrd to acquire wakelocks correctly
we need to ensure that it belongs to system group

Bug: 24546055

Change-Id: I00b9effa7351f1cd8ef9fc062de12b5276254801