### PR TITLE
sony-common: make sure include librsjni.so

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -171,6 +171,10 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     libprotobuf-cpp-full
 
+# RenderScript
+PRODUCT_PACKAGES += \
+    librsjni
+
 # ExtendedSettings
 PRODUCT_PACKAGES += \
     ExtendedSettings


### PR DESCRIPTION
needed by some apps due to renderscript

Signed-off-by: David Viteri <davidteri91@gmail.com>