### PR TITLE
sony: common: Add SecureElement

### DIFF
--- a/common-packages.mk
+++ b/common-packages.mk
@@ -77,7 +77,8 @@ PRODUCT_PACKAGES += \
 # NFC packages
 PRODUCT_PACKAGES += \
     NfcNci \
-    Tag
+    Tag \
+    SecureElement
 
 # CAMERA
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
It is necessary at Pie version.

Welcome back NFC for loire and maybe for tone too.

PN547 works
it requires hardware/nxp/nfc changes
WIP: https://review.choose-a.name/c/choose-a/android_hardware_nxp_nfc/+/1801

Change-Id: I1084d5f655033e03568c90a9f58efc4caec07feb
Signed-off-by: Humberto Borba <humberos@omnirom.org>