### PR TITLE
add guard for ro.telephony.default_network

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -32,8 +32,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 endif
 
 # Default to LTE/GSM/WCDMA.
+ifneq ($(BOARD_IS_DSDS),true)
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.telephony.default_network=9
+endif
 
 # System props for the data modules
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
at the beginning this project supported only single sim targets now there are dual sim targets
add a guard to ro.telephony.default_network so dsds devices can set own properties

Signed-off-by: David Viteri <davidteri91@gmail.com>