### PR TITLE
[DONOTMERGE] gps: switch to an updated hal

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -82,7 +82,7 @@ MASTER_SIDE_CP_TARGET_LIST := msm8996 msm8998
 include $(call all-makefiles-under,$(LOCAL_PATH))
 
 audio-hal := hardware/qcom/audio
-gps-hal := hardware/qcom/gps/msm8994
+gps-hal := hardware/qcom/gps/sdm845
 display-hal := hardware/qcom/display/msm8998
 QCOM_MEDIA_ROOT := hardware/qcom/media/msm8998
 OMX_VIDEO_PATH := mm-video-v4l2

--- a/common.mk
+++ b/common.mk
@@ -129,10 +129,11 @@ PRODUCT_PACKAGES += \
 
 # GPS
 PRODUCT_PACKAGES += \
-    libloc_api_v02 \
     libloc_core \
-    libloc_eng \
-    libgps.utils
+    libgps.utils \
+    liblocation_api \
+    libloc_pla \
+    libgnss
 
 # WLAN
 PRODUCT_PACKAGES += \
@@ -175,7 +176,8 @@ PRODUCT_PACKAGES += \
 # QCOM GPS
 PRODUCT_PACKAGES += \
     libloc_api_v02 \
-    libloc_ds_api
+    libloc_ds_api \
+    libgnsspps
 
 # Charger
 PRODUCT_PACKAGES += \

--- a/treble.mk
+++ b/treble.mk
@@ -53,7 +53,8 @@ PRODUCT_PACKAGES += \
 
 # GNSS
 PRODUCT_PACKAGES += \
-    android.hardware.gnss@1.0-impl
+    android.hardware.gnss@1.0-impl-qti \
+    android.hardware.gnss@1.0-service-qti
 
 # Light
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
The msm8994 gps hal we are using is obsolete. Switch to using a more up-to-date hal.

Change-Id: I4449e66f772c298a040d71cf8d3aca14b290aa07