### PR TITLE
sony-common: seccomp: remove unneeded llssek syscall

### DIFF
--- a/seccomp_policy/mediacodec.policy
+++ b/seccomp_policy/mediacodec.policy
@@ -1,7 +1,5 @@
 # device specific syscalls
-# extension of services/mediacodec/minijail/seccomp_policy/mediacodec-arm.policy
 pselect6: 1
 eventfd2: 1
 sendto: 1
 recvfrom: 1
-_llseek: 1


### PR DESCRIPTION
04-19 12:43:38.399   587   587 W /system/bin/mediaextractor: libminijail[587]: compile_file: nonexistent syscall '_llseek'

Signed-off-by: David Viteri <davidteri91@gmail.com>