### PR TITLE
sony-common: build: configure BT for 8916

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -92,7 +92,11 @@ include $(call all-makefiles-under,$(gps-hal))
 include $(call all-makefiles-under,$(media-hal))
 
 ifeq ($(BOARD_HAVE_BLUETOOTH_QCOM),true)
-  include $(call all-makefiles-under,hardware/qcom/bt)
+ifneq ($(filter rhine,$(PRODUCT_PLATFORM)),)
+  include $(call all-makefiles-under,hardware/qcom/bt/msm8960)
+else
+  include $(call all-makefiles-under,hardware/qcom/bt/msm8992)
+endif
 endif
 ifeq ($(BOARD_WLAN_DEVICE),qcwcn)
   include $(call all-makefiles-under,hardware/qcom/wlan/qcwcn)


### PR DESCRIPTION
rhine uses 8960
kanuti uses 8992

Signed-off-by: David Viteri <davidteri91@gmail.com>