### PR TITLE
sony-common: fix audio effects warnings in logs

### DIFF
--- a/rootdir/system/vendor/etc/audio_effects.conf
+++ b/rootdir/system/vendor/etc/audio_effects.conf
@@ -7,31 +7,31 @@
 #    }
 libraries {
   bundle {
-    path /system/vendor/lib/soundfx/libbundlewrapper.so
+    path /vendor/lib/soundfx/libbundlewrapper.so
   }
   reverb {
-    path /system/vendor/lib/soundfx/libreverbwrapper.so
+    path /vendor/lib/soundfx/libreverbwrapper.so
   }
   visualizer_sw {
-    path /system/vendor/lib/soundfx/libvisualizer.so
+    path /vendor/lib/soundfx/libvisualizer.so
   }
   visualizer_hw {
-    path /system/vendor/lib/soundfx/libqcomvisualizer.so
+    path /vendor/lib/soundfx/libqcomvisualizer.so
   }
   downmix {
-    path /system/vendor/lib/soundfx/libdownmix.so
+    path /vendor/lib/soundfx/libdownmix.so
   }
   proxy {
-    path /system/vendor/lib/soundfx/libeffectproxy.so
+    path /vendor/lib/soundfx/libeffectproxy.so
   }
   offload_bundle {
-    path /system/vendor/lib/soundfx/libqcompostprocbundle.so
+    path /vendor/lib/soundfx/libqcompostprocbundle.so
   }
   qcom_pre_processing {
-    path /system/vendor/lib/soundfx/libqcomvoiceprocessing.so
+    path /vendor/lib/soundfx/libqcomvoiceprocessing.so
   }
   loudness_enhancer {
-    path /system/vendor/lib/soundfx/libldnhncr.so
+    path /vendor/lib/soundfx/libldnhncr.so
   }
 }
 
@@ -39,7 +39,7 @@ libraries {
 # audio HAL implements support for default software audio pre-processing effects
 #
 #  pre_processing {
-#    path /system/vendor/lib/soundfx/libaudiopreprocessing.so
+#    path /vendor/lib/soundfx/libaudiopreprocessing.so
 #  }
 
 # list of effects to load. Each effect element must contain a "library" and a "uuid" element.


### PR DESCRIPTION
09-07 22:46:33.131   533   533 W EffectsFactory: checkLibraryPath() corrected library path /system/vendor/lib/soundfx/libbundlewrapper.so to /vendor/lib/soundfx/libbundlewrapper.so
09-07 22:46:33.137   533   533 W EffectsFactory: checkLibraryPath() corrected library path /system/vendor/lib/soundfx/libreverbwrapper.so to /vendor/lib/soundfx/libreverbwrapper.so
09-07 22:46:33.143   533   533 W EffectsFactory: checkLibraryPath() corrected library path /system/vendor/lib/soundfx/libvisualizer.so to /vendor/lib/soundfx/libvisualizer.so
09-07 22:46:33.151   533   533 W EffectsFactory: checkLibraryPath() corrected library path /system/vendor/lib/soundfx/libqcomvisualizer.so to /vendor/lib/soundfx/libqcomvisualizer.so
09-07 22:46:33.152   533   533 W EffectsFactory: checkLibraryPath() corrected library path /system/vendor/lib/soundfx/libdownmix.so to /vendor/lib/soundfx/libdownmix.so
09-07 22:46:33.158   533   533 W EffectsFactory: checkLibraryPath() corrected library path /system/vendor/lib/soundfx/libeffectproxy.so to /vendor/lib/soundfx/libeffectproxy.so
09-07 22:46:33.161   533   533 W EffectsFactory: checkLibraryPath() corrected library path /system/vendor/lib/soundfx/libqcompostprocbundle.so to /vendor/lib/soundfx/libqcompostprocbundle.so
09-07 22:46:33.163   533   533 W EffectsFactory: checkLibraryPath() corrected library path /system/vendor/lib/soundfx/libqcomvoiceprocessing.so to /vendor/lib/soundfx/libqcomvoiceprocessing.so
09-07 22:46:33.167   533   533 W EffectsFactory: checkLibraryPath() corrected library path /system/vendor/lib/soundfx/libldnhncr.so to /vendor/lib/soundfx/libldnhncr.so

Signed-off-by: David Viteri <davidteri91@gmail.com>