### PR TITLE
gpt-utils: add dtbo and vbmeta to partition swap list

### DIFF
--- a/hardware/gpt-utils/gpt-utils.h
+++ b/hardware/gpt-utils/gpt-utils.h
@@ -80,7 +80,10 @@ extern "C" {
 #define AB_SLOT_B_SUFFIX                "_b"
 #define PTN_XBL                         "xbl"
 #define PTN_XBL_CFG                     "xbl_config"
-#define PTN_SWAP_LIST                   PTN_XBL, PTN_XBL_CFG, "rpm", "tz", "abl", "hyp", "keymaster", "cmnlib", "cmnlib64", "pmic", "devcfg", "keystore", "mdtp", "mdtpsecapp", "xfl", "tzxflattest", "tzxfl"
+#define PTN_SWAP_LIST                   PTN_XBL, PTN_XBL_CFG, \
+            "rpm", "tz", "abl", "hyp", "keymaster", "cmnlib", \
+            "cmnlib64", "pmic", "devcfg", "keystore", "mdtp", \
+            "mdtpsecapp", "xfl", "tzxflattest", "tzxfl", "dtbo", "vbmeta"
 #define AB_PTN_LIST PTN_SWAP_LIST, "boot", "system", "vendor", "modem", "bluetooth", "oem", "rdimage", "dsp"
 #define BOOT_DEV_DIR    "/dev/block/bootdevice/by-name"
 


### PR DESCRIPTION
needed by sdm845

Signed-off-by: David Viteri <davidteri91@gmail.com>