### PR TITLE
Add netutils-wrapper to device compatibility matrix.

### DIFF
--- a/compatibility_matrix.xml
+++ b/compatibility_matrix.xml
@@ -55,4 +55,17 @@
             <instance>default</instance>
         </interface>
     </hal>
+    <hal format="native" optional="false">
+        <name>netutils-wrapper</name>
+        <!--
+            netutils-wrapper should only list a single version x.0.
+            netutils-wrapper next version has less functionalities than
+            previous versions, so unlike a HAL, netutils-wrapper are not
+            backwards compatible. Hence the major version must be bumped for
+            each update.
+            Vendor code should switch to (x+1).0 completely before when the
+            requirement is updated here.
+        -->
+        <version>1.0</version>
+    </hal>
 </compatibility-matrix>


### PR DESCRIPTION
netutils-wrapper only list a single version x.0 in its
requirement. System manifest might provide a list of
netutils-wrapper versions it supports {x, y, z}.0.

Bug: 64447338
Test: m compatibility_matrix.xml system_manifest.xml -j
      (checks compatibility at build time)

Change-Id: I2ec919fd5378aed7160c636cb7f2bd138db1473f