### PR TITLE
[master] rootdir: Android.mk: Add msm8916 to qmuxd.rc service barrier

### DIFF
--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -151,7 +151,7 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 
-ifneq ($(filter msm8952,$(TARGET_BOARD_PLATFORM)),)
+ifneq ($(filter msm8916 msm8952,$(TARGET_BOARD_PLATFORM)),)
 include $(CLEAR_VARS)
 LOCAL_MODULE := qmuxd.rc
 LOCAL_MODULE_CLASS := ETC


### PR DESCRIPTION
Add msm8916 to the build barier for qmuxd.rc service since it is
used on msm8939 and it should be built for it too.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>