### PR TITLE
init: Adapt toybox_static location for AOSP O

### DIFF
--- a/init/Android.mk
+++ b/init/Android.mk
@@ -27,8 +27,8 @@ root_init_real := $(TARGET_ROOT_OUT)/init.real
 # If /init is a file and not a symlink then rename it to /init.real
 # and make /init be a symlink to /sbin/init_sony (which will execute
 # /init.real, if appropriate.
-$(root_init_real): $(root_init) $(PRODUCT_OUT)/utilities/toybox $(PRODUCT_OUT)/utilities/keycheck $(PRODUCT_OUT)/utilities/init_sony
-	cp $(PRODUCT_OUT)/utilities/toybox $(TARGET_ROOT_OUT)/sbin/toybox_init
+$(root_init_real): $(root_init) $(TARGET_RECOVERY_ROOT_OUT)/sbin/toybox_static $(PRODUCT_OUT)/utilities/keycheck $(PRODUCT_OUT)/utilities/init_sony
+	cp $(TARGET_RECOVERY_ROOT_OUT)/sbin/toybox_static $(TARGET_ROOT_OUT)/sbin/toybox_init
 	cp $(PRODUCT_OUT)/utilities/keycheck $(TARGET_ROOT_OUT)/sbin/keycheck
 	cp $(PRODUCT_OUT)/utilities/init_sony $(TARGET_ROOT_OUT)/sbin/init_sony
 	$(hide) if [ ! -L $(root_init) ]; then \


### PR DESCRIPTION
 * Introduced in AOSP master in platform/external/toybox,
    commit I589c4a248e135c6c0e25aadd063717c87369ef40,
    toybox_static is now part of the AOSP original packages,
    therefore adapt the binary's location and use it

Change-Id: I0b861de24c24efe47bbff1d8ae80c7c818d77b9c