### PR TITLE
common: init: Rewrite and fix the init_sony configuration safeties

### DIFF
--- a/init/Android.mk
+++ b/init/Android.mk
@@ -12,6 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Abort if the device is not handled by init_sony
+ifeq (,$(findstring DEV_BLOCK_FOTA_NUM,$(BOARD_SONY_INIT_FLAGS)))
+$(error device-sony-common-init: DEV_BLOCK_FOTA_NUM missing in "$(TARGET_DEVICE)", platform "$(PRODUCT_PLATFORM)", with '$(BOARD_SONY_INIT_FLAGS)')
+endif
+
+# Debug current init_sony settings
+$(info device-sony-common-init: init_sony for "$(TARGET_DEVICE)", platform "$(PRODUCT_PLATFORM)", with '$(BOARD_SONY_INIT_FLAGS)')
+
 # Init overrides for init_sony
 root_init      := $(TARGET_ROOT_OUT)/init
 root_init_real := $(TARGET_ROOT_OUT)/init.real

--- a/init/config.mk
+++ b/init/config.mk
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Flag: FOTA number set
-fota_num_set := false
-
 # Init configuration for init_sony
 BOARD_SONY_INIT_FLAGS :=
 BOARD_SONY_INIT_INCLUDE := $(COMMON_PATH)/include
@@ -23,38 +20,31 @@ BOARD_SONY_INIT_INCLUDE := $(COMMON_PATH)/include
 ifneq ($(filter yukon,$(PRODUCT_PLATFORM)),)
 ifneq ($(filter eagle,$(TARGET_DEVICE)),)
 BOARD_SONY_INIT_FLAGS += -DDEV_BLOCK_FOTA_NUM="22"
-fota_num_set := true
 endif
 ifneq ($(filter flamingo,$(TARGET_DEVICE)),)
 BOARD_SONY_INIT_FLAGS += -DDEV_BLOCK_FOTA_NUM="18"
-fota_num_set := true
 endif
 ifneq ($(filter seagull,$(TARGET_DEVICE)),)
 BOARD_SONY_INIT_FLAGS += -DDEV_BLOCK_FOTA_NUM="21"
-fota_num_set := true
 endif
 ifneq ($(filter tianchi,$(TARGET_DEVICE)),)
 BOARD_SONY_INIT_FLAGS += -DDEV_BLOCK_FOTA_NUM="16"
-fota_num_set := true
 endif
 endif
 
 # Board: rhine
 ifneq ($(filter rhine,$(PRODUCT_PLATFORM)),)
 BOARD_SONY_INIT_FLAGS += -DDEV_BLOCK_FOTA_NUM="16"
-fota_num_set := true
 endif
 
 # Board: shinano
 ifneq ($(filter shinano,$(PRODUCT_PLATFORM)),)
 BOARD_SONY_INIT_FLAGS += -DDEV_BLOCK_FOTA_NUM="16"
-fota_num_set := true
 endif
 
 # Board: kanuti
 ifneq ($(filter kanuti,$(PRODUCT_PLATFORM)),)
 BOARD_SONY_INIT_FLAGS += -DDEV_BLOCK_FOTA_NUM="21"
-fota_num_set := true
 endif
 
 # Board: kitakami
@@ -62,7 +52,6 @@ ifneq ($(filter kitakami,$(PRODUCT_PLATFORM)),)
 BOARD_SONY_INIT_FLAGS += -DDEV_BLOCK_FOTA_NUM="32"
 BOARD_SONY_INIT_FLAGS += -DDEV_BLOCK_FOTA_MAJOR="259"
 BOARD_SONY_INIT_FLAGS += -DDEV_BLOCK_FOTA_MINOR="0"
-fota_num_set := true
 endif
 
 # Board: loire
@@ -71,22 +60,12 @@ ifneq ($(filter kugo,$(TARGET_DEVICE)),)
 BOARD_SONY_INIT_FLAGS += -DDEV_BLOCK_FOTA_NUM="46"
 BOARD_SONY_INIT_FLAGS += -DDEV_BLOCK_FOTA_MAJOR="259"
 BOARD_SONY_INIT_FLAGS += -DDEV_BLOCK_FOTA_MINOR="14"
-fota_num_set := true
 else
 BOARD_SONY_INIT_FLAGS += -DDEV_BLOCK_FOTA_NUM="42"
 BOARD_SONY_INIT_FLAGS += -DDEV_BLOCK_FOTA_MAJOR="259"
 BOARD_SONY_INIT_FLAGS += -DDEV_BLOCK_FOTA_MINOR="10"
-fota_num_set := true
 endif
 endif
-
-# Abort if the device is not handled
-ifneq ($(fota_num_set),true)
-$(error device-sony-common-init: DEV_BLOCK_FOTA_NUM missing for "$(TARGET_DEVICE)", platform "$(PRODUCT_PLATFORM)")
-endif
-
-# Debug current init_sony settings
-$(info device-sony-common-init: init_sony for "$(TARGET_DEVICE)", platform "$(PRODUCT_PLATFORM)", with $(BOARD_SONY_INIT_FLAGS))
 
 # FOTA check is broken on all devices
 BOARD_SONY_INIT_FLAGS += -DFOTA_RAMDISK_CHECK="0"


### PR DESCRIPTION
 * Avoid showing the 'info device-sony-common-init:' on lunch config
 * Handle the missing DEV_BLOCK_FOTA_NUM in init/Android.mk
 * Fix an error appearing on 6.0 build/ involving TARGET_ARCH detection

Change-Id: Ic11d39b81013413c84aefef255a7e802ceb17a73
Signed-off-by: Adrian DC <radian.dc@gmail.com>