### PR TITLE
sony-common: audio: add audio related property overrides

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -249,6 +249,14 @@ PRODUCT_PROPERTY_OVERRIDES += \
     media.aac_51_output_enabled=true \
     audio.deep_buffer.media=1
 
+# Reduce client buffer size for fast audio output tracks
+PRODUCT_PROPERTY_OVERRIDES += \
+    af.fast_track_multiplier=1
+
+# Low latency audio buffer size in frames
+PRODUCT_PROPERTY_OVERRIDES += \
+    audio_hal.period_size=192
+
 # Property to enable user to access Google WFD settings.
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.debug.wfd.enable=1


### PR DESCRIPTION
override audio_hal.period_size and audio_hal.period_size
properties to optimize the playback latency.

Change-Id: Ifdb748af8b702320990e2aaa50a2c95648f60906