### PR TITLE
[master] sony: common: init: set ioprio to realtime for rmt_storage

### DIFF
--- a/rootdir/init.common.srv.rc
+++ b/rootdir/init.common.srv.rc
@@ -48,6 +48,7 @@ service rmt_storage /odm/bin/rmt_storage
     class core
     user root
     group system wakelock
+    ioprio rt 0
     writepid /dev/cpuset/system-background/tasks
     shutdown critical
 


### PR DESCRIPTION
Setting ioprio to realtime within rmt_stroage requires unnecessarily
granting CAP_SYS_ADMIN, which is a highly privileged superuser
capability.

Having init set ioprio at service launch removes the need for
granting this capability and keeps rmt_storage unprivileged.

Addresses the following errors:
07-20dd 14:21:03.867   824   824 W rmt_storage: type=1400 audit(0.0:4):
avc: denied { sys_admin } for capability=21 scontext=u:r:rmt_storage:s0
tcontext=u:r:rmt_storage:s0 tclass=capability permissive=0
07-20 14:21:03.874   824   824 E rmt_storage: Error setting io priority
to CLASS_RT (1)

Test 1 and 2 below verify that my change results in the intended
behavior. Test 3 is a sanity check to show the state without
granting CAP_SYS_ADMIN and to demonstrate that my change results
in the intended state.

Test: original code with CAP_SYS_ADMIN granted
    # ionice -p <rmt_storage pid>
    Realtime: prio 0
Test: ioprio_set moved to init.rc script
    # ionice -p <rmt_storage pid>
    Realtime: prio 0
Test: original code without CAP_SYS_ADMIN granted (sanity check)
    # ionice -p <rmt_storage pid>
    unknown: prio 0

Bug: 63074582
Change-Id: I9bc660aaca72f3df562e8010bc23c9731f648a9e