### PR TITLE
rootdir: init.common.rc: call setrlimit earlier

### DIFF
--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -77,6 +77,9 @@ on init
     chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/cluster_freq_vote_min
 
 on fs
+    # Set RLIMIT_MEMLOCK to 64MB
+    setrlimit 8 67108864 67108864
+
     # Start HW service manager early
     start hwservicemanager
 
@@ -183,9 +186,6 @@ on post-fs-data
     setprop vold.post_fs_data_done 1
 
 on early-boot
-    # Set RLIMIT_MEMLOCK to 64MB
-    setrlimit 8 67108864 67108864
-
     # Graphics Permissions bootanimation
     chmod 0664 /sys/devices/virtual/graphics/fb0/msm_cmd_autorefresh_en
     chown system graphics /sys/devices/virtual/graphics/fb0/msm_cmd_autorefresh_en


### PR DESCRIPTION
Some services rely on init to set some limits, which they then simply inherit.
A concrete example is netd, which expects a memlock limit larger than 5MiB
https://android.googlesource.com/platform/system/netd/+/android-9.0.0_r18/libbpf/include/bpf/BpfUtils.h#96
init does set the required limit correctly, but too late.
Move setrlimit to "on fs", and before starting hwservicemanager, to guarantee correct limit settings for subprocesses.