### PR TITLE
common: hals: Use 8994 HALs for 8974 boards

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -81,10 +81,19 @@ MASTER_SIDE_CP_TARGET_LIST := msm8996
 
 include $(call all-makefiles-under,$(LOCAL_PATH))
 
+# Platform common HALs
 audio-hal := hardware/qcom/audio
-display-hal := hardware/qcom/display/msm8996
-gps-hal := hardware/qcom/gps/msm8994
-media-hal := hardware/qcom/media/msm8996
+
+# Platform specific HALs
+ifeq ($(TARGET_BOARD_PLATFORM),msm8974)
+  display-hal := hardware/qcom/display/msm8994
+  gps-hal := hardware/qcom/gps/msm8994
+  media-hal := hardware/qcom/media/msm8994
+else
+  display-hal := hardware/qcom/display/msm8996
+  gps-hal := hardware/qcom/gps/msm8994
+  media-hal := hardware/qcom/media/msm8996
+endif
 
 include $(display-hal)/Android.mk
 include $(call all-makefiles-under,$(audio-hal))


### PR DESCRIPTION
 * When building for 8974, use a different set of HALs

Change-Id: Ib6457e88efea253b4a0b7178c7a391f13da08661
Signed-off-by: Adrian DC <radian.dc@gmail.com>