### PR TITLE
[n-mr1] common.rc: Use setgid on /data/misc/wifi

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -68,6 +68,9 @@ on post-fs-data
     # Create directory used by bluetooth subsystem
     mkdir /data/misc/bluetooth 2770 bluetooth bluetooth
 
+    # Create directory used by Wireless subsystem
+    mkdir /data/misc/wifi 2770 wifi wifi
+
     # To observe dnsmasq.leases file for dhcp information of soft ap.
     chown dhcp system /data/misc/dhcp
 


### PR DESCRIPTION
The macaddrsetup service creates a file in this directory containing
the wifi MAC address that needs to be readable by the wireless
service. Ensure files created here are in the wifi group.