### PR TITLE
[COMMON] common: init: Move hwservicemanager to avoid firmware load issues

### DIFF
--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -90,10 +90,10 @@ on fs
 
     restorecon_recursive /persist
 
+on post-fs
     # Start HW service manager early
     start hwservicemanager
 
-on post-fs
     # Wait qseecomd started
     wait_for_prop sys.listeners.registered true
 


### PR DESCRIPTION
Move hwservicemanager start to post-fs to avoid firmware
loading issues (ADSP and SLPI) due to Android FS checks
at boot.