### PR TITLE
treble: Remove misleading PRODUCT_FULL_TREBLE := true

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -1,5 +1,3 @@
-PRODUCT_FULL_TREBLE := true
-
 # RenderScript HAL
 PRODUCT_PACKAGES += \
     android.hardware.renderscript@1.0-impl


### PR DESCRIPTION
This value is ignored and overwritten based on
`PRODUCT_FULL_TREBLE_OVERRIDE` or `PRODUCT_SHIPPING_API_LEVEL`, and thus has
no reason to be set in our makefile.
Relevant build section:
https://android.googlesource.com/platform/build/+/2b32469c47378c3e655e0ef4057ce15a824b184a/core/config.mk#693

In the future we may want to enable this again by setting `PRODUCT_SHIPPING_API_LEVEL`, as soon as it's fully compatible.