### PR TITLE
common: RIL: build libprotobuf-cpp-full

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -156,6 +156,10 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     libemoji
 
+# RIL
+PRODUCT_PACKAGES += \
+    libprotobuf-cpp-full
+
 # ExtendedSettings
 PRODUCT_PACKAGES += \
     ExtendedSettings


### PR DESCRIPTION
this libs is a dependency for the new libril used by the new libs for android 7.0

Change-Id: Ic4e7ab93d521673de874abd8ac7310829d674d65