### PR TITLE
sony-common: Use GID "wakelock" to control access to kernel wakelock

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -268,6 +268,7 @@ service mlog_qmi_service /system/vendor/bin/mlog_qmi_service
 service rmt_storage /system/vendor/bin/rmt_storage
     class core
     user root
+    group system wakelock
     writepid /dev/cpuset/system-background/tasks
 
 # DSDS second ril
@@ -284,14 +285,14 @@ service ril-daemon2 /system/bin/rild -c 2
 service qmuxd /system/vendor/bin/qmuxd
     class main
     user radio
-    group radio audio bluetooth gps nfc diag
+    group radio audio bluetooth wakelock gps nfc diag
     disabled
     writepid /dev/cpuset/system-background/tasks
 
 # QCOM prop
 service netmgrd /system/vendor/bin/netmgrd
     class main
-    group system
+    group system wakelock
     disabled
     writepid /dev/cpuset/system-background/tasks
 


### PR DESCRIPTION
Bug: 25864142
Change-Id: Ief59e26ce63b341115d42d0145a43a845b1645da