### PR TITLE
[o-mr0] Add common flags for all current platforms

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -34,6 +34,13 @@ BOARD_KERNEL_CMDLINE += msm_rtb.filter=0x3F ehci-hcd.park=3
 BOARD_KERNEL_CMDLINE += coherent_pool=8M
 BOARD_KERNEL_CMDLINE += sched_enable_power_aware=1 user_debug=31
 
+BOARD_MKBOOTIMG_ARGS := --ramdisk_offset $(BOARD_RAMDISK_OFFSET) --tags_offset $(BOARD_KERNEL_TAGS_OFFSET)
+
+TARGET_KERNEL_ARCH := arm64
+TARGET_KERNEL_HEADER_ARCH := arm64
+TARGET_KERNEL_CROSS_COMPILE_PREFIX := aarch64-linux-android-
+BOARD_KERNEL_IMAGE_NAME := Image.gz-dtb
+
 TARGET_USERIMAGES_USE_EXT4 := true
 BOARD_CACHEIMAGE_FILE_SYSTEM_TYPE := ext4
 


### PR DESCRIPTION
These flags are common for all of our current platforms, and when we migrating to the Image.lz4-dtb in the future we will not need to update each platform repository separately. If it's will be merged these flags can be and will be removed from PlatformConfig.mk on each platform.