### PR TITLE
[URGENT] RQBalance-PowerHAL locking logic fix

### DIFF
--- a/power/rqbalance_halext.c
+++ b/power/rqbalance_halext.c
@@ -265,7 +265,9 @@ int new_lock_init(unsigned int time, unsigned short type, int state)
 
 	/* If lock is already present */
 	ret = get_locktype_by_type(type);
-	if (ret) {
+	if (ret < 0) {
+		luid = rand();
+	} else {
 		locknum = ret;
 		luid = current_locks[locknum].luid;
 
@@ -273,8 +275,6 @@ int new_lock_init(unsigned int time, unsigned short type, int state)
 			start_timer(current_locks[locknum].tid, time);
 
 		goto do_action;
-	} else {
-		luid = rand();
 	}
 
 	number_of_locks++;

--- a/power/rqbalance_halext.c
+++ b/power/rqbalance_halext.c
@@ -441,7 +441,7 @@ int halext_perf_lock_acquire(struct rqbalance_halext_params *params)
 		lock_state = (params->argument[0] & 0xff);
 
 		return new_lock_init((unsigned int)params->time,
-					lock_type, lock_state);
+					(unsigned short)lock_type, lock_state);
 	}
 
 	for (i = 0; i <= arraysz; i++) {


### PR DESCRIPTION
During some commit porting for final release, a logic inversion happened in the search functions, but that change was not reflected in the usage of one of those functions in new_lock_init, producing a complete breakage of the RQBalance-PowerHAL locking logic and Advanced Power Hints.

This fix has been tested on SoMC Maple and has to be merged ASAP for decreasing heat and power consumption in the handled cases.