### PR TITLE
sony-common: cameraHAL: Advertize correct timestamp source

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -270,7 +270,8 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.camera.gyro.disable=1 \
     persist.camera.feature.cac=0 \
     persist.camera.ois.disable=0 \
-    persist.camera.zsl.mode=1
+    persist.camera.zsl.mode=1 \
+    persist.camera.time.monotonic=0
 
 # Sensors debug
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
from kernel ISP uses boot time sonyxperiadev/kernel@80c65b3
set boot time as default

Signed-off-by: David Viteri <davidteri91@gmail.com>