### PR TITLE
common: Rename & set rfkilldisabled property for brcm_fmradio.

### DIFF
--- a/brcm_fmradio/brcm-uim-sysfs/upio.c
+++ b/brcm_fmradio/brcm-uim-sysfs/upio.c
@@ -93,7 +93,7 @@ static int is_rfkill_disabled(void)
 {
     char value[PROPERTY_VALUE_MAX];
 
-    property_get("ro.rfkilldisabled", value, "0");
+    property_get("ro.rfkilldisableduim", value, "0");
     UPIODBG("is_rfkill_disabled ? [%s]", value);
 
     if (strcmp(value, "1") == 0) {

--- a/common.mk
+++ b/common.mk
@@ -304,3 +304,9 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # sdcardFS
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.sys.sdcardfs=true
+
+# BT/FMRadio
+ifeq ($(filter rhine kanuti,$(SOMC_PLATFORM)),)
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.rfkilldisabled=1
+endif


### PR DESCRIPTION
Rename rfkilldisabled to rfkilldisableduim in the parsing code
of UIM such that we can set rfkilldisabled in the build.prop to
stop android's bt implementation to mess around with the chip's
power states.
This allows to enable BT while the FMRadio is on.

Change-Id: I6639e21ee4c1ca592ed70f417c825ed2a987be71
Signed-off-by: Alexander Diewald <Diewi@diewald-net.com>