### PR TITLE
sony-common: disable BT by default

### DIFF
--- a/overlay/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
+++ b/overlay/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
@@ -17,6 +17,7 @@
  */
 -->
 <resources>
+    <bool name="def_bluetooth_on">false</bool>
     <bool name="def_screen_brightness_automatic_mode">true</bool>
     <string name="def_backup_transport">com.google.android.gms/.backup.BackupTransportService</string>
 </resources>


### PR DESCRIPTION
in case of build gapped rom on bcm devices having bt enabled cause reboots
disable BT by default ... it can be enabled by user after pass Initial configuration

refer: https://android.googlesource.com/platform/frameworks/base/+/8c18431be868e0960e80638c1a974d71a0df05b4%5E%21/#F0

Signed-off-by: David Viteri <davidteri91@gmail.com>