### PR TITLE
treble: remove gnss service

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -76,15 +76,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.gnss</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>IGnss</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.graphics.allocator</name>
         <transport>hwbinder</transport>
         <version>2.0</version>

--- a/treble.mk
+++ b/treble.mk
@@ -52,8 +52,7 @@ PRODUCT_PACKAGES += \
 
 # GNSS
 PRODUCT_PACKAGES += \
-    android.hardware.gnss@1.0-impl \
-    android.hardware.gnss@1.0-service
+    android.hardware.gnss@1.0-impl
 
 # Light
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
the 8994 gps hal we use is not compatible enough and causes the service to spam logcat with errors.

Change-Id: I1a82744ce3fe2bb63895b240a7b770acde6bd926