### PR TITLE
Revert "do not dexpreopt prebuilts"

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -82,7 +82,6 @@ ifeq ($(HOST_OS),linux)
     endif
   endif
 endif
-DONT_DEXPREOPT_PREBUILTS := true
 
 BUILD_KERNEL := true
 -include device/sony/common-headers/KernelHeaders.mk


### PR DESCRIPTION
This causes issues with custom ROMs that explicitly enforce
position independent code, so that dalvik execution from /data
for /system APKs can be disabled.

Since they may also provide prebuilt APKs (F-Droid, Silence
etc.) that live on the /system partition, we should not force
this build time preference onto users.

Furthermore we have a huge amount of space on /system, and first
boot is significantly faster when all APKs are processed at build.

Effectively, The only thing this flag does is slow down developers
when they want to test a clean boot.

This reverts commit 3d3e040342e906d260c943bd55be4e2f137132df.