### PR TITLE
sony-common: enable sdcardFS support

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -278,3 +278,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
     debug.qualcomm.sns.daemon=0 \
     debug.qualcomm.sns.hal=0 \
     debug.qualcomm.sns.libsensor1=0
+
+# sdcardFS
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.sys.sdcardfs=true


### PR DESCRIPTION
https://android.googlesource.com/platform/system/core/+/android-7.0.0_r24/sdcard/sdcard.c#96

Signed-off-by: David Viteri <davidteri91@gmail.com>