### PR TITLE
sony: common: remove cache build flag

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -42,7 +42,6 @@ TARGET_KERNEL_CROSS_COMPILE_PREFIX := aarch64-linux-android-
 BOARD_KERNEL_IMAGE_NAME := Image.gz-dtb
 
 TARGET_USERIMAGES_USE_EXT4 := true
-BOARD_CACHEIMAGE_FILE_SYSTEM_TYPE := ext4
 
 BOARD_ROOT_EXTRA_FOLDERS := bt_firmware dsp firmware persist odm
 


### PR DESCRIPTION
this is not more common since nile (SDM660) has not cache partition
move this to platform

Signed-off-by: David Viteri <davidteri91@gmail.com>