### PR TITLE
Drop "mkdir /data/data/media"

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -102,8 +102,6 @@ on post-fs-data
     mkdir /data/audio 0770 media audio
     chmod 2770 /data/audio
 
-    mkdir /data/data/media 0770 media media
-
     # QCOM camera stack
     mkdir /data/misc/camera 0770 camera camera
 


### PR DESCRIPTION
this command prevents the encryption policy from being set correctly
on the directory `/data/data` when a device first boots in FBE mode.