### PR TITLE
Sony-common: build gps location from repo

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -134,7 +134,12 @@ PRODUCT_PACKAGES += \
 
 # QCOM OSS
 PRODUCT_PACKAGES += \
-   librmnetctl
+    librmnetctl
+
+# QCOM GPS
+PRODUCT_PACKAGES += \
+    libloc_api_v02 \
+    libloc_ds_api
 
 # Charger
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Do not use prebuilt libs anymore

Signed-off-by: David Viteri <davidteri91@gmail.com>