### PR TITLE
Fix incorrect condition checking

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -4,6 +4,8 @@ LOCAL_PATH := $(call my-dir)
 
 include $(call all-makefiles-under,$(LOCAL_PATH))
 
+endif
+
 ifneq ($(filter shinano kitakami,$(PRODUCT_PLATFORM)),)
 $(shell mkdir -p $(PRODUCT_OUT)/system/vendor/firmware)
 $(shell pushd $(PRODUCT_OUT)/system/vendor/firmware > /dev/null && ln -s /vendor/etc/firmware/libpn547_fw.so libpn547_fw.so && popd > /dev/null)
@@ -59,5 +61,4 @@ $(shell pushd $(PRODUCT_OUT)/system/vendor > /dev/null && ln -s /odm/firmware fi
 
 $(shell pushd $(PRODUCT_OUT)/odm/firmware > /dev/null && ln -s /vendor/etc/firmware/libpn547_fw.so libpn547_fw.so && popd > /dev/null)
 
-endif
 endif


### PR DESCRIPTION
Android.mk has defined several conditional expressions which check for absense of explicitly listed platforms and based on that perform some actions. However except first conditional, all other expressions are defined inside first expression, e.g.:

```make
ifneq ($(filter yukon rhine shinano kanuti kitakami loire,$(PRODUCT_PLATFORM)),)
...
ifneq ($(filter loire tone yoshino,$(PRODUCT_PLATFORM)),)
endif
endif
```

So for instance if I was building for ```loire``` platform, check for it would be evaluated at least twice and when I was building ```rhine``` platform, no code would be executed at all.

Following commit moves all conditional expressions to same global level, e.g.:
```make
ifneq ($(filter yukon rhine shinano kanuti kitakami loire,$(PRODUCT_PLATFORM)),)
...
endif

ifneq ($(filter loire tone yoshino,$(PRODUCT_PLATFORM)),)
...
endif
```

If this behavior is an error and not an intention, please merge this PR.

Thanks!

Signed-off-by: Vladimir Zahradnik <vladimir.zahradnik@gmail.com>