### PR TITLE
sony: common: tone: Remove BCM BT/FM requirement

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -306,7 +306,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.sys.sdcardfs=true
 
 # BT/FMRadio
-ifeq ($(filter rhine kanuti,$(SOMC_PLATFORM)),)
+ifeq ($(filter rhine kanuti tone,$(SOMC_PLATFORM)),)
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.rfkilldisabled=1
 endif


### PR DESCRIPTION
Tone does not have BCM BT/FM at all.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Id6d72d6ec484c1ef05cd94880f86a425a0332faa