### PR TITLE
sony-common: remove unneeded HDMI symlink

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -196,9 +196,6 @@ on boot
 
     chmod 0444 /sys/devices/platform/msm_hsusb/gadget/usb_state
 
-    # Create symlink for fb1 as HDMI
-    symlink /dev/graphics/fb1 /dev/graphics/hdmi
-
     # Graphics Permissions
     chown system graphics /sys/class/graphics/fb0/idle_time
     chmod 0664 /sys/class/graphics/fb0/idle_time


### PR DESCRIPTION
on aosp we are not using HDMI also on legacy platforms it was symlinked to FB1 if you see at
msm8956-mdss.dtsi
msm8996-mdss.dtsi
msm8998-mdss.dtsi

the new platforms are using hdmi under FB2 not FB1

in the case of needed add this to 8974 init and 8994 init

Signed-off-by: David Viteri <davidteri91@gmail.com>