### PR TITLE
[COMMON] init.common.rc: Add permissions for DispCal

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -190,6 +190,10 @@ on boot
     # Dynamic Resolution Switch
     chown system graphics /sys/class/graphics/fb0/mode
     chmod 0664 /sys/class/graphics/fb0/mode
+    
+    # Display Calibration
+    chown system graphics /sys/devices/mdss_dsi_panel/pcc_profile
+    chmod 0664 /sys/devices/mdss_dsi_panel/pcc_profile
 
     chown system graphics /sys/class/graphics/fb1/avi_itc
     chown system graphics /sys/class/graphics/fb1/avi_cn0_1


### PR DESCRIPTION
ExtendedSettings now implements the new DispCal functionality
and it requires to access the required kernel sysfs to work.
Assign correct permissions.