### PR TITLE
property: add back old BT address property

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -118,6 +118,9 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # BT address
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.vendor.bt.bdaddr_path=/data/vendor/bluetooth/bluetooth_bdaddr
+# BT address for devices with BCM BT
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.bt.bdaddr_path=/data/vendor/bluetooth/bluetooth_bdaddr
 
 # System prop for NFC DT
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
Devices that have broadcom bluetooth need the old property.
Since it has no effect on newer devices with qcom bluetooth, avoid adding a guard and simply include for all devices.