### PR TITLE
sony-common: fix rild-daemon2

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -291,7 +291,7 @@ service rmt_storage /system/vendor/bin/rmt_storage
     writepid /dev/cpuset/system-background/tasks
 
 # DSDS second ril
-service ril-daemon2 /system/bin/rild -c 2
+service ril-daemon2 /system/vendor/bin/hw/rild -c 2
     class main
     socket rild2 stream 660 root radio
     socket sap_uim_socket2 stream 660 bluetooth bluetooth


### PR DESCRIPTION
kugo:/vendor/bin/hw # ls
android.hardware.configstore@1.0-service  android.hardware.media.omx@1.0-service  rild  wpa_supplicant

Signed-off-by: David Viteri <davidteri91@gmail.com>