### PR TITLE
healthd: Check SoC status before entering off-mode charging

### DIFF
--- a/healthd/healthd_board_sony.cpp
+++ b/healthd/healthd_board_sony.cpp
@@ -37,6 +37,10 @@
 #define GREEN_LED_PATH         "/sys/class/leds/led:rgb_green/brightness"
 #define BLUE_LED_PATH          "/sys/class/leds/led:rgb_blue/brightness"
 
+#define BMS_READY_PATH                "/sys/class/power_supply/bms/soc_reporting_ready"
+#define WAIT_BMS_READY_TIMES_MAX      200
+#define WAIT_BMS_READY_INTERVAL_USEC  200000
+
 #define LOGV(x...) do { KLOG_DEBUG("charger", x); } while (0)
 #define LOGE(x...) do { KLOG_ERROR("charger", x); } while (0)
 #define LOGW(x...) do { KLOG_WARNING("charger", x); } while (0)
@@ -179,6 +183,8 @@ void healthd_board_mode_charger_init()
     int ret;
     char buff[8] = "\0";
     int charging_enabled = 0;
+    int bms_ready = 0;
+    int wait_count = 0;
     int fd;
 
     /* check the charging is enabled or not */
@@ -187,13 +193,30 @@ void healthd_board_mode_charger_init()
         return;
     ret = read(fd, buff, sizeof(buff));
     close(fd);
-    if (ret > 0 && sscanf(buff, "%d\n", &charging_enabled)) {
+    if (ret > 0) {
+        sscanf(buff, "%d\n", &charging_enabled);
+        LOGW("android charging is %s\n",
+                !!charging_enabled ? "enabled" : "disabled");
         /* if charging is disabled, reboot and exit power off charging */
-        if (charging_enabled)
-            return;
-        LOGW("android charging is disabled, exit!\n");
-        reboot(RB_AUTOBOOT);
+        if (!charging_enabled)
+            reboot(RB_AUTOBOOT);
     }
+    fd = open(BMS_READY_PATH, O_RDONLY);
+    if (fd < 0)
+            return;
+    while (1) {
+        ret = read(fd, buff, sizeof(buff));
+        if (ret >= 0)
+	    sscanf(buff, "%d\n", &bms_ready);
+        else
+            LOGE("read soc-ready failed, ret=%d\n", ret);
+        if ((bms_ready > 0) || (wait_count++ > WAIT_BMS_READY_TIMES_MAX))
+            break;
+        usleep(WAIT_BMS_READY_INTERVAL_USEC);
+        lseek(fd, 0, SEEK_SET);
+    }
+    close(fd);
+    LOGE("Checking BMS SoC ready done!\n");
 }
 
 void healthd_board_init(struct healthd_config*)


### PR DESCRIPTION
The battery capacity reporting from battery power_supply could be a
default value before BMS initialization done. This causes an incorrect
battery capacity being showed up at the beginning frames of off-mode
charging. Check whether the soc reporting is ready before entering into
off-mode charging.

CRs-Fixed: 1042133
Change-Id: I35d9308dc56d7d4acfbad74ddccd53a64afb53ce