### PR TITLE
rootdir: vendor: init: remove xtra.rc

### DIFF
--- a/rootdir/vendor/etc/init/xtra.rc
+++ b/rootdir/vendor/etc/init/xtra.rc
@@ -1,5 +1,0 @@
-# XTRA daemon
-service xtra-daemon /odm/bin/xtra-daemon
-    class late_start
-    user gps
-    group gps system


### PR DESCRIPTION
The service xtra-daemon service is not necessary for gps functionality.
Confirmed by clearing AGPS data, removing the service and then rebooting and trying to get a lock. The time to first fix (TTFF) wasn't drastically affected by the service removal.