### PR TITLE
rootdir: init: make sensors service oneshot

### DIFF
--- a/rootdir/init.common.srv.rc
+++ b/rootdir/init.common.srv.rc
@@ -100,6 +100,7 @@ service sensors /odm/bin/sensors.qcom
     class main
     user root system
     group root system
+    oneshot
     writepid /dev/cpuset/system-background/tasks
     # Grants the ability for this daemon to bind IPC router ports so it can
     # register QMI services


### PR DESCRIPTION
this service seems to exit when it has done its work, so not setting oneshot means that the service restarts indefinitely.
Make the service oneshot to avoid that.

Change-Id: I8d55ec9390527074af3605ff9bd73cbea629989a