### PR TITLE
sony-common: add BOARD_IS_AUTOMOTIVE needed by our Android.mk

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -19,6 +19,7 @@ COMMON_PATH := device/sony/common
 TARGET_USES_AOSP := true
 
 TARGET_BOARD_AUTO := true
+BOARD_IS_AUTOMOTIVE := true
 
 TARGET_NO_RADIOIMAGE := true
 TARGET_NO_BOOTLOADER := true


### PR DESCRIPTION
to override qcom repos

this is used like TARGET_BOARD_AUTO in hardware/qcom/gps

Signed-off-by: David Viteri <davidteri91@gmail.com>