### PR TITLE
[master] sony: common: Update BT FM sysfs path

### DIFF
--- a/brcm_fmradio/brcm-uim-sysfs/include/uim.h
+++ b/brcm_fmradio/brcm-uim-sysfs/include/uim.h
@@ -141,12 +141,12 @@ typedef struct {
 /* Sys_fs entry. The Line discipline driver sets this to 1 when bluedroid open BT protocol driver */
 /* Note: This entry is used in bt_hci_bdroid.c (Android source). Also present in
  *  brcm_sh_ldisc.c (v4l2_drivers) and board specific file (android kernel source) */
-#define INSTALL_SYSFS_ENTRY "/sys/bus/platform/drivers/bcm_ldisc/bcmbt_ldisc.93/install"
-#define LDISC_VENDOR_PARAMS   "/sys/bus/platform/drivers/bcm_ldisc/bcmbt_ldisc.93/vendor_params"
+#define INSTALL_SYSFS_ENTRY "/sys/bus/platform/drivers/bcm_ldisc/soc:bcmbt_ldisc/install"
+#define LDISC_VENDOR_PARAMS   "/sys/bus/platform/drivers/bcm_ldisc/soc:bcmbt_ldisc/vendor_params"
 
-#define BDADDR_SYSFS_ENTRY  "/sys/bus/platform/drivers/bcm_ldisc/bcmbt_ldisc.93/bdaddr"
-#define FW_PATCHFILE_SYSFS_ENTRY  "/sys/bus/platform/drivers/bcm_ldisc/bcmbt_ldisc.93/fw_patchfile"
-#define LDISC_SYSFS_SNOOP     "/sys/bus/platform/drivers/bcm_ldisc/bcmbt_ldisc.93/snoop_enable"
+#define BDADDR_SYSFS_ENTRY  "/sys/bus/platform/drivers/bcm_ldisc/soc:bcmbt_ldisc/bdaddr"
+#define FW_PATCHFILE_SYSFS_ENTRY  "/sys/bus/platform/drivers/bcm_ldisc/soc:bcmbt_ldisc/fw_patchfile"
+#define LDISC_SYSFS_SNOOP     "/sys/bus/platform/drivers/bcm_ldisc/soc:bcmbt_ldisc/snoop_enable"
 
 /* install sysfs entry values */
 #define V4L2_STATUS_ERR '2'  // error occured in BT application (HCI command timeout or HW error)


### PR DESCRIPTION
it is a 3.18 kernel requirement.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I958a6b3ecb01b6d8f3c2ee629bba23c273d9dcdf