### PR TITLE
Do not create the dsp directory since it is created by all platforms which need it, as a symlink.

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -47,7 +47,7 @@ BOARD_KERNEL_IMAGE_NAME := Image.gz-dtb
 TARGET_USES_MKE2FS := true
 TARGET_USERIMAGES_USE_EXT4 := true
 
-BOARD_ROOT_EXTRA_FOLDERS := bt_firmware dsp firmware persist odm
+BOARD_ROOT_EXTRA_FOLDERS := bt_firmware firmware persist odm
 
 # Filesystem
 TARGET_FS_CONFIG_GEN := $(COMMON_PATH)/config.fs


### PR DESCRIPTION
It is created according to BOARD_ROOT_EXTRA_SYMLINKS in BoardConfig.mk and PlatformConfig.mk.
Creating both the /dsp directory and the /dsp symlink would cause the symlink to be /dsp/dsp.