### PR TITLE
sony: common: Add basic USB HAL

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -109,7 +109,8 @@ PRODUCT_PACKAGES += \
 # Usb HAL
 PRODUCT_PACKAGES += \
     android.hardware.usb@1.0 \
-    android.hardware.usb@1.0-service
+    android.hardware.usb@1.0-service \
+    android.hardware.usb@1.0-service.basic
 
 # Thermal HAL
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Add basic USB HAL that reports no status change

It depends on hardware/interfaces patch and sepolicy filecontexts entry.

Signed-off-by: Humberto Borba <humberos@omnirom.org>
Change-Id: If36c56fa3e628425cb0dc719a7d77f6e974054d1