### PR TITLE
[TEMP] common: disable wireless display

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -105,7 +105,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Property to enable user to access Google WFD settings.
 PRODUCT_PROPERTY_OVERRIDES += \
-    persist.debug.wfd.enable=1
+    persist.debug.wfd.enable=0
 
 # Property to choose between virtual/external wfd display
 PRODUCT_PROPERTY_OVERRIDES += \

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -163,7 +163,7 @@
          * The remote submix module "audio.r_submix.default" must be installed on the device.
          * The device must be provisioned with HDCP keys (for protected content).
     -->
-    <bool name="config_enableWifiDisplay">true</bool>
+    <bool name="config_enableWifiDisplay">false</bool>
 
     <!-- Vibrator pattern for a very short but reliable vibration for soft keyboard tap -->
     <integer-array name="config_keyboardTapVibePattern">


### PR DESCRIPTION
The feature is not working, and causes logcat spam by incessently trying to initialize wifi p2p, which is failing.
Disable it for now, until a solution is found.