### PR TITLE
healthd: Add compatibility with DRM SDE driver

### DIFF
--- a/hardware/healthd/Android.mk
+++ b/hardware/healthd/Android.mk
@@ -11,4 +11,8 @@ LOCAL_C_INCLUDES := \
     bootable/recovery/minui/include \
     bootable/recovery
 
+ifeq ($(TARGET_USES_SDE),true)
+    LOCAL_CFLAGS += -DDRMSDE_BACKLIGHT
+endif
+
 include $(BUILD_STATIC_LIBRARY)

--- a/hardware/healthd/healthd_board_sony.cpp
+++ b/hardware/healthd/healthd_board_sony.cpp
@@ -29,7 +29,11 @@
 
 #define ARRAY_SIZE(x)                 (sizeof(x)/sizeof(x[0]))
 
+#ifdef DRMSDE_BACKLIGHT
+#define BACKLIGHT_PATH                "/sys/class/backlight/panel0-backlight/brightness"
+#else
 #define BACKLIGHT_PATH                "/sys/class/leds/lcd-backlight/brightness"
+#endif
 #define CHARGING_ENABLED_PATH         "/sys/class/power_supply/battery/charging_enabled"
 
 #define RED_LED_PATH                  "/sys/class/leds/led:rgb_red/brightness"


### PR DESCRIPTION
extend commit 5fc2b506ce533aa537f76bac6bcde6b791a9ab26 to healthd.sony

Signed-off-by: David Viteri <davidteri91@gmail.com>