### PR TITLE
Add camera package to default dnd access list

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -262,4 +262,7 @@
     <!-- If this is true, device supports Sustained Performance Mode. -->
     <bool name="config_sustainedPerformanceModeSupported">true</bool>
 
+    <!-- Colon separated list of package names that should be granted DND access -->
+    <string name="config_defaultDndAccessPackages" translatable="false">com.google.android.GoogleCamera:com.android.camera2</string>
+
 </resources>


### PR DESCRIPTION
include GoogleCamera
inlcude AOSPCamera see https://android.googlesource.com/platform/packages/apps/Camera2/+/35ad43aeb0d810f1ce104d17556f447743756673%5E%21/#F0

Signed-off-by: David Viteri <davidteri91@gmail.com>