### PR TITLE
Drop redundant audio package

### DIFF
--- a/common-packages.mk
+++ b/common-packages.mk
@@ -22,7 +22,6 @@ PRODUCT_PACKAGES += \
 # For audio.primary
 PRODUCT_PACKAGES += \
     libtinyalsa \
-    libtinycompress \
     libaudioroute \
     tinymix
 


### PR DESCRIPTION
 * Vendor specific tinycompress is explicitly built in the audio HAL.
 * See : https://android.googlesource.com/platform/hardware/qcom/audio/+/android-8.1.0_r15/hal/Android.mk#92

Change-Id: I8e25e4e5da141e9aad5646cb551fa85d772181f1