### PR TITLE
init: remove video symlinks

### DIFF
--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -224,11 +224,6 @@ on boot
     chown radio radio /data/misc/radio/copy_complete
     chmod 0660 /data/misc/radio/copy_complete
 
-    # Camera Recording
-    mkdir /dev/video
-    symlink /dev/video32 /dev/video/venus_dec
-    symlink /dev/video33 /dev/video/venus_enc
-
     chmod 0444 /sys/devices/platform/msm_hsusb/gadget/usb_state
 
     # Graphics Permissions


### PR DESCRIPTION
newer devices use another video instance like video2

Signed-off-by: David Viteri <davidteri91@gmail.com>