### PR TITLE
Remove ro.sys.sdcardfs property

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -140,10 +140,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     debug.qualcomm.sns.hal=0 \
     debug.qualcomm.sns.libsensor1=0
 
-# sdcardFS
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.sys.sdcardfs=true
-
 # RILD
 PRODUCT_PROPERTY_OVERRIDES += \
     rild.libpath=/odm/lib64/libril-qc-qmi-1.so \


### PR DESCRIPTION
* It's enabled by default since 8.0.0