### PR TITLE
sony-common: fpc: loire: fix warning in build

### DIFF
--- a/fingerprint/fpc_imp_loire.c
+++ b/fingerprint/fpc_imp_loire.c
@@ -41,7 +41,7 @@ static struct QSEECom_handle * mHdl;
 
 static int qsee_load_trustlet(struct QSEECom_handle **clnt_handle,
                        const char *path, const char *fname,
-                       uint32_t sb_size)
+                       uint32_t __attribute__((unused))sb_size)
 {
     int ret = 0;
     char* errstr;


### PR DESCRIPTION
evice/sony/common/fingerprint/fpc_imp_loire.c:44:33: warning: unused parameter 'sb_size' [-Wunused-parameter]
                       uint32_t sb_size)

Signed-off-by: David Viteri <davidteri91@gmail.com>