### PR TITLE
init: Add init_sony build barrier

### DIFF
--- a/init/Android.mk
+++ b/init/Android.mk
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # Abort if the device is not handled by init_sony
+ifeq ($(BOARD_USES_INIT_SONY),true)
 ifeq (,$(findstring DEV_BLOCK_FOTA_NUM,$(BOARD_SONY_INIT_FLAGS)))
 $(error device-sony-common-init: DEV_BLOCK_FOTA_NUM missing in "$(TARGET_DEVICE)", platform "$(PRODUCT_PLATFORM)", with '$(BOARD_SONY_INIT_FLAGS)')
 endif
@@ -40,3 +41,4 @@ $(root_init_real): $(root_init) $(TARGET_RECOVERY_ROOT_OUT)/sbin/toybox_static $
 	fi
 
 ALL_DEFAULT_INSTALLED_MODULES += $(root_init_real)
+endif


### PR DESCRIPTION
init_sony is a workaround for Sony devices that are not able
to reboot to FOTAKernel by "reboot recovery" command or such.
Since we have already "fixed" such behaviour on loire and tone,
this helper becomes redundant for those platforms and should
not be built by default