### PR TITLE
Bluetooth: Allow wakelock access to wcnss_filter

### DIFF
--- a/android_filesystem_config.h
+++ b/android_filesystem_config.h
@@ -40,7 +40,7 @@ static const struct fs_path_config android_device_files[] = {
     { 00700, AID_CAMERA,    AID_SHELL,     (1ULL << CAP_SYS_NICE), "odm/bin/mm-qcamera-daemon" },
     { 00755, AID_SYSTEM,    AID_SYSTEM,    (1ULL << CAP_NET_BIND_SERVICE), "odm/bin/pm-service" },
     { 00755, AID_SYSTEM,    AID_SYSTEM,    (1ULL << CAP_NET_BIND_SERVICE), "odm/bin/cnss-daemon"},
-    { 00755, AID_SYSTEM,    AID_SYSTEM,    (1ULL << CAP_SYS_NICE), "odm/bin/wcnss_filter"},
+    { 00755, AID_SYSTEM,    AID_SYSTEM,    (1ULL << CAP_SYS_NICE) | (1ULL << CAP_BLOCK_SUSPEND), "odm/bin/wcnss_filter"},
     { 00755, AID_ROOT,      AID_SHELL,     0, "odm/bin/*"},
 #ifdef NO_ANDROID_FILESYSTEM_CONFIG_DEVICE_DIRS
     { 00000, AID_ROOT,      AID_ROOT,      0, "system/etc/fs_config_dirs" },


### PR DESCRIPTION
Bluetooth driver needs to hold a wakelock while receiving
packets from the UART to make sure that no bytes are lost.

Test: Bluetooth on/off
Bug: 63628397
Change-Id: I8cd6a13921cdc2777c64b0624f544a9548292522
(cherry picked from commit 0c2b5e803d9655007d664937b179e36c37178956)