### PR TITLE
rootdir: vendor: services: remove capablities from sensors service

### DIFF
--- a/rootdir/vendor/etc/init/sensors.rc
+++ b/rootdir/vendor/etc/init/sensors.rc
@@ -8,6 +8,3 @@ service sensors /odm/bin/sensors.qcom
     user root
     group root system
     writepid /dev/cpuset/system-background/tasks
-    # Grants the ability for this daemon to bind IPC router ports so it can
-    # register QMI services
-    capabilities NET_BIND_SERVICE


### PR DESCRIPTION
Adding NET_BIND_SERVICE capability to sensors service causes it to crash with a sigtrap.
Removing it fixes that issue, and the service seems to run fine afterwards.

Thanks to luk1337@github for the hint!

Change-Id: I60d5723ec07d4c8f06be8e164ddbacdb315bb437