### PR TITLE
Revert "sony-common: cameraHAL: Advertize correct timestamp source"

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -286,8 +286,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.camera.stats.af.paaf=0 \
     persist.camera.feature.cac=0 \
     persist.camera.ois.disable=0 \
-    persist.camera.zsl.mode=1 \
-    persist.camera.time.monotonic=0
+    persist.camera.zsl.mode=1
 
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.camera.HAL3.enabled=0 \


### PR DESCRIPTION
This reverts commit 255373136ae19af395eeff0d996f2787ba974643.

sometimes after record 1080p videos and playback the display rest freeze at first frame