### PR TITLE
switch to camera HAL3

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -262,7 +262,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Camera
 PRODUCT_PROPERTY_OVERRIDES += \
-    persist.camera.HAL3.enabled=0 \
+    persist.camera.HAL3.enabled=1 \
     persist.camera.gyro.disable=1 \
     persist.camera.feature.cac=0 \
     persist.camera.ois.disable=0 \


### PR DESCRIPTION
on android 7 we have to use HAL3 as default

Signed-off-by: Alin Jerpelea <alin.jerpelea@sonymobile.com>