### PR TITLE
sony: common: Tunning swappiness

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -47,6 +47,7 @@ on init
     write /sys/block/zram0/comp_algorithm lz4
     write /sys/block/zram0/max_comp_streams 4
     write /proc/sys/vm/page-cluster 0
+    write /proc/sys/vm/swappiness 100
 
 on post-fs-data
     # Create directory used by bluetooth subsystem


### PR DESCRIPTION
This control is used to define how aggressive the kernel will
swap memory pages throught zRAM.

Up to 100
Default is 60

the logic of this patch is to force the kernel to addresses the memory pages
to zram block available (compressed memory way), consequently,
this increases the amount available memory to system.

Signed-off-by: Humberto Borba <humberos@gmail.com>