### PR TITLE
Remove `camera.device@3.2-impl` from product packages

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -28,7 +28,6 @@ PRODUCT_PACKAGES += \
 
 # Camera
 PRODUCT_PACKAGES += \
-    camera.device@3.2-impl \
     android.hardware.camera.provider@2.4-impl \
     android.hardware.camera.provider@2.4-service
 


### PR DESCRIPTION
* android.hardware.camera.provider@2.4-impl depends on it
  thus we don't need to add it to product packages manually.