### PR TITLE
Enforce RRO on framework-res

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -20,6 +20,9 @@ COMMON_PATH := device/sony/common
 
 DEVICE_PACKAGE_OVERLAYS += $(COMMON_PATH)/overlay
 
+PRODUCT_ENFORCE_RRO_TARGETS := \
+    framework-res
+
 # Codecs Configuration
 PRODUCT_COPY_FILES += \
     frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_audio.xml \


### PR DESCRIPTION
Overlays only for framework-res will be converted into RROs.

Other overlays can't be converted due to some known issues on app RRO.

Bug: 36231603
Change-Id: Idca30fdbbcc990fd124de16a06a112a346612a61
(cherry picked from commit db1b6058200fc5255f519cf6609fca7619d6743e)