### PR TITLE
[o-mr0] Remove build barrier for clean ramdump partition

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -206,12 +206,10 @@ PRODUCT_PACKAGES += \
     librqbalance
 
 # PRODUCT_PLATFORM isn't set yet, thus we check the available path
-ifneq (,$(filter %loire %tone %yoshino,$(PLATFORM_COMMON_PATH)))
 ifneq (,$(filter userdebug eng,$(TARGET_BUILD_VARIANT)))
 # ramdump cleaner
 PRODUCT_PACKAGES += \
     rdclean.sh
-endif
 endif
 
 # odmcheck

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -1,6 +1,5 @@
 LOCAL_PATH := $(call my-dir)
 
-ifneq (,$(filter loire tone yoshino,$(PRODUCT_PLATFORM)))
 ifneq (,$(filter userdebug eng,$(TARGET_BUILD_VARIANT)))
 include $(CLEAR_VARS)
 LOCAL_MODULE             := rdclean.sh
@@ -10,7 +9,6 @@ LOCAL_INIT_RC_64         := vendor/etc/init/rdclean.rc
 LOCAL_MODULE_TARGET_ARCH := arm64
 LOCAL_VENDOR_MODULE      := true
 include $(BUILD_PREBUILT)
-endif
 endif
 
 include $(CLEAR_VARS)


### PR DESCRIPTION
Ramdump partition is available on all modern qcom SoC's,
even on a msm8939. So clean ramdump partition can be used
on all devices and there is no sense in using this barrier.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>