### PR TITLE
[URGENT] [COMMON] Ensure directory creation and correct perms for PowerServer

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -110,6 +110,11 @@ on post-fs-data
 
     # FM Radio
     mkdir /data/misc/fm 0770 system system
+    
+    # RQBalance-PowerHAL PowerServer
+    mkdir /data/misc/powerhal
+    chmod 0773 /data/misc/powerhal
+    chown system system /data/misc/powerhal
 
     chown system /dev/block/bootdevice/by-name
 


### PR DESCRIPTION
RQBalance-PowerHAL PowerServer will create it automatically
but, for some reason, on some Android versions the directory
will be created with wrong permissions.
Fix this by paranoidly ensuring directory creation and by doing
permission changes at init time.

IMPORTANT NOTE:
Do NOT use "mkdir powerhal 0773 system system": as I wrote,
the directory may be already there at that time!!