### PR TITLE
[master] sony: common: Start adsprpcd service later

### DIFF
--- a/rootdir/vendor/etc/init/adsprpcd.rc
+++ b/rootdir/vendor/etc/init/adsprpcd.rc
@@ -1,8 +1,9 @@
 # ADSP FastRPC
 service adsprpcd /odm/bin/adsprpcd
-   class main
+   class late_start
    user media
    group media
+   disabled
 
 service audiopd /odm/bin/adsprpcd audiopd
    class main
@@ -12,3 +13,6 @@ service audiopd /odm/bin/adsprpcd audiopd
 
 on property:ro.board.platform=sdm660
     enable audiopd
+
+on property:sys.qcom.devup=1
+    start adsprpcd

--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -333,9 +333,6 @@ on boot
     setrlimit 4 -1 -1
     write /proc/sys/kernel/dmesg_restrict 0
 
-on property:sys.qcom.devup=1
-    start sensors
-
 on property:sys.boot_completed=1
     # Enable ZRAM on boot_complete
     swapon_all /vendor/etc/fstab.${ro.hardware}

--- a/rootdir/vendor/etc/init/sensors.rc
+++ b/rootdir/vendor/etc/init/sensors.rc
@@ -13,3 +13,6 @@ service sensors /odm/bin/sensors.qcom
     user system
     group system
     disabled
+
+on property:sys.qcom.devup=1
+    start sensors


### PR DESCRIPTION
Like sensors service, adsprpcd is also intermittent
on suzu@loire due to some race condition at services initialization.

So this patch is moving adsprpcd service from main class to late_start
and also adding a property condition for its initialization.

on property:sys.qcom.devup=1

Now adsprpcd service starts with no problem.