### PR TITLE
ramdump cleaner - common part

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -205,6 +205,15 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     librqbalance
 
+# PRODUCT_PLATFORM isn't set yet, thus we check the available path
+ifneq (,$(filter %loire %tone %yoshino,$(PLATFORM_COMMON_PATH)))
+ifneq (,$(filter userdebug eng,$(TARGET_BUILD_VARIANT)))
+# ramdump cleaner
+PRODUCT_PACKAGES += \
+    rdclean.sh
+endif
+endif
+
 # librqbalance enablement
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.vendor.extension_library=/system/vendor/lib/librqbalance.so

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -1,0 +1,14 @@
+LOCAL_PATH := $(call my-dir)
+
+ifneq (,$(filter loire tone yoshino,$(PRODUCT_PLATFORM)))
+ifneq (,$(filter userdebug eng,$(TARGET_BUILD_VARIANT)))
+include $(CLEAR_VARS)
+LOCAL_MODULE             := rdclean.sh
+LOCAL_MODULE_CLASS       := EXECUTABLES
+LOCAL_SRC_FILES_arm64    := vendor/bin/rdclean.sh
+LOCAL_INIT_RC_64         := vendor/etc/init/rdclean.rc
+LOCAL_MODULE_TARGET_ARCH := arm64
+LOCAL_VENDOR_MODULE      := true
+include $(BUILD_PREBUILT)
+endif
+endif

--- a/rootdir/vendor/bin/rdclean.sh
+++ b/rootdir/vendor/bin/rdclean.sh
@@ -1,0 +1,12 @@
+#!/system/bin/sh
+
+dev=/dev/block/bootdevice/by-name/rdimage
+
+tag=`dd if=$dev bs=1 count=8 2>/dev/null`
+[ "$tag" != "ANDROID!" ] && {
+  tag=`echo $tag | sed -e 's,^.\(...\).*$,\1,'`
+  [ "$tag" != "ELF" ] && exit 0
+}
+
+log -p w -t rdclean clearing ramdump partition
+cat /dev/zero > $dev

--- a/rootdir/vendor/etc/init/rdclean.rc
+++ b/rootdir/vendor/etc/init/rdclean.rc
@@ -1,0 +1,4 @@
+service rdclean /vendor/bin/rdclean.sh
+    user root
+    class core
+    oneshot


### PR DESCRIPTION
This adds ramdump cleaner for loire & tone & yoshino platforms. Please note that it depends on selinux change specific for the each platform, uploaded separately.