### PR TITLE
sony: common: init: Remove max_comp_streams

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -49,7 +49,6 @@ on init
 
     # Setup zram options
     write /sys/block/zram0/comp_algorithm lz4
-    write /sys/block/zram0/max_comp_streams 4
     write /proc/sys/vm/page-cluster 0
 
 on post-fs-data


### PR DESCRIPTION
It should be added per platform.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Id6eead02b09ef902e1c5678ca66584e2c68f35f8