### PR TITLE
sony-common: add graphics perms for bootanimation

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -121,6 +121,10 @@ on early-boot
     # Set RLIMIT_MEMLOCK to 64MB
     setrlimit 8 67108864 67108864
 
+    # Graphics Permissions bootanimation
+    chmod 0664 /sys/devices/virtual/graphics/fb0/msm_cmd_autorefresh_en
+    chown system graphics /sys/devices/virtual/graphics/fb0/msm_cmd_autorefresh_en
+
 on boot
     # Bluetooth modules
     chown system system /sys/module/bluetooth/parameters/disable_ertm


### PR DESCRIPTION
picked from marlin

Signed-off-by: David Viteri <davidteri91@gmail.com>