### PR TITLE
treble: remove sensors service

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -183,15 +183,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.sensors</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>ISensors</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.renderscript</name>
         <transport arch="32+64">passthrough</transport>
         <version>1.0</version>

--- a/treble.mk
+++ b/treble.mk
@@ -61,8 +61,7 @@ PRODUCT_PACKAGES += \
 
 # Sensors
 PRODUCT_PACKAGES += \
-    android.hardware.sensors@1.0-impl \
-    android.hardware.sensors@1.0-service
+    android.hardware.sensors@1.0-impl
 
 # Vibrator
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
The service is causing random issues upon boot, these include:
1. compass not working at all
2. compass returning errant values, even after calibration
3. all sensors not working

Remove the service for now, until the proprietary sensors frameworks is
updated to be compatible.

Change-Id: If6452423a5ae14a70005830a23500553075f697c