### PR TITLE
rootdir: init.common.usb.rc: remove unneeded mkdir call

### DIFF
--- a/rootdir/init.common.usb.rc
+++ b/rootdir/init.common.usb.rc
@@ -17,7 +17,6 @@ on boot
     write /sys/class/android_usb/android0/iManufacturer ${ro.product.manufacturer}
     write /sys/class/android_usb/android0/f_rndis/manufacturer ${ro.product.manufacturer}
     write /sys/class/android_usb/android0/iProduct ${ro.product.model}
-    mkdir /config 0770 shell shell
     mkdir /dev/usb-ffs 0770 shell shell
     mkdir /dev/usb-ffs/adb 0770 shell shell
     mount configfs none /config


### PR DESCRIPTION
The folder /config is already created at this point in the boot process, so no need to do that again.
Not only that, but the permissions declared in the mkdir call are wrong for Android.
Android can then not write to /config, and as a result cannot configure /config/sdcardfs.

Change-Id: I001f73adcebb550748ce18fc40b69033ba1e5aa4