### PR TITLE
[DONOTMERGE] rootdir: system: gps_debug: add SUPL server config

### DIFF
--- a/rootdir/system/etc/gps_debug.conf
+++ b/rootdir/system/etc/gps_debug.conf
@@ -6,8 +6,8 @@
 ##### AGPS server settings #####
 ################################
 # FOR SUPL SUPPORT, set the following
-# SUPL_HOST=supl.google.com or IP
-# SUPL_PORT=7275
+SUPL_HOST=supl.sonyericsson.com
+SUPL_PORT=7275
 
 # supl version 2.0
 # SUPL_VER=0x20000


### PR DESCRIPTION
The gps hal does not seem to read SUPL data from gps.conf
Hence, add the configuration to gps_debug.conf to allow android to set those

Change-Id: Ib14d5f782b9b6095360186582a514e83dff69b80