### PR TITLE
[COMMON] hardware: liblights: Add support for MicroCommunicator backlight

### DIFF
--- a/hardware/liblights/Android.mk
+++ b/hardware/liblights/Android.mk
@@ -7,6 +7,11 @@ ifeq ($(TARGET_COMPILE_WITH_MSM_KERNEL),true)
 LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
 LOCAL_ADDITIONAL_DEPENDENCIES := $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
 endif
+
+ifeq ($(TARGET_USES_UCOMM_BACKLIGHT),true)
+    LOCAL_CFLAGS += -DUCOMMSVR_BACKLIGHT
+endif
+
 LOCAL_MODULE := android.hardware.light@2.0-service.sony
 LOCAL_INIT_RC := android.hardware.light@2.0-service.sony.rc
 LOCAL_SRC_FILES := \
@@ -22,5 +27,9 @@ LOCAL_SHARED_LIBRARIES := \
     libhidlbase \
     libhidltransport \
     android.hardware.light@2.0
+
+ifeq ($(TARGET_USES_UCOMM_BACKLIGHT),true)
+    LOCAL_SHARED_LIBRARIES += libucommunicator
+endif
 
 include $(BUILD_EXECUTABLE)

--- a/hardware/liblights/Light.cpp
+++ b/hardware/liblights/Light.cpp
@@ -22,6 +22,12 @@
 
 #include "Light.h"
 
+#ifdef UCOMMSVR_BACKLIGHT
+extern "C" {
+#include <comm_server/ucomm_ext.h>
+}
+#endif
+
 namespace android {
     namespace hardware {
         namespace light {
@@ -195,8 +201,11 @@ namespace android {
                             if (mDevice->backlight_bits > 8) {
                                 brightness = brightness << (mDevice->backlight_bits - 8);
                             }
-
+#ifdef UCOMMSVR_BACKLIGHT
+                            err = ucommsvr_set_backlight(brightness);
+#else
                             err = writeInt(LCD_FILE, brightness);
+#endif
                         }
 
                         pthread_mutex_unlock(&mDevice->g_lcd_lock);


### PR DESCRIPTION
Devices with projection unit require the new Micro Communicator
to manage the same.
Add support to send the backlight events to the MicroComm to
be able to manage the projection light on these devices.

This support gets enabled only when TARGET_USES_UCOMM_BACKLIGHT.