### PR TITLE
[o-mr0] changes for FBE (part 2/2)

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -54,7 +54,7 @@ on charger
     start irsc_util
 
 on fs
-    mount_all ./fstab.${ro.hardware}
+    mount_all ./fstab.${ro.hardware} --early
 
     # /dsp is initially unlabelled so we need to mount
     # it as rw, restore AOSP labels, then remount
@@ -77,6 +77,8 @@ on fs
 on post-fs
     # Wait qseecomd started
     wait_for_prop sys.listeners.registered true
+
+    mount_all ./fstab.${ro.hardware} --late
 
     exec - system graphics -- /vendor/bin/odmcheck
 


### PR DESCRIPTION
Use "--early" and "--late" flags so that userdata can be mounted in
FBE mode.  To make the fbe keys available, vold needs to communicate
with keymaster via qseecomd.