### PR TITLE
CommonConfig: only pre-optimize boot classpath and system_server jars

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -96,6 +96,7 @@ ifeq ($(HOST_OS),linux)
     endif
   endif
 endif
+WITH_DEXPREOPT_BOOT_IMG_AND_SYSTEM_SERVER_ONLY ?= true
 
 BUILD_KERNEL := true
 -include device/sony/common-headers/KernelHeaders.mk


### PR DESCRIPTION
The new WITH_DEXPREOPT_BOOT_IMG_AND_SYSTEM_SERVER_ONLY flag introduced in o-mr1 makes it possible to only pre-optimize boot and system_server related dex code.
Use the flag to avoid SELinux denials related to system_server trying to access dalvik/art cache from /data, while having other system dex code optimized at runtime.
This should also help save some space on /system.

Thanks to LuK1337@github for the hint!

Change-Id: I026b7fa8b2a4b270ff44cab71bd1e6d304ef3c6b