### PR TITLE
common: Unify ro.odm.* definition

### DIFF
--- a/misc/version/Android.mk
+++ b/misc/version/Android.mk
@@ -1,1 +1,1 @@
-$(shell pushd $(PRODUCT_OUT)/odm/ > /dev/null && echo "ro.odm.version=$(PLATFORM_VERSION)_$(TARGET_KERNEL_VERSION)_$(TARGET_BOOTLOADER_BOARD_NAME)_$(TARGET_VENDOR_VERSION)" >build.prop && popd > /dev/null)
+$(shell pushd $(PRODUCT_OUT)/odm/ > /dev/null && echo "ro.odm.version=$(PLATFORM_VERSION)_$(SOMC_KERNEL_VERSION)_$(SOMC_PLATFORM)_$(TARGET_VENDOR_VERSION)" >build.prop && popd > /dev/null)


### PR DESCRIPTION
If we use different definitions chances are that we run into missmatches even if we don't want to.
Also, SOMC_KERNEL_VERSION is undefined.