### PR TITLE
sony-common: disable CHARGER_INIT_BLANK

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -57,6 +57,7 @@ BOARD_VENDOR_QCOM_LOC_PDK_FEATURE_SET := true
 TARGET_NO_RPC := true
 
 # Charger
+BOARD_CHARGER_DISABLE_INIT_BLANK := true
 BOARD_CHARGER_ENABLE_SUSPEND := true
 
 # Include an expanded selection of fonts


### PR DESCRIPTION
when you connect AC charger (when device is off) the display show battery charge image (AOSP) and then it rest on
this help us to fix it ... unfortunatelly when you hold power button to see charge image again the display rest on again

Signed-off-by: David Viteri <davidteri91@gmail.com>