### PR TITLE
sony-common: add GNSS HAL

### DIFF
--- a/treble.mk
+++ b/treble.mk
@@ -51,6 +51,11 @@ PRODUCT_PACKAGES += \
     android.hardware.nfc@1.0-impl \
     android.hardware.nfc@1.0-service
 
+# GNSS
+PRODUCT_PACKAGES += \
+    android.hardware.gnss@1.0-impl \
+    android.hardware.gnss@1.0-service
+
 # Light
 PRODUCT_PACKAGES += \
     android.hardware.light@2.0-impl \


### PR DESCRIPTION
include impl and service to binderize them in future via manifest.xml

this is needed by GPS HAL

Signed-off-by: David Viteri <davidteri91@gmail.com>