### PR TITLE
common: add guard to serial console

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -29,7 +29,9 @@ TARGET_NO_KERNEL := false
 ifneq ($(BOARD_USE_ENFORCING_SELINUX),true)
 BOARD_KERNEL_CMDLINE += androidboot.selinux=permissive
 endif
-#BOARD_KERNEL_CMDLINE += console=ttyMSM0,115200,n8 androidboot.console=ttyMSM0
+ifeq ($(BOARD_ENABLE_SERIAL_CONSOLE),true)
+BOARD_KERNEL_CMDLINE += console=ttyMSM0,115200,n8 androidboot.console=ttyMSM0
+endif
 BOARD_KERNEL_CMDLINE += msm_rtb.filter=0x3F ehci-hcd.park=3
 BOARD_KERNEL_CMDLINE += coherent_pool=8M
 BOARD_KERNEL_CMDLINE += sched_enable_power_aware=1 user_debug=31


### PR DESCRIPTION
enable it by a flag when is needed

Signed-off-by: David Viteri <davidteri91@gmail.com>