### PR TITLE
sony-common: Allow lid to control sleep/wake behaviour

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -202,4 +202,9 @@
          rmem_min,rmem_def,rmem_max,wmem_min,wmem_def,wmem_max -->
     <string name="config_wifi_tcp_buffers" translatable="false">524288,6291456,8291456,524288,6291456,8291456</string>
 
+    <!-- Indicate whether closing the lid causes the device to go to sleep and opening
+         it causes the device to wake up.
+         The default is false. -->
+    <bool name="config_lidControlsSleep">true</bool>
+
 </resources>


### PR DESCRIPTION
https://android.googlesource.com/platform/frameworks/base/+/android-6.0.1_r77/core/res/res/values/config.xml#661

This allows flip covers such as the Sony Smart Style Cover
to suspend or wake the device.