### PR TITLE
[COMMON] SystemUI: Disable lockscreen anti-falsing classifier

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -30,4 +30,9 @@
 
     <!-- Should "4G" be shown instead of "LTE" when the network is NETWORK_TYPE_LTE? -->
     <bool name="config_show4GForLTE">false</bool>
+
+    <!-- If true, enable the advance anti-falsing classifier on the lockscreen. On some devices it
+         does not work well, particularly with noisy touchscreens. Note that disabling it may
+         increase the rate of unintentional unlocks. -->
+    <bool name="config_lockscreenAntiFalsingClassifierEnabled">false</bool>
 </resources>


### PR DESCRIPTION
The anti falsing feature makes some devices to be basically
impossible to get reliably unlocked at lockscreen stage and
not only: it can also be seriously difficult to even reply to a
phone call.
This is mainly seen on Loire Suzu and Tone Dora.
Disable the feature to solve the issue.