### PR TITLE
rqbalance: move socket path out of /data

### DIFF
--- a/librqbalance/rqbalance_ctl.c
+++ b/librqbalance/rqbalance_ctl.c
@@ -31,7 +31,7 @@
 #include <hardware/power.h>
 #include <utils/Log.h>
 
-#define POWERSERVER_SOCKET		"/data/misc/powerhal/rqbsvr"
+#define POWERSERVER_SOCKET		"/dev/socket/powerhal/rqbsvr"
 
 #define MAX_ARGUMENTS	20
 struct rqbalance_halext_params {

--- a/power/power.h
+++ b/power/power.h
@@ -32,7 +32,7 @@
 #define PROP_DEBUGLVL			"powerhal.debug_level"
 
 /* PowerServer definitions */
-#define POWERSERVER_DIR			"/data/misc/powerhal/"
+#define POWERSERVER_DIR			"/dev/socket/powerhal/"
 #define POWERSERVER_SOCKET		POWERSERVER_DIR "rqbsvr"
 #define POWERSERVER_MAXCONN		10
 

--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -104,11 +104,6 @@ on post-fs-data
 
     # FM Radio
     mkdir /data/misc/fm 0770 system system
-    
-    # RQBalance-PowerHAL PowerServer
-    mkdir /data/misc/powerhal
-    chmod 0773 /data/misc/powerhal
-    chown system system /data/misc/powerhal
 
     chown system /dev/block/bootdevice/by-name
 
@@ -162,6 +157,9 @@ on boot
 
     #Create NETMGR daemon socket area
     mkdir /dev/socket/netmgr 0750 radio radio
+
+    # RQBalance-PowerHAL PowerServer
+    mkdir /dev/socket/powerhal 0773 system system
 
     #create netmgr log dir
     mkdir /data/misc/netmgr 0770 radio radio


### PR DESCRIPTION
Having the socket for PowerServer under /data caused issues with
encryption where cryptfs would try to unmount /data, but would fail
because the power hal would still hold its socket open.
Move the socket over to /dev/socket/rqbalance/ to avoid such issues, and
to also keep it together with other sockets.