### PR TITLE
sony-common: drop net_raw group

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -310,14 +310,14 @@ service irsc_util /system/vendor/bin/irsc_util "/etc/sec_config"
 service per_mgr /system/vendor/bin/pm-service
     class core
     user system
-    group system net_raw
+    group system
     writepid /dev/cpuset/system-background/tasks
 
 # QCOM prop
 service per_proxy /system/vendor/bin/pm-proxy
     class core
     user system
-    group system net_raw
+    group system
     disabled
     writepid /dev/cpuset/system-background/tasks
 


### PR DESCRIPTION
Use CAP_NET_BIND_SERVICE instead
following marlin

Signed-off-by: David Viteri <davidteri91@gmail.com>