### PR TITLE
Disable Treble OMX by default.

### DIFF
--- a/treble.mk
+++ b/treble.mk
@@ -102,3 +102,7 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     android.hardware.power@1.0-impl \
     android.hardware.power@1.0-service
+
+# Default OMX service to non-Treble
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.media.treble_omx=false


### PR DESCRIPTION
Test: Manual use of Camera, Movies, Photos and YouTube apps.

Test: With CtsMediaTestCases.apk installed,
adb shell am instrument -e size small -w
'android.media.cts/android.support.test.runner.AndroidJUnitRunner'

Bug: 31399200
Change-Id: I6c027a29e5336d1834f6f5ee9f555e5c39834c3c