### PR TITLE
[COMMON] healthd: Fix includes for Android 8.0

### DIFF
--- a/healthd/Android.mk
+++ b/healthd/Android.mk
@@ -7,6 +7,8 @@ LOCAL_MODULE := libhealthd.$(TARGET_DEVICE)
 LOCAL_CFLAGS := -Werror
 LOCAL_C_INCLUDES := \
     system/core/healthd/include \
+    system/core/base/include \
+    bootable/recovery/minui/include \
     bootable/recovery
 
 include $(BUILD_STATIC_LIBRARY)

--- a/power/Android.mk
+++ b/power/Android.mk
@@ -24,8 +24,7 @@ endif
 LOCAL_C_INCLUDES := external/expat/lib
 
 LOCAL_SRC_FILES := power.c rqbalance_halext.c expatparser.c
-LOCAL_SHARED_LIBRARIES := liblog libcutils
-LOCAL_STATIC_LIBRARIES := libexpat_static
+LOCAL_SHARED_LIBRARIES := liblog libcutils libexpat
 LOCAL_MODULE := power.$(TARGET_DEVICE)
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_RELATIVE_PATH := hw


### PR DESCRIPTION
Now we need to include system/core/include as well because of
nested header inclusion changes, at least in frameworks/native and
also, some headers were moved to proper locations (minui etc).