### PR TITLE
[N-MR1] Rename odm build properties file with standard filename

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -173,10 +173,10 @@ ifeq ($(NXP_CHIP_FW_TYPE), PN553)
 $(shell pushd $(PRODUCT_OUT)/odm/firmware > /dev/null && ln -s /vendor/etc/firmware/libpn553_fw.so libpn553_fw.so && popd > /dev/null)
 endif
 
-$(shell pushd $(PRODUCT_OUT)/odm/ > /dev/null && echo "ro.kernel.version=$(TARGET_KERNEL_VERSION)" >odm_version.prop && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/odm/ > /dev/null && echo "ro.build.version=$(PLATFORM_VERSION)" >>odm_version.prop && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/odm/ > /dev/null && echo "ro.platform.version=$(TARGET_BOARD_PLATFORM)" >>odm_version.prop && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/odm/ > /dev/null && echo "ro.vendor.version=$(TARGET_VENDOR_VERSION)" >>odm_version.prop && popd > /dev/null)
+$(shell pushd $(PRODUCT_OUT)/odm/ > /dev/null && echo "ro.kernel.version=$(TARGET_KERNEL_VERSION)" > build.prop && popd > /dev/null)
+$(shell pushd $(PRODUCT_OUT)/odm/ > /dev/null && echo "ro.build.version=$(PLATFORM_VERSION)" >> build.prop && popd > /dev/null)
+$(shell pushd $(PRODUCT_OUT)/odm/ > /dev/null && echo "ro.platform.version=$(TARGET_BOARD_PLATFORM)" >> build.prop && popd > /dev/null)
+$(shell pushd $(PRODUCT_OUT)/odm/ > /dev/null && echo "ro.vendor.version=$(TARGET_VENDOR_VERSION)" >> build.prop && popd > /dev/null)
 
 endif
 endif

--- a/odm.mk
+++ b/odm.mk
@@ -19,7 +19,7 @@ CUSTOM_IMAGE_DICT_FILE := device/sony/common/odm_info.txt
 CUSTOM_IMAGE_SELINUX := true
 
 CUSTOM_IMAGE_COPY_FILES := \
-			$(foreach p,$(TARGET_OUT_ODM)/odm_version.prop,$(p):) \
+			$(foreach p,$(TARGET_OUT_ODM)/build.prop,$(p):) \
 			$(foreach p,$(TARGET_OUT_ODM)/bin,$(p):) \
 			$(foreach p,$(TARGET_OUT_ODM)/firmware,$(p):) \
 			$(foreach p,$(TARGET_OUT_ODM)/lib,$(p):) \


### PR DESCRIPTION
FS config (on 8.0 and master) define specific file access rights only for /odm/build.prop and /odm/default.prop