### PR TITLE
[master] sony: common: Allow custom projects to set their qcom hals

### DIFF
--- a/hardware/qcom/Android.mk
+++ b/hardware/qcom/Android.mk
@@ -1,3 +1,6 @@
+ifneq ($(wildcard device/sony/common/hardware/qcom/custom.mk),)
+    include device/sony/common/hardware/qcom/custom.mk
+else
 # Board platforms lists to be used for
 # TARGET_BOARD_PLATFORM specific featurization
 QCOM_BOARD_PLATFORMS += msm8952 msm8996 msm8998 sdm660 sdm845
@@ -31,3 +34,4 @@ include $(display-hal)/Android.mk
 include $(call all-makefiles-under,$(audio-hal))
 include $(call all-makefiles-under,$(gps-hal))
 include $(call all-makefiles-under,$(media-hal))
+endif


### PR DESCRIPTION
This patch allows custom android projects to use their ways to manage qcom hals location and its revision. Also, it will reduce deltas for custom projects which uses this project as an upstream.

Change-Id: I23f37e990641971d771ad8bcb3e72907ddded6cc
Signed-off-by: Humberto Borba <humberos@omnirom.org>