### PR TITLE
Return "0" as duty pcts when brightness is equal 0

### DIFF
--- a/hardware/liblights/Light.cpp
+++ b/hardware/liblights/Light.cpp
@@ -143,6 +143,10 @@ namespace android {
                     std::string Light::getScaledDutyPcts(int brightness) {
                         std::string buf, pad;
 
+                        if (brightness <= 0) {
+                            return "0";
+                        }
+
                         for (auto i : BRIGHTNESS_RAMP) {
                             buf += pad;
                             buf += std::to_string(i * brightness / 255);


### PR DESCRIPTION
* For some reason our driver doesn't really like
  duty pcts that are like: "0,0,0,0,0,0,0,0" breaking
  custom colors in RGB sync blink.
* Returning "0" instead fixes that issue.