### PR TITLE
sony-common: fix mediaHAL path

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -84,7 +84,7 @@ include $(call all-makefiles-under,$(LOCAL_PATH))
 audio-hal := hardware/qcom/audio
 display-hal := hardware/qcom/display/msm8994
 gps-hal := hardware/qcom/gps/msm8994
-media-hal := hardware/qcom/media/msm8994
+media-hal := hardware/qcom/media/msm8974
 
 include $(display-hal)/Android.mk
 include $(call all-makefiles-under,$(audio-hal))


### PR DESCRIPTION
with this you are saying GOOD BYE QCOM encoders/decoders
FIX IT

Signed-off-by: David Viteri <davidteri91@gmail.com>