### PR TITLE
[COMMON] Remove the platform-specific lpm_levels cmdline

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -27,7 +27,6 @@ ifneq ($(BOARD_USE_ENFORCING_SELINUX),true)
 BOARD_KERNEL_CMDLINE += androidboot.selinux=permissive
 endif
 BOARD_KERNEL_CMDLINE += console=ttyMSM0,115200,n8 androidboot.console=ttyMSM0
-BOARD_KERNEL_CMDLINE += lpm_levels.sleep_disabled=1
 BOARD_KERNEL_CMDLINE += msm_rtb.filter=0x3F ehci-hcd.park=3
 BOARD_KERNEL_CMDLINE += dwc3.maximum_speed=high dwc3_msm.prop_chg_detect=Y
 BOARD_KERNEL_CMDLINE += coherent_pool=8M


### PR DESCRIPTION
This cmdline option is now platform-specific: on kernel 4.4
Tone needs it disabled.
This option is moved to platform configuration.