### PR TITLE
sony-common: power: move powerHAL to /vendor

### DIFF
--- a/power/Android.mk
+++ b/power/Android.mk
@@ -27,6 +27,8 @@ LOCAL_SRC_FILES := power.c rqbalance_halext.c expatparser.c
 LOCAL_SHARED_LIBRARIES := liblog libcutils libexpat
 LOCAL_MODULE := power.$(TARGET_DEVICE)
 LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_OWNER := sony
+LOCAL_PROPRIETARY_MODULE := true
 LOCAL_MODULE_RELATIVE_PATH := hw
 
 include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
under /system/lib/hw - /system/lib64/hw it give this
E RQBalance-PowerHAL: Error writing to /sys/devices/system/cpu/cpuquiet/nr_power_max_cpus: Invalid argument

having maple on powersave mode
maple:/ # cat sys/devices/system/cpu/cpuquiet/nr_power_max_cpus
3

under /vendor/lib/hw - /vendor/lib64/hw maple can run on performance mode
maple:/ # cat sys/devices/system/cpu/cpuquiet/nr_power_max_cpus
8

Signed-off-by: David Viteri <davidteri91@gmail.com>