### PR TITLE
[COMMON] config.fs: Assign bluetooth user/group to cnss-daemon

### DIFF
--- a/config.fs
+++ b/config.fs
@@ -6,8 +6,8 @@ caps: 0
 
 [odm/bin/cnss-daemon]
 mode: 0755
-user: AID_SYSTEM
-group: AID_SYSTEM
+user: AID_BLUETOOTH
+group: AID_BLUETOOTH
 caps: NET_BIND_SERVICE
 
 [odm/bin/pm-service]


### PR DESCRIPTION
The cnss-daemon needs to have AID_BLUETOOTH to be
able to be started from Android init.