### PR TITLE
common: hals: Add WLAN qcwcn HAL inclusion

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -91,4 +91,8 @@ include $(call all-makefiles-under,$(audio-hal))
 include $(call all-makefiles-under,$(gps-hal))
 include $(call all-makefiles-under,$(media-hal))
 
+ifeq ($(BOARD_WLAN_DEVICE),qcwcn)
+  include $(call all-makefiles-under,hardware/qcom/wlan/qcwcn)
+endif
+
 endif


### PR DESCRIPTION
 * The HAL in hardware/qcom/wlan/qcwcn is blocked
    under TARGET_BOARD_AUTO, therefore it needs
    to be explicitely called for devices needing it

Change-Id: Ia97b656d4ee01507c79f5ed267f045265d7ec8f0
Signed-off-by: Adrian DC <radian.dc@gmail.com>