### PR TITLE
sony-common: add guard to selinux

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -23,11 +23,13 @@ TARGET_NO_RECOVERY := false
 TARGET_NO_KERNEL := false
 
 # common cmdline parameters
-BOARD_KERNEL_CMDLINE += user_debug=31 androidboot.selinux=permissive
+ifneq ($(BOARD_USE_ENFORCING_SELINUX),true)
+BOARD_KERNEL_CMDLINE += androidboot.selinux=permissive
+endif
 BOARD_KERNEL_CMDLINE += msm_rtb.filter=0x3F ehci-hcd.park=3
 BOARD_KERNEL_CMDLINE += dwc3.maximum_speed=high dwc3_msm.prop_chg_detect=Y
 BOARD_KERNEL_CMDLINE += coherent_pool=8M
-BOARD_KERNEL_CMDLINE += sched_enable_power_aware=1
+BOARD_KERNEL_CMDLINE += sched_enable_power_aware=1 user_debug=31
 
 TARGET_USERIMAGES_USE_EXT4 := true
 BOARD_CACHEIMAGE_FILE_SYSTEM_TYPE := ext4

--- a/brcm_fmradio/brcm-uim-sysfs/upio.c
+++ b/brcm_fmradio/brcm-uim-sysfs/upio.c
@@ -93,7 +93,7 @@ static int is_rfkill_disabled(void)
 {
     char value[PROPERTY_VALUE_MAX];
 
-    property_get("ro.rfkilldisableduim", value, "0");
+    property_get("ro.rfkilldisabled.uim", value, "0");
     UPIODBG("is_rfkill_disabled ? [%s]", value);
 
     if (strcmp(value, "1") == 0) {


### PR DESCRIPTION
if BOARD_USE_ENFORCING_SELINUX := true is defined then you will use Enforcing SELinux

Signed-off-by: David Viteri <davidteri91@gmail.com>