### PR TITLE
sony-common: cameraHAL: Advertize correct timestamp source

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -268,7 +268,8 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.camera.gyro.disable=1 \
     persist.camera.feature.cac=0 \
     persist.camera.ois.disable=0 \
-    persist.camera.zsl.mode=1
+    persist.camera.zsl.mode=1 \
+    persist.camera.time.monotonic=0
 
 ifneq ($(filter shinano rhine, $(SOMC_PLATFORM)),)
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
from kernel ISP uses boot time https://github.com/sonyxperiadev/kernel/commit/80c65b30f9e9e3b01ac9c39b30d813248f4b0d05
set boot time as default

HAL1 8974

12-27 10:27:51.063  5594  5630 D CAM_MemoryQuery: timestamp=159955, availMem=866, totalMem=1687, totalPSS=15, lastTrimLevel=0, largeMemoryClass=512, nativePSS=2, dalvikPSS=6, otherPSS=7,threshold=144, lowMemory=false
12-27 10:27:51.493   396  5677 D mm-camera: mct: start_sof_check_thread: Starting SOF timeout thread
12-27 10:27:55.883   396  5677 D mm-camera: mct: stop_sof_check_thread: Stopping SOF timeout thread

HAL3 8994

12-27 10:34:11.786  5206  5341 D CAM_MemoryQuery: timestamp=278646, availMem=1729, totalMem=2696, totalPSS=31, lastTrimLevel=0, largeMemoryClass=512, nativePSS=8, dalvikPSS=12, otherPSS=11,threshold=216, lowMemory=false
12-27 10:34:13.129  1062  5233 D Camera3-Device: Set real time priority for request queue thread (tid 5434)
12-27 10:34:13.358   528  5423 D mm-camera: mct: start_sof_check_thread: Starting SOF timeout thread
12-27 10:34:18.975   528  5423 D mm-camera: mct: stop_sof_check_thread: Stopping SOF timeout thread

Signed-off-by: David Viteri <davidteri91@gmail.com>