### PR TITLE
[master] sony: common: init: Fix dac override for charger

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -25,6 +25,7 @@ on charger
 # Offline charger
 service charger /charger
     class charger
+    group root system
     seclabel u:r:charger:s0
 
 on early-init

--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -26,6 +26,7 @@ on charger
 service charger /charger
     class charger
     group root system
+    critical
     seclabel u:r:charger:s0
 
 on early-init


### PR DESCRIPTION
Add system group to the charger service and avoid
selinux denials.

avc:  denied  { dac_override } for  pid=465 comm="charger" capability=1
scontext=u:r:charger:s0 tcontext=u:r:charger:s0
tclass=capability permissive=0

Also, set service as critical.

If the charger service doesn't work properly
then we'll be able to check what's wrong with it
by reading pstore if it is a critical service.

If the service is not critical then we'll get a freezing boot splash
which will not help in nothing for users and developers.