### PR TITLE
Fix debugfs mount statement

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 on early-init
-    mount debugfs /sys/kernel/debug /sys/kernel/debug mode=755
+    mount debugfs debugfs /sys/kernel/debug
+    chmod 0755 /sys/kernel/debug
 
 on init
     wait /dev/block/platform/soc/${ro.boot.bootdevice}


### PR DESCRIPTION
fix debugfs mount statement as per the following two upstream commits:

```
  remote: https://source.codeaurora.org/quic/la/device/qcom/common
  branch: qcom-devices.lnx.1.0.r15-rel

  4d5f58b init: Mount debugfs by default
  ed099c1 init.qcom.rc: Mount debugfs with correct permissions
```