### PR TITLE
common: remove not needed mapper service

### DIFF
--- a/treble.mk
+++ b/treble.mk
@@ -8,8 +8,7 @@ PRODUCT_PACKAGES += \
     android.hardware.graphics.allocator@2.0-service \
     android.hardware.graphics.composer@2.1-impl \
     android.hardware.graphics.composer@2.1-service \
-    android.hardware.graphics.mapper@2.0-impl \
-    android.hardware.graphics.mapper@2.0-service
+    android.hardware.graphics.mapper@2.0-impl
 
 # Memtrack
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
simple ... mapper has not init service
check
https://android.googlesource.com/platform/hardware/interfaces/+/android-8.0.0_r15/graphics/mapper/2.0/default/

Signed-off-by: David Viteri <davidteri91@gmail.com>