### PR TITLE
[master] sony: common: sepolicy: Resolve timekeep dac_override denial

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -212,7 +212,7 @@ on boot
     chmod 0660 /data/misc/radio/copy_complete
 
     # Create folder for timekeep
-    mkdir /data/time/ 0700 system system
+    mkdir /data/time/ 0770 system system
 
     # Camera Recording
     mkdir /dev/video

--- a/rootdir/init.common.srv.rc
+++ b/rootdir/init.common.srv.rc
@@ -133,7 +133,7 @@ service charger /charger
 service timekeep /system/vendor/bin/timekeep restore
     class late_start
     user root
-    group root
+    group root system
     oneshot
     writepid /dev/cpuset/system-background/tasks
 


### PR DESCRIPTION
Do not grant timekeep dac_override capability by adding the service
to the system group and also set /data/time permission.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ife6e672352f8ab4b8e12bfe893463b4984bd3448