### PR TITLE
Fix dev-keys configuration

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -17,8 +17,14 @@ $(call inherit-product-if-exists, device/sony/customization/customization.mk)
 # Vendor version
 TARGET_VENDOR_VERSION := v15
 
-# Release key
-PRODUCT_DEFAULT_DEV_CERTIFICATE := vendor/oss/release-keys/releasekey
+# Specify a "dev-keys" configuration.  Keys from
+# vendor/oss/release-keys will be used instead of the keys under
+# build/make/target/product/security, with the exception of the verity
+# key.  For verity, the build system will still use
+# build/make/target/product/security/verity.pk8, but this can be
+# changed using a post-build re-signing operation (or by making a
+# change inside the build project).
+PRODUCT_DEFAULT_DEV_CERTIFICATE := vendor/oss/release-keys/testkey
 
 # Common path
 COMMON_PATH := device/sony/common


### PR DESCRIPTION
PRODUCT_DEFAULT_DEV_CERTIFICATE should be used to specify the new
location of testkey.  Prior to this change, some apks were still being
signed with keys from build/make/target/product/security.

Note that setting PRODUCT_DEFAULT_DEV_CERTIFICATE does not effect what
verity key is used (so the build is still using
build/make/target/product/security/verity).