### PR TITLE
sony: common: sepolicy: Resolve thermanager dac_override

### DIFF
--- a/rootdir/init.common.srv.rc
+++ b/rootdir/init.common.srv.rc
@@ -119,7 +119,7 @@ service adsprpcd /odm/bin/adsprpcd
 service thermanager /system/vendor/bin/thermanager /system/etc/thermanager.xml
     class main
     user root
-    group root
+    group root system
     writepid /dev/cpuset/system-background/tasks
 
 # Offline charger


### PR DESCRIPTION
 * Do not grant thermanager dac_override capability

 * Add thermanager to 'system' group

Change-Id: I4cff1444715427f33ebe2d8185f4ec6fd5a95b52