### PR TITLE
common.rc: Create netmgrd dirs on /data in post-fs-data not of boot trigger

### DIFF
--- a/rootdir/vendor/etc/init/netmgrd.rc
+++ b/rootdir/vendor/etc/init/netmgrd.rc
@@ -2,6 +2,7 @@ on boot
     #Create NETMGR daemon socket area
     mkdir /dev/socket/netmgr 0750 radio radio
 
+on post-fs-data
     #create netmgr log dir
     mkdir /data/vendor/netmgr 0770 radio radio
     chmod 0770 /data/vendor/netmgr


### PR DESCRIPTION
The boot trigger gets executed before the filesystems are ready. If an
encrypted filesystem is used, it is not yet mounted at the time of execution of
the boot trigger. This causes problems with "forceencrypt" settings in the
fstab, as the partition is also encrypted on the first boot and directories
can never be created at all.

sonyxperiadev/bug_tracker#78
