### PR TITLE
[master] sony: common: init: Fix dac_override for timekeep definitely

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -214,6 +214,7 @@ on boot
 
     # Create folder for timekeep
     mkdir /data/time/ 0770 system system
+    chmod 0770 /data/time/ats_2
 
     # Camera Recording
     mkdir /dev/video

--- a/rootdir/init.common.srv.rc
+++ b/rootdir/init.common.srv.rc
@@ -136,7 +136,7 @@ service charger /charger
 # OSS time
 service timekeep /vendor/bin/timekeep restore
     class late_start
-    user root
+    user root system
     group root system
     oneshot
     writepid /dev/cpuset/system-background/tasks


### PR DESCRIPTION
This issue is still present on tone platform.
So set ats_2 file permission and avoid the requirement
to add dac_override entry in selinux rules.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I3906789bdfed0bc0fa549046d50b5605282baa88