### PR TITLE
packages: do not include thermanager for kernel version 4.9

### DIFF
--- a/common-packages.mk
+++ b/common-packages.mk
@@ -92,9 +92,11 @@ PRODUCT_PACKAGES += \
     timekeep \
     TimeKeep \
 
+ifneq ($(SOMC_KERNEL_VERSION),4.9)
 # OSS Thermal Management
 PRODUCT_PACKAGES += \
     thermanager
+endif
 
 # OSS WIFI and BT MAC tool
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
The thermal management has moved to kernel from userspace.
Do not include thermanager in that case to avoid conflicts.

Change-Id: I2dc3eb387fab34b0fc155453f22a35f86c8ebfbd