### PR TITLE
Fixes for creating MAC address files on Oreo

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -41,7 +41,7 @@ on init
 
 on post-fs-data
     # Create directory used by bluetooth subsystem
-    mkdir /data/misc/bluetooth 0770 bluetooth bluetooth
+    mkdir /data/misc/bluetooth 2770 bluetooth bluetooth
 
     # To observe dnsmasq.leases file for dhcp information of soft ap.
     chown dhcp system /data/misc/dhcp


### PR DESCRIPTION
The macaddrsetup service creates a file in this directory containing the bluetooth MAC address that needs to be readable by the bluetooth service. Ensure files created here are in the bluetooth group.