### PR TITLE
use /charger symlink to launch healthd

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -349,10 +349,10 @@ service thermanager /system/bin/thermanager /system/etc/thermanager.xml
     writepid /dev/cpuset/system-background/tasks
 
 # Offline charger
-service charger /sbin/healthd -c
+service charger /charger
     class charger
     critical
-    seclabel u:r:healthd:s0
+    seclabel u:r:charger:s0
     writepid /dev/cpuset/system-background/tasks
 
 # OSS time


### PR DESCRIPTION
Makes this consistent with other targets and maken sure
any changes in healthd will be transparent to targets as long
as the symlink is maintained.

Update the seclabel accordingly too.

Test: Tested charge-only mode on angler

Change-Id: Ic71e32f52c39bc45eae8d2552259695934592fc7
Signed-off-by: Sandeep Patil <sspatil@google.com>