### PR TITLE
rootdir: vendor: add public.libraries.txt

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -57,6 +57,10 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     $(COMMON_PATH)/rootdir/vendor/etc/audio_effects.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_effects.xml
 
+# Public Libraries
+PRODUCT_COPY_FILES += \
+    $(COMMON_PATH)/rootdir/vendor/etc/public.libraries.txt:$(TARGET_COPY_OUT_VENDOR)/etc/public.libraries.txt
+
 # librqbalance
 PRODUCT_PACKAGES += \
     librqbalance

--- a/rootdir/vendor/etc/public.libraries.txt
+++ b/rootdir/vendor/etc/public.libraries.txt
@@ -1,0 +1,4 @@
+libadsprpc.so
+libcdsprpc.so
+libsdsprpc.so
+libOpenCL.so


### PR DESCRIPTION
Android needs this text file to know what libraries are allowed to be loaded by apps directly.
For now, add:
libOpenCL.so to the list, in order to get OpenCL to function properly.
adsprpc related libraries, since they were also declared public in stock.

Change-Id: I15ef7a7ab7d1f1a0cc6b484cd2ca9993f40de23b