### PR TITLE
overlay: Disable rounded corners

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values-sw372dp/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values-sw372dp/dimens.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ * Copyright (c) 2006, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+-->
+<resources>
+    <dimen name="rounded_corner_content_padding">0dp</dimen>
+</resources>


### PR DESCRIPTION
* None of devices that we support have
  rounded screen.