### PR TITLE
[master] sony: common: init: Fix charger dependencies

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -13,11 +13,6 @@
 # limitations under the License.
 
 on charger
-    # Booting modem
-    wait /dev/block/bootdevice/by-name/system
-    mount ext4 /dev/block/bootdevice/by-name/system /system ro barrier=1
-    wait /dev/block/bootdevice/by-name/oem
-    mount ext4 /dev/block/bootdevice/by-name/oem /odm ro barrier=1
     start rmt_storage
     start mlog_qmi_service
     start irsc_util
@@ -36,6 +31,9 @@ on early-init
 on init
     wait /dev/block/platform/soc/${ro.boot.bootdevice}
     symlink /dev/block/platform/soc/${ro.boot.bootdevice} /dev/block/bootdevice
+
+    # Mount RO partitions early and load all init files from /system/vendor
+    mount_all ./fstab.${ro.hardware} --early
 
     # Enable subsystem restart
     write /sys/module/subsystem_restart/parameters/enable_ramdumps 0
@@ -61,8 +59,6 @@ on init
     write /proc/sys/vm/page-cluster 0
 
 on fs
-    mount_all ./fstab.${ro.hardware}
-
     # /dsp is initially unlabelled so we need to mount
     # it as rw, restore AOSP labels, then remount
     restorecon_recursive /dsp
@@ -80,6 +76,10 @@ on fs
     # qseecomd needs /dev/block/bootdevice
     # vold needs keymaster that needs qseecomd
     start qseecomd
+
+on late-fs
+    # Mount RW partitions which need run fsck
+    mount_all ./fstab.${ro.hardware} --late
 
 on post-fs
     # Wait qseecomd started


### PR DESCRIPTION
This path allows system and odm to be mounted early which
have .rc files and critical services that are called/required
from boot process.

There is a race condition during offline charger service call as following:

When its dependencies are declared in vendor then we have the service loading error:

[    2.189134] charger: android charging is enabled
[    2.202449] EXT4-fs (mmcblk0p52): mounted filesystem with ordered data mode. Opts: barrier=1
[    2.207436] EXT4-fs (mmcblk0p28): mounted filesystem with ordered data mode. Opts: barrier=1
[    2.207589] init: do_start: Service rmt_storage not found
[    2.207648] init: do_start: Service mlog_qmi_service not found
[    2.207745] init: do_start: Service irsc_util not found
[    2.207809] init: processing action (charger) from (init.loire.pwr.rc:30)

If the services are declared inline (in ramdisk) then we have:

[    2.662462] charger: android charging is enabled
[    2.676562] EXT4-fs (mmcblk0p52): mounted filesystem with ordered data mode. Opts: barrier=1
[    2.684344] EXT4-fs (mmcblk0p28): mounted filesystem with ordered data mode. Opts: barrier=1
[    2.685980] init: starting service 'rmt_storage'...
[    2.686785] init: starting service 'mlog_qmi_service'...
[    2.687525] init: starting service 'irsc_util'...
[    2.688257] init: processing action (charger) from (init.loire.pwr.rc:30)

Signed-off-by: Humberto Borba <humberos@omnirom.org>
Change-Id: I927a23aaec1847b5ab8dfc8fda6172ce930d2c6e