### PR TITLE
[master] hardware: qcom: Move BT HAL under SOMC_KERNEL_VERSION ifeq

### DIFF
--- a/hardware/qcom/Android.mk
+++ b/hardware/qcom/Android.mk
@@ -10,6 +10,7 @@ MASTER_SIDE_CP_TARGET_LIST := msm8996 msm8998 sdm660 sdm845
 
 ifeq ($(SOMC_KERNEL_VERSION),4.4)
 audio-hal := hardware/qcom/audio
+bt-hal := hardware/qcom/bt/msm8998
 gps-hal := hardware/qcom/gps/sdm845
 display-hal := hardware/qcom/display/msm8998
 QCOM_MEDIA_ROOT := hardware/qcom/media/msm8998
@@ -19,6 +20,7 @@ endif
 
 ifeq ($(SOMC_KERNEL_VERSION),4.9)
 audio-hal := hardware/qcom/audio
+bt-hal := hardware/qcom/bt/sdm845
 gps-hal := hardware/qcom/gps/sdm845
 display-hal := hardware/qcom/display/sde
 QCOM_MEDIA_ROOT := hardware/qcom/media/sdm845
@@ -43,5 +45,5 @@ include $(call all-makefiles-under,$(gps-hal))
 include $(call all-makefiles-under,$(media-hal))
 
 ifeq ($(BOARD_HAVE_BLUETOOTH_QCOM),true)
-include $(call all-makefiles-under,hardware/qcom/bt/msm8998)
+include $(call all-makefiles-under,$(bt-hal))
 endif


### PR DESCRIPTION
Use the SOMC_KERNEL_VERSION flag to pick the appropriate BT HAL:
    - msm8998 for k4.4
    - sdm845    for k4.9

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>