### PR TITLE
[master] sony: common: Add system group|user to sensors service

### DIFF
--- a/rootdir/init.common.srv.rc
+++ b/rootdir/init.common.srv.rc
@@ -98,8 +98,8 @@ service msm_irqbalance /odm/bin/msm_irqbalance -f /system/etc/msm_irqbalance.con
 # QCOM sensors
 service sensors /odm/bin/sensors.qcom
     class main
-    user root
-    group root
+    user root system
+    group root system
     writepid /dev/cpuset/system-background/tasks
     # Grants the ability for this daemon to bind IPC router ports so it can
     # register QMI services


### PR DESCRIPTION
Access /data/misc/sensors/debug and /data/system/sensors/settings
This requires system when selinux security is enforced
at least on tone platform.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I10685a43bf92e403210c904117edfabbb990a006