### PR TITLE
manifest: add missing interface for renderscript

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -220,6 +220,10 @@
         <name>android.hardware.renderscript</name>
         <transport arch="32+64">passthrough</transport>
         <version>1.0</version>
+        <interface>
+            <name>IDevice</name>
+            <instance>default</instance>
+        </interface>
     </hal>
     <hal format="hidl">
         <name>android.hardware.sensors</name>


### PR DESCRIPTION
09-27 08:59:47.150   543   543 W /system/bin/hwservicemanager: getTransport: Cannot find entry android.hardware.renderscript@1.0::IDevice/default in either framework or device manifest.

Signed-off-by: David Viteri <davidteri91@gmail.com>