### PR TITLE
common: add slot2 for radio and radio.deprecated

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -185,10 +185,12 @@
         <interface>
             <name>IRadio</name>
             <instance>slot1</instance>
+            <instance>slot2</instance>
         </interface>
         <interface>
             <name>ISap</name>
             <instance>slot1</instance>
+            <instance>slot2</instance>
         </interface>
     </hal>
     <hal format="hidl">
@@ -198,6 +200,7 @@
         <interface>
             <name>IOemHook</name>
             <instance>slot1</instance>
+            <instance>slot2</instance>
         </interface>
     </hal>
     <hal format="hidl">


### PR DESCRIPTION
03-19 04:35:23.787   568   568 W /system/bin/hwservicemanager: getTransport: Cannot find entry android.hardware.radio@1.0::IRadio/slot2 in either framework or device manifest.
03-19 04:35:23.804   568   568 W /system/bin/hwservicemanager: getTransport: Cannot find entry android.hardware.radio.deprecated@1.0::IOemHook/slot2 in either framework or device manifest.

Signed-off-by: David Viteri <davidteri91@gmail.com>