### PR TITLE
overlay: Enable GPRS and EDGE

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -180,7 +180,7 @@
          Empty is viewed as "all".  Only used on devices which
          don't support RIL_REQUEST_GET_RADIO_CAPABILITY
          format is UMTS|LTE|... -->
-    <string translatable="false" name="config_radio_access_family">GSM | WCDMA | LTE</string>
+    <string translatable="false" name="config_radio_access_family">GSM | GPRS | EDGE | WCDMA | LTE</string>
 
     <!-- Configure mobile tcp buffer sizes in the form:
          rat-name:rmem_min,rmem_def,rmem_max,wmem_min,wmem_def,wmem_max


### PR DESCRIPTION
RadioAccessFamily only selects RAF_GSM, not the grouped GSM.

See https://github.com/android/platform_frameworks_base/blob/master/telephony/java/android/telephony/RadioAccessFamily.java#L363