### PR TITLE
vold: Use mke2fs to create ext4 images

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -41,6 +41,8 @@ TARGET_KERNEL_HEADER_ARCH := arm64
 TARGET_KERNEL_CROSS_COMPILE_PREFIX := aarch64-linux-android-
 BOARD_KERNEL_IMAGE_NAME := Image.gz-dtb
 
+# Use mke2fs to create ext4 images
+TARGET_USES_MKE2FS := true
 TARGET_USERIMAGES_USE_EXT4 := true
 
 BOARD_ROOT_EXTRA_FOLDERS := bt_firmware dsp firmware persist odm


### PR DESCRIPTION
Set TARGET_USES_MKE2FS := true to use new EXT4 tool chain

Bug: 62421233
Test: walleye boots with new parition
Change-Id: Id6e5c68b2d7854e5330ad87443b974361a4bff9d