### PR TITLE
[master] Use z3fold as zRAM backend

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -33,6 +33,7 @@ BOARD_KERNEL_CMDLINE += console=ttyMSM0,115200,n8 androidboot.console=ttyMSM0
 BOARD_KERNEL_CMDLINE += msm_rtb.filter=0x3F ehci-hcd.park=3
 BOARD_KERNEL_CMDLINE += coherent_pool=8M
 BOARD_KERNEL_CMDLINE += sched_enable_power_aware=1 user_debug=31
+BOARD_KERNEL_CMDLINE += zram.backend=z3fold
 
 TARGET_USERIMAGES_USE_EXT4 := true
 BOARD_CACHEIMAGE_FILE_SYSTEM_TYPE := ext4


### PR DESCRIPTION
We added z3fold to kernel, but it isn't used by default.
This change makes use of this driver.

Requires https://github.com/sonyxperiadev/kernel/pull/1515