### PR TITLE
[master] sony: common: init: Fix dac_override denial for charger

### DIFF
--- a/rootdir/init.common.rc
+++ b/rootdir/init.common.rc
@@ -20,7 +20,7 @@ on charger
 # Offline charger
 service charger /charger
     class charger
-    group root system
+    group root system log
     critical
     seclabel u:r:charger:s0
 


### PR DESCRIPTION
This group is necessary for charger service which will fix selinux denials
as following:

avc:  denied  { dac_override } for  pid=475 comm="charger" capability=1
scontext=u:r:charger:s0 tcontext=u:r:charger:s0
tclass=capability permissive=0

avc:  denied  { dac_read_search } for  pid=475 comm="charger" capability=2
scontext=u:r:charger:s0 tcontext=u:r:charger:s0 tclass=capability permissive=0

Signed-off-by: Humberto Borba <humberos@omnirom.org>
Change-Id: I5b0354be45ee5ae036ca12f4a04765354fab21cc