### PR TITLE
Drop libbt-vendor

### DIFF
--- a/common-packages.mk
+++ b/common-packages.mk
@@ -70,9 +70,11 @@ PRODUCT_PACKAGES += \
     wpa_supplicant.conf \
     libwpa_client
 
+ifeq ($(BOARD_HAVE_BLUETOOTH_BCM),true)
 # Bluetooth
 PRODUCT_PACKAGES += \
     libbt-vendor
+endif
 
 # NFC packages
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
* We are using QTI bluetooth HAL therefore
  libbt-vendor isn't used for anything.