### PR TITLE
wifi: fix wifi on nile

### DIFF
--- a/hardware/qca_cld3/Android.mk
+++ b/hardware/qca_cld3/Android.mk
@@ -1,4 +1,8 @@
 ifeq ($(WIFI_DRIVER_BUILT),qca_cld3)
 $(shell mkdir -p $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/firmware/wlan/qca_cld)
+ifneq ($(filter nile,$(PRODUCT_PLATFORM)),)
+$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR) > /dev/null && ln -s /persist/wlan_mac.bin data/misc/wifi/wlan_mac.bin && popd > /dev/null)
+else
 $(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR) > /dev/null && ln -s /data/misc/wifi/wlan_mac.bin firmware/wlan/qca_cld/wlan_mac.bin && popd > /dev/null)
+endif
 endif


### PR DESCRIPTION
sdm660 has wlan_mac.bin placed on /persist partition and it should be linked to /data
this fixes the unknown IP address

Signed-off-by: David Viteri <davidteri91@gmail.com>