### PR TITLE
[RQB-POWER] Sustained performance and Cluster Frequency Limits (rqb-cfl)

### DIFF
--- a/hardware/power/power.c
+++ b/hardware/power/power.c
@@ -40,9 +40,6 @@ static struct rqbalance_params *rqb;
 static int hal_init_ok = false;
 static rqb_pwr_mode_t cur_pwrmode;
 
-/* Remove this when all platforms will be migrated? */
-static bool param_perf_supported = true;
-
 /* PowerServer */
 static int sock;
 static int clientsock;
@@ -259,9 +256,6 @@ void set_power_mode(rqb_pwr_mode_t mode)
 {
     char* mode_string = rqb_param_string(mode, false);
 
-    if (mode == POWER_MODE_PERFORMANCE && !param_perf_supported)
-        return;
-
     ALOGI("Setting %s mode", mode_string);
 
     __set_power_mode(&rqb[mode]);
@@ -428,9 +422,6 @@ static void power_init(struct power_module *module UNUSED)
     if (ret < 0)
         goto general_error;
 
-    if (!param_perf_supported)
-        ALOGW("No performance parameters. Going on.");
-
     hal_init_ok = true;
 
     property_get(PROP_DEBUGLVL, propval, "0");
@@ -498,7 +489,7 @@ static void power_hint(struct power_module *module UNUSED, power_hint_t hint,
             break;
 
         case POWER_HINT_VR_MODE:
-            if (data && param_perf_supported) {
+            if (data) {
                 set_power_mode(POWER_MODE_PERFORMANCE);
             } else {
                 set_power_mode(POWER_MODE_BALANCED);
@@ -506,7 +497,7 @@ static void power_hint(struct power_module *module UNUSED, power_hint_t hint,
             break;
 
         case POWER_HINT_LAUNCH:
-            if (data && param_perf_supported) {
+            if (data) {
                 set_power_mode(POWER_MODE_PERFORMANCE);
             } else {
                 set_power_mode(POWER_MODE_BALANCED);

--- a/hardware/power/power.c
+++ b/hardware/power/power.c
@@ -122,6 +122,7 @@ static char* rqb_param_string(rqb_pwr_mode_t pwrmode, bool compat)
         case POWER_MODE_SUSTAINED:
             type_string = "sustained_perf";
             compat_string = "sustain";
+            break;
         default:
             return "unknown";
     }
@@ -137,10 +138,11 @@ static char* rqb_param_string(rqb_pwr_mode_t pwrmode, bool compat)
  *
  * \param pwrmode - RQBalance Power Mode (from enum rqb_pwr_mode_t)
  */
-static void print_parameters(rqb_pwr_mode_t pwrmode)
+static void print_parameters(rqb_pwr_mode_t pwrmode, int dbg_lvl)
 {
     char* mode_string = rqb_param_string(pwrmode, false);
     struct rqbalance_params *cur_params = &rqb[pwrmode];
+    int i;
 
     ALOGI("Parameters for %s mode:", mode_string);
     ALOGI("Minimum cores:       %s", cur_params->min_cpus);
@@ -148,6 +150,14 @@ static void print_parameters(rqb_pwr_mode_t pwrmode)
     ALOGI("Upcore thresholds:   %s", cur_params->up_thresholds);
     ALOGI("Downcore thresholds: %s", cur_params->down_thresholds);
     ALOGI("Balance level:       %s", cur_params->balance_level);
+
+    if (dbg_lvl < 2)
+        return;
+
+    for (i = 0; i < CLUSTER_MAX; i++)
+        ALOGI("Cluster %d MIN-MAX:   %s - %s", i,
+               cur_params->freq_limit[i].min_freq,
+               cur_params->freq_limit[i].max_freq);
 }
 
 /*
@@ -247,6 +257,18 @@ void __set_special_power_mode(char* max_cpus, char* min_cpus,
     return;
 }
 
+void __set_cpufreq_mode(struct rqbalance_params *rqparm)
+{
+    int i, ret;
+
+    for (i = 0; i < CLUSTER_MAX; i++) {
+        sysfs_write(SYS_CPU_HI_LIMIT, rqparm->freq_limit[i].max_freq);
+        sysfs_write(SYS_CPU_LOW_LIMIT, rqparm->freq_limit[i].min_freq);
+    }
+
+    return;
+}
+
 /*
  * set_power_mode - Writes power configuration to the RQBalance driver
  *
@@ -259,6 +281,7 @@ void set_power_mode(rqb_pwr_mode_t mode)
     ALOGI("Setting %s mode", mode_string);
 
     __set_power_mode(&rqb[mode]);
+    __set_cpufreq_mode(&rqb[mode]);
 
     cur_pwrmode = mode;
 }
@@ -389,7 +412,8 @@ static bool init_all_rqb_params(void)
 {
     int i, ret;
 
-    rqb = malloc(sizeof(struct rqbalance_params) * POWER_MODE_MAX);
+    rqb = (struct rqbalance_params*) calloc(POWER_MODE_MAX,
+                                            sizeof(struct rqbalance_params));
     assert(rqb != NULL);
 
     for (i = 0; i < POWER_MODE_MAX; i++)
@@ -430,7 +454,7 @@ static void power_init(struct power_module *module UNUSED)
     if (dbg_lvl > 0) {
         ALOGW("WARNING: Starting in debug mode");
         for (i = 0; i < POWER_MODE_MAX; i++) {
-                print_parameters(i);
+                print_parameters(i, dbg_lvl);
         }
     } else {
         ALOGI("Loading with debug off. To turn on, set %s", PROP_DEBUGLVL);

--- a/hardware/power/power.c
+++ b/hardware/power/power.c
@@ -122,6 +122,9 @@ static char* rqb_param_string(rqb_pwr_mode_t pwrmode, bool compat)
             type_string = "video_encoding";
             compat_string = "venc";
             break;
+        case POWER_MODE_SUSTAINED:
+            type_string = "sustained_perf";
+            compat_string = "sustain";
         default:
             return "unknown";
     }
@@ -505,6 +508,14 @@ static void power_hint(struct power_module *module UNUSED, power_hint_t hint,
         case POWER_HINT_LAUNCH:
             if (data && param_perf_supported) {
                 set_power_mode(POWER_MODE_PERFORMANCE);
+            } else {
+                set_power_mode(POWER_MODE_BALANCED);
+            }
+            break;
+
+        case POWER_HINT_SUSTAINED_PERFORMANCE:
+            if (data) {
+                set_power_mode(POWER_MODE_SUSTAINED);
             } else {
                 set_power_mode(POWER_MODE_BALANCED);
             }

--- a/hardware/power/power.h
+++ b/hardware/power/power.h
@@ -52,6 +52,7 @@ typedef enum {
 	POWER_MODE_PERFORMANCE,
 	POWER_MODE_OMXDECODE,
 	POWER_MODE_OMXENCODE,
+	POWER_MODE_SUSTAINED,
 	/* Do not use this entry */
 	POWER_MODE_MAX,
 } rqb_pwr_mode_t;

--- a/hardware/power/power.h
+++ b/hardware/power/power.h
@@ -27,9 +27,11 @@
 #define SYS_BALANCE_LVL		RQBALANCE_NODE "balance_level"
 #define SYS_UPCORE_THRESH	RQBALANCE_NODE "nr_run_thresholds"
 #define SYS_DNCORE_THRESH	RQBALANCE_NODE "nr_down_run_thresholds"
+#define SYS_CPU_LOW_LIMIT	RQBALANCE_NODE "cluster_freq_vote_min"
+#define SYS_CPU_HI_LIMIT	RQBALANCE_NODE "cluster_freq_vote_max"
 
 /* Android properties */
-#define PROP_DEBUGLVL			"powerhal.debug_level"
+#define PROP_DEBUGLVL			"persist.powerhal.debug_level"
 
 /* PowerServer definitions */
 #define POWERSERVER_DIR			"/dev/socket/powerhal/"
@@ -58,6 +60,33 @@ typedef enum {
 } rqb_pwr_mode_t;
 
 /*
+ * enum rqb_cfl_clusters_t
+ * Provides System Clusters definitions
+ *
+ * The CLUSTER_MAX entry is used as commodity for code
+ * and shall NEVER be used to reference a CPU Cluster.
+ */
+typedef enum {
+	CLUSTER_LITTLE = 0,
+	CLUSTER_BIG,
+	/* Do not use this entry */
+	CLUSTER_MAX,
+} rqb_cfl_clusters_t;
+
+/*
+ * struct rqbalance_cluster_freq_params
+ * Cluster Frequency Limits structure
+ *
+ * Contains the set of values for the Frequency Limits functionality.
+ * This struct HAS to contain ALL the parameters supported by the
+ * RQBalance Frequency Limits kernel driver functionality.
+ */
+struct rqbalance_cfl_params {
+	char max_freq[10];
+	char min_freq[10];
+};
+
+/*
  * struct rqbalance_params
  * Main RQBalance-PowerHAL structure
  *
@@ -71,6 +100,7 @@ struct rqbalance_params {
 	char up_thresholds[PROPERTY_VALUE_MAX];
 	char down_thresholds[PROPERTY_VALUE_MAX];
 	char balance_level[PROPERTY_VALUE_MAX];
+        struct rqbalance_cfl_params freq_limit[CLUSTER_MAX];
 };
 
 /* Exported functions */

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -259,4 +259,7 @@
         <item>A_GLONASS_POS_PROTOCOL_SELECT=2</item>
     </string-array>
 
+    <!-- If this is true, device supports Sustained Performance Mode. -->
+    <bool name="config_sustainedPerformanceModeSupported">true</bool>
+
 </resources>


### PR DESCRIPTION
Since version 7.0, Android supports a sustained performance
power hint for long-running applications, like games,
camera (in our case, viewfinder, photos but video encoding
keeps its own hint), RenderScript and audio processing:
in these cases the device requires to keep an high performance
state which will produce a lot of heat and, after a while,
the performance will decrease due to thermal mitigations.

To address this issue, handle the sustained performance hint
to limit the performance of the device to an acceptable level
while avoiding overheat.

This patchset also implements userspace management for the new
RQBalance kerneldriver's Cluster Frequency Limits functionality.

Now we support setting limits on minimum and/or maximum frequency
for all clusters by specifying that on any RQBalance-PowerHAL
profile through the XML with the parameters:
- clusterN_freq_min to limit the minimum frequency
- clusterN_freq_max to limit the maximum frequency
where N=0 stands for the "first" cluster, typically LITTLE.

Even though this is not enforced, please note that this feature
is meant to be used with a voting mechanism for temporarily
limiting one or more clusters' frequency and this shall never
be used as a way to permanently set a minimum or maximum
frequency for the clusters: for this, please refer to
the standard CPUFreq sysfs nodes.

Requires update to the RQBalance kernel driver:
https://github.com/kholk/kernel/commit/bb405414e1255377d5814c07bf8fdbb75db0eae5

---------------------------------------------------------------------------
**Example node for a Tone device**

`    <sustained_perf>`
`        <cpuquiet min_cpus="3" max_cpus="3"/>`
`        <rqbalance balance_level="40"/>`
`        <rqbalance down_thresholds="0 35 95 160 4294967295 4294967295 4294967295 4294967295"/>`
`        <rqbalance   up_thresholds="65 145 300 4294967295 4294967295 4294967295 4294967295 4294967295"/>`
`        <rqbalance    cluster0_freq_min="0"/>`
`        <rqbalance    cluster0_freq_max="1324800"/>`
`        <rqbalance    cluster1_freq_min="0"/>`
`        <rqbalance    cluster1_freq_max="1824000"/>`
`    </sustained_perf>`

---------------------------------------------------------------------------
Even though this should be *perfectly* working, this shall *not be merged until further notice*, due to undergoing testing.

This PR is here for everyone to be able to join the testing and to announce the new feature.