### PR TITLE
netmgr: remove legacy /data/misc/netmgr folder

### DIFF
--- a/rootdir/vendor/etc/init/netmgrd.rc
+++ b/rootdir/vendor/etc/init/netmgrd.rc
@@ -7,10 +7,6 @@ on post-fs-data
     mkdir /data/vendor/netmgr 0770 radio radio
     chmod 0770 /data/vendor/netmgr
 
-    #create netmgr log dir legacy
-    mkdir /data/misc/netmgr 0770 radio radio
-    chmod 0770 /data/misc/netmgr
-
 # NET Manager Daemon
 service netmgrd /odm/bin/netmgrd
     class main


### PR DESCRIPTION
all the things were move to /data/vendor/netmgr and we should not add permissions
for the old location

Signed-off-by: David Viteri <davidteri91@gmail.com>