### PR TITLE
sony-common: usb.rc: cleanup

### DIFF
--- a/rootdir/init.common.usb.rc
+++ b/rootdir/init.common.usb.rc
@@ -54,29 +54,27 @@ on boot
     mount functionfs adb /dev/usb-ffs/adb uid=2000,gid=2000
     write /sys/class/android_usb/android0/f_ffs/aliases adb
     setprop sys.usb.configfs 1
-    setprop sys.usb.rndis.func.name "rndis_bam"
-    setprop sys.usb.rmnet.func.name "rmnet_bam"
 
 # USB compositions
 # Note: PID 0x902X advertises QCOM. Useful for NT based OSes.
 on property:sys.usb.config=mtp && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/functions/mtp.gs0/os_desc/interface.MTP/compatible_id "MTP"
+    write /config/usb_gadget/g1/functions/mtp.gs0/os_desc/interface.MTP/compatible_id "mtp"
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "mtp"
     write /config/usb_gadget/g1/os_desc/use 1
     write /config/usb_gadget/g1/idProduct 0x0${ro.usb.pid_suffix}
+    setprop sys.usb.state ${sys.usb.config}
 
 on property:sys.usb.config=mtp,adb && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/functions/mtp.gs0/os_desc/interface.MTP/compatible_id "MTP"
+    write /config/usb_gadget/g1/functions/mtp.gs0/os_desc/interface.MTP/compatible_id "mtp_adb"
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "mtp_adb"
     write /config/usb_gadget/g1/os_desc/use 1
     write /config/usb_gadget/g1/idProduct 0x5${ro.usb.pid_suffix}
-
-on property:sys.usb.tethering=true
-    write /sys/class/net/rndis0/queues/rx-0/rps_cpus ${sys.usb.rps_mask}
+    setprop sys.usb.state ${sys.usb.config}
 
 on property:sys.usb.config=rndis && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "rndis"
     rm /config/usb_gadget/g1/configs/b.1/f1
     rm /config/usb_gadget/g1/configs/b.1/f2
-    rm /config/usb_gadget/g1/configs/b.1/f3
     write /config/usb_gadget/g1/idProduct 0x7${ro.usb.pid_suffix}
     symlink /config/usb_gadget/g1/functions/${sys.usb.rndis.func.name}.rndis /config/usb_gadget/g1/configs/b.1/f1
     write /config/usb_gadget/g1/UDC ${sys.usb.controller}
@@ -86,67 +84,40 @@ on property:sys.usb.ffs.ready=1 && property:sys.usb.config=rndis,adb && property
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "rndis_adb"
     rm /config/usb_gadget/g1/configs/b.1/f1
     rm /config/usb_gadget/g1/configs/b.1/f2
-    rm /config/usb_gadget/g1/configs/b.1/f3
     write /config/usb_gadget/g1/idProduct 0x8${ro.usb.pid_suffix}
     symlink /config/usb_gadget/g1/functions/${sys.usb.rndis.func.name}.rndis /config/usb_gadget/g1/configs/b.1/f1
     symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f2
     write /config/usb_gadget/g1/UDC ${sys.usb.controller}
-    setprop sys.usb.state rndis,adb
+    setprop sys.usb.state ${sys.usb.config}
 
 on property:sys.usb.config=ptp && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/functions/ptp.gs1/os_desc/interface.MTP/compatible_id "PTP"
+    write /config/usb_gadget/g1/functions/ptp.gs1/os_desc/interface.MTP/compatible_id "ptp"
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "ptp"
     write /config/usb_gadget/g1/os_desc/use 1
     write /config/usb_gadget/g1/idProduct 0x9${ro.usb.pid_suffix}
+    setprop sys.usb.state ${sys.usb.config}
 
 on property:sys.usb.config=ptp,adb && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/functions/ptp.gs1/os_desc/interface.MTP/compatible_id "PTP"
+    write /config/usb_gadget/g1/functions/ptp.gs1/os_desc/interface.MTP/compatible_id "ptp_adb"
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "ptp_adb"
     write /config/usb_gadget/g1/os_desc/use 1
     write /config/usb_gadget/g1/idProduct 0xA${ro.usb.pid_suffix}
+    setprop sys.usb.state ${sys.usb.config}
 
 on property:sys.usb.config=midi && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/idProduct 0xC${ro.usb.pid_suffix}
+    setprop sys.usb.state ${sys.usb.config}
 
 on property:sys.usb.config=midi,adb && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/idProduct 0xF${ro.usb.pid_suffix}
+    setprop sys.usb.state ${sys.usb.config}
 
 # Completely redeclare ADB for safety purposes
-on property:sys.usb.config=adb && property:sys.usb.configfs=1
-    start adbd
-
 on property:sys.usb.config=adb && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "adb"
     rm /config/usb_gadget/g1/configs/b.1/f1
     rm /config/usb_gadget/g1/configs/b.1/f2
-    rm /config/usb_gadget/g1/configs/b.1/f3
-    rm /config/usb_gadget/g1/configs/b.1/f4
-    rm /config/usb_gadget/g1/configs/b.1/f5
     write /config/usb_gadget/g1/idProduct 0x0${ro.usb.pid_suffix}
     symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f1
     write /config/usb_gadget/g1/UDC ${sys.usb.controller}
     setprop sys.usb.state ${sys.usb.config}
-
-# Ethernet over USB
-on property:sys.usb.config=ncm && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "ncm"
-    rm /config/usb_gadget/g1/configs/b.1/f1
-    rm /config/usb_gadget/g1/configs/b.1/f2
-    rm /config/usb_gadget/g1/configs/b.1/f3
-    write /config/usb_gadget/g1/idProduct 0xB${ro.usb.pid_suffix}
-    symlink /config/usb_gadget/g1/functions/ncm.0 /config/usb_gadget/g1/configs/b.1/f1
-    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
-    setprop sys.usb.state ${sys.usb.config}
-
-on property:sys.usb.config=ncm,adb && property:sys.usb.configfs=1
-    start adbd
-
-on property:sys.usb.ffs.ready=1 && property:sys.usb.config=ncm,adb && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "ncm_adb"
-    rm /config/usb_gadget/g1/configs/b.1/f1
-    rm /config/usb_gadget/g1/configs/b.1/f2
-    rm /config/usb_gadget/g1/configs/b.1/f3
-    write /config/usb_gadget/g1/idProduct 0xB${ro.usb.pid_suffix}
-    symlink /config/usb_gadget/g1/functions/ncm.0 /config/usb_gadget/g1/configs/b.1/f1
-    symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f2
-    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
-    setprop sys.usb.state ${sys.usb.config}
-


### PR DESCRIPTION
following wahoo
move sys.usb.rndis.func.name per platform since it change between loire/tone and yoshino

poplar:/config/usb_gadget/g1/functions # ls
accessory.gs2  audio_source.gs2  cser.dun.0  cser.nmea.1  ffs.adb  gsi.dpl  gsi.rmnet  gsi.rndis  midi.gs5  mtp.gs0  ncm.0  ptp.gs1

dora:/config/usb_gadget/g1/functions # ls
accessory.gs2  cser.dun.0  cser.nmea.1  ffs.adb  mtp.gs0  ncm.0  ptp.gs1  rmnet_bam.dpl  rmnet_bam.rmnet  rndis_bam.rndis

kugo:/config/usb_gadget/g1/functions # ls
accessory.gs2  cser.dun.0  cser.nmea.1  ffs.adb  mtp.gs0  ncm.0  ptp.gs1  rmnet_bam.dpl  rmnet_bam.rmnet  rndis_bam.rndis

Signed-off-by: David Viteri <davidteri91@gmail.com>