### PR TITLE
Initial odmcheck (1/4)

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -214,6 +214,10 @@ PRODUCT_PACKAGES += \
 endif
 endif
 
+# odmcheck
+PRODUCT_PACKAGES += \
+    odmcheck
+
 # librqbalance enablement
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.vendor.extension_library=/system/vendor/lib/librqbalance.so

--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -75,6 +75,9 @@ on post-fs
     # Wait qseecomd started
     wait_for_prop sys.listeners.registered true
 
+on post-fs
+    exec - system graphics -- /system/vendor/bin/odmcheck
+
 on post-fs-data
     # We can start netd here before in is launched in common init.rc on zygote-start
     start netd


### PR DESCRIPTION
Odmcheck will block init until exited. If a mismatch between odm partition and the build props is detected a warning screen will be shown. Currently this warning screen just has a simple placeholder UI with the version information shown on a blue background. The warning screen will be shown for 10 seconds, then the boot will resume regardless. Once everything is in place and works fine, after changing a build flag, odmcheck will instead shutdown the device after the 10 seconds.