### PR TITLE
[master] sony: common: Move fstab mount process to common

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -54,6 +54,8 @@ on charger
     start irsc_util
 
 on fs
+    mount_all ./fstab.${ro.boot.hardware}
+
     # Start HW service manager early
     start hwservicemanager
 
@@ -284,3 +286,7 @@ on boot
 
     setrlimit 4 -1 -1
     write /proc/sys/kernel/dmesg_restrict 0
+
+on property:sys.boot_completed=1
+    # Enable ZRAM on boot_complete
+    swapon_all ./fstab.${ro.boot.hardware}


### PR DESCRIPTION
Also, do not call swap mount until completed boot process
This help to save ~50ms in boot time and bootanim shown time

Reference:
https://android.googlesource.com/device/google/wahoo/+/06b4b0ce139eea0e015184297cedbbbc9cf2d8d3

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ic63fb53689d7da8ca948cedfd4f41d9869f64033