### PR TITLE
common: prop: Add volume steps

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -91,7 +91,9 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.audio.fluence.speaker=true \
     media.aac_51_output_enabled=true \
     audio.deep_buffer.media=1 \
-    fmas.hdph_sgain=0
+    fmas.hdph_sgain=0 \
+    ro.config.vc_call_vol_steps=8 \
+    ro.config.media_vol_steps=24
 
 # Property to enable user to access Google WFD settings.
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
This allows for greater flexibility in configuring audio for precise
situations where the stock Android configuration does not provide
enough headway

Signed-off-by: RJ Trujillo <certifiedblyndguy@gmail.com>