### PR TITLE
sony-common: libeffects: move all libraries to vendor

### DIFF
--- a/rootdir/system/vendor/etc/audio_effects.conf
+++ b/rootdir/system/vendor/etc/audio_effects.conf
@@ -7,31 +7,31 @@
 #    }
 libraries {
   bundle {
-    path /system/lib/soundfx/libbundlewrapper.so
+    path /system/vendor/lib/soundfx/libbundlewrapper.so
   }
   reverb {
-    path /system/lib/soundfx/libreverbwrapper.so
+    path /system/vendor/lib/soundfx/libreverbwrapper.so
   }
   visualizer_sw {
-    path /system/lib/soundfx/libvisualizer.so
+    path /system/vendor/lib/soundfx/libvisualizer.so
   }
   visualizer_hw {
-    path /system/lib/soundfx/libqcomvisualizer.so
+    path /system/vendor/lib/soundfx/libqcomvisualizer.so
   }
   downmix {
-    path /system/lib/soundfx/libdownmix.so
+    path /system/vendor/lib/soundfx/libdownmix.so
   }
   proxy {
-    path /system/lib/soundfx/libeffectproxy.so
+    path /system/vendor/lib/soundfx/libeffectproxy.so
   }
   offload_bundle {
-    path /system/lib/soundfx/libqcompostprocbundle.so
+    path /system/vendor/lib/soundfx/libqcompostprocbundle.so
   }
   qcom_pre_processing {
-    path /system/lib/soundfx/libqcomvoiceprocessing.so
+    path /system/vendor/lib/soundfx/libqcomvoiceprocessing.so
   }
   loudness_enhancer {
-    path /system/lib/soundfx/libldnhncr.so
+    path /system/vendor/lib/soundfx/libldnhncr.so
   }
 }
 
@@ -39,7 +39,7 @@ libraries {
 # audio HAL implements support for default software audio pre-processing effects
 #
 #  pre_processing {
-#    path /system/lib/soundfx/libaudiopreprocessing.so
+#    path /system/vendor/lib/soundfx/libaudiopreprocessing.so
 #  }
 
 # list of effects to load. Each effect element must contain a "library" and a "uuid" element.


### PR DESCRIPTION
Signed-off-by: David Viteri <davidteri91@gmail.com>