### PR TITLE
[master] sony: common: Do not start bootanimation early

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -66,7 +66,6 @@ on fs
 on late-fs
     # Start services for bootanim
     start surfaceflinger
-    start bootanim
     start hwcomposer-2-1
     start configstore-hal-1-0
     start gralloc-2-0
@@ -78,7 +77,6 @@ on post-fs
     # Wait qseecomd started
     wait_for_prop sys.listeners.registered true
 
-on post-fs
     exec - system graphics -- /vendor/bin/odmcheck
 
 on post-fs-data


### PR DESCRIPTION
    1 .Fix tone boot process by removing bootanimation service call

    2. Remove duplicate stage.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: If249d460ee945cc5a856567cb8005bc5fb519563