### PR TITLE
[COMMON] hardware: lights: Add compatibility with DRM SDE driver

### DIFF
--- a/hardware/liblights/Android.mk
+++ b/hardware/liblights/Android.mk
@@ -12,6 +12,10 @@ ifeq ($(TARGET_USES_UCOMM_BACKLIGHT),true)
     LOCAL_CFLAGS += -DUCOMMSVR_BACKLIGHT
 endif
 
+ifeq ($(TARGET_USES_SDE),true)
+    LOCAL_CFLAGS += -DDRMSDE_BACKLIGHT
+endif
+
 LOCAL_MODULE := android.hardware.light@2.0-service.sony
 LOCAL_INIT_RC := android.hardware.light@2.0-service.sony.rc
 LOCAL_SRC_FILES := \

--- a/hardware/liblights/Light.h
+++ b/hardware/liblights/Light.h
@@ -85,11 +85,19 @@ const static std::string BLUE_BLINK_FILE
 const static std::string RGB_BLINK_FILE
         = "/sys/class/leds/rgb/rgb_blink";
 
+#ifdef DRMSDE_BACKLIGHT
+const static std::string LCD_FILE
+        = "/sys/class/backlight/panel0-backlight/brightness";
+
+const static std::string LCD_MAX_FILE
+        = "/sys/class/backlight/panel0-backlight/max_brightness";
+#else
 const static std::string LCD_FILE
         = "/sys/class/leds/lcd-backlight/brightness";
 
 const static std::string LCD_MAX_FILE
         = "/sys/class/leds/lcd-backlight/max_brightness";
+#endif
 
 const static std::string PERSISTENCE_FILE
         = "/sys/class/graphics/fb0/msm_fb_persist_mode";


### PR DESCRIPTION
On the DRM SDE driver, the display backlight is registered as a
backlight class device, hence it resides in a different folder.
Add a build variable TARGET_USES_SDE to switch the backlight
paths for the new driver.