### PR TITLE
Rename brcm_fmradio parameter UartPort to UimUartPort.

### DIFF
--- a/brcm_fmradio/brcm-uim-sysfs/uim.c
+++ b/brcm_fmradio/brcm-uim-sysfs/uim.c
@@ -481,7 +481,7 @@ typedef struct {
  * Currently supported entries in vendor_conf and corresponding action functions
  */
 static const conf_entry_t vendor_conf_table[] = {
-    {"UartPort", userial_set_port},
+    {"UimUartPort", userial_set_port},
     {"UartBaudRate", hw_set_uart_baudrate},
     {"FwPatchSettlementDelay", hw_set_patchram_settlement_delay},
     {"LpmWakePolarity",hw_set_lpm_polarity},


### PR DESCRIPTION
This allows to pass the brcm device node to libbt (uses UartPort) such
that the BT data flow is routed through the kernel ldisc driver. As a
consequence parallel use of BT & FMRadio is possible. The Uim service
needs to be aware of the "real" Uart device node instead.
Use the same naming as in I2c0c8f3016415fac5f2c68b9a33a75b2687d8a87

Change-Id: I08a1c72f3955429fa7c8d93e57f219782b1db467
Signed-off-by: Alexander Diewald <Diewi@diewald-net.com>