### PR TITLE
common: switch qcom.devup to vendor property

### DIFF
--- a/rootdir/vendor/bin/init.qcom.devstart.sh
+++ b/rootdir/vendor/bin/init.qcom.devstart.sh
@@ -3,4 +3,4 @@
 echo 1 > /sys/kernel/boot_adsp/boot
 echo 1 > /sys/kernel/boot_cdsp/boot
 echo 1 > /sys/kernel/boot_slpi/boot
-setprop sys.qcom.devup 1
+setprop vendor.qcom.devup 1

--- a/rootdir/vendor/etc/init/adsprpcd.rc
+++ b/rootdir/vendor/etc/init/adsprpcd.rc
@@ -14,5 +14,5 @@ service audiopd /odm/bin/adsprpcd audiopd
 on property:ro.board.platform=sdm660
     enable audiopd
 
-on property:sys.qcom.devup=1
+on property:vendor.qcom.devup=1
     start adsprpcd

--- a/rootdir/vendor/etc/init/sensors.rc
+++ b/rootdir/vendor/etc/init/sensors.rc
@@ -14,5 +14,5 @@ service sensors /odm/bin/sensors.qcom
     group system
     disabled
 
-on property:sys.qcom.devup=1
+on property:vendor.qcom.devup=1
     start sensors

--- a/rootdir/vendor/etc/init/sscrpcd.rc
+++ b/rootdir/vendor/etc/init/sscrpcd.rc
@@ -4,5 +4,5 @@ service sscrpcd /odm/bin/sscrpcd
     group system
     disabled
 
-on property:sys.qcom.devup=1
+on property:vendor.qcom.devup=1
     start sscrpcd


### PR DESCRIPTION
Starting from Oreo, this should be a vendor property.

Needs a change in device-sony-sepolicy as well:
```
property_contexts:
vendor.qcom.devup          u:object_r:vendor_device_prop:s0
property.te:
type vendor_device_prop, property_type;
```