### PR TITLE
wifi: Add wificond to products

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -115,6 +115,7 @@ PRODUCT_PACKAGES += \
     p2p_supplicant.conf \
     hostapd \
     libwpa_client \
+    wificond \
     wpa_supplicant \
     wpa_supplicant.conf
 


### PR DESCRIPTION
We need our new wifi native daemon wificond for Android O.
This CL gets it installed on the device.

BUG=29220405
TEST=compile

Change-Id: Ibba0329777f78217f6d11f4cb2ad1305661d2097