### PR TITLE
init: xtra service removal

### DIFF
--- a/common-init.mk
+++ b/common-init.mk
@@ -34,5 +34,4 @@ PRODUCT_PACKAGES += \
     tad.rc \
     ta_qmi.rc \
     tftp_server.rc \
-    wpa_supplicant.rc \
-    xtra.rc
+    wpa_supplicant.rc 


### PR DESCRIPTION
Missed inclusion in the removal of the xtra-daemon service.
Fixes build.