### PR TITLE
sony-common: Allow lid to control sleep/wake behaviour

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -205,4 +205,9 @@
     <!-- Flag indicating whether round icons should be parsed from the application manifest. -->
     <bool name="config_useRoundIcon">true</bool>
 
+    <!-- Indicate whether closing the lid causes the device to go to sleep and opening
+         it causes the device to wake up.
+         The default is false. -->
+    <bool name="config_lidControlsSleep">true</bool>
+
 </resources>


### PR DESCRIPTION
https://android.googlesource.com/platform/frameworks/base/+/android-7.1.1_r6/core/res/res/values/config.xml#688

This allows flip covers such as the Sony Smart Style Cover
to suspend or wake the device.