### PR TITLE
hardware: qcom: bt: enable suport for sdm845

### DIFF
--- a/hardware/qcom/Android.mk
+++ b/hardware/qcom/Android.mk
@@ -40,5 +40,11 @@ include $(call all-makefiles-under,$(gps-hal))
 include $(call all-makefiles-under,$(media-hal))
 
 ifeq ($(BOARD_HAVE_BLUETOOTH_QCOM),true)
+ifeq ($(SOMC_KERNEL_VERSION),4.4)
 include $(call all-makefiles-under,hardware/qcom/bt/msm8998)
+endif
+
+ifeq ($(SOMC_KERNEL_VERSION),4.9)
+include $(call all-makefiles-under,hardware/qcom/bt/sdm845)
+endif
 endif


### PR DESCRIPTION
configure the gits for 4.9 kernel and sdm845 SOC

Signed-off-by: David Viteri <davidteri91@gmail.com>