### PR TITLE
sony: common: Start sensors service later

### DIFF
--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -333,6 +333,9 @@ on boot
     setrlimit 4 -1 -1
     write /proc/sys/kernel/dmesg_restrict 0
 
+on property:sys.qcom.devup=1
+    start sensors
+
 on property:sys.boot_completed=1
     # Enable ZRAM on boot_complete
     swapon_all /vendor/etc/fstab.${ro.hardware}

--- a/rootdir/vendor/etc/init/sensors.rc
+++ b/rootdir/vendor/etc/init/sensors.rc
@@ -9,6 +9,7 @@ on post-fs-data
 
 # Sensor service
 service sensors /odm/bin/sensors.qcom
-    class main
+    class late_start
     user system
     group system
+    disabled


### PR DESCRIPTION
Sensor is intermittent on suzu@loire due to some
race condition at services initialization.

So this patch is moving sensor service from main class to late_start
and also adding a property condition for its initialization.

on property:sys.qcom.devup=1

Now service starts with no problem.

Change-Id: I92aa47d073a2038c5ac71fafbe8093ba4fee0e42
Signed-off-by: Humberto Borba <humberos@omnirom.org>