### PR TITLE
[COMMON] Add the QC FastRPC adsprpc daemon

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -332,6 +332,12 @@ service qseecomd /system/vendor/bin/qseecomd
     group root
     writepid /dev/cpuset/system-background/tasks
 
+# QCOM ADSP FastRPC
+service adsprpcd /system/vendor/bin/adsprpcd
+   class main
+   user media
+   group media
+
 # OSS thermal management
 service thermanager /system/bin/thermanager /system/etc/thermanager.xml
     class main


### PR DESCRIPTION
This daemon is responsible for FastRPC offloading from CPU to
Hexagon DSP. This is actually a strict requirement for ACDB
calibrations to work for phone calls (otherwise ADSP fails).