### PR TITLE
sony-common: Restrict HAL implementation access to only /data/vendor/nfc

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -112,6 +112,7 @@ on post-fs-data
     # Local data and nfcee xml storage
     mkdir /data/nfc 0770 nfc nfc
     mkdir /data/nfc/param 0770 nfc nfc
+    mkdir /data/vendor/nfc 0770 nfc nfc
 
     # FM Radio
     mkdir /data/misc/fm 0770 system system


### PR DESCRIPTION
following commit https://android.googlesource.com/platform/system/nfc/+/d482d7c489603ecbbb8eb5bb4d69e2024eb46217%5E%21/#F0

Signed-off-by: David Viteri <davidteri91@gmail.com>