### PR TITLE
[WIP] init.common: Use /dsp instead of /vendor/dsp

### DIFF
--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -85,10 +85,12 @@ on fs
 
     mount_all /vendor/etc/fstab.${ro.hardware}
 
-    # /dsp is initially unlabelled so we need to mount
-    # it as rw, restore AOSP labels, then remount
-    restorecon_recursive /dsp
-    mount rootfs rootfs /dsp ro remount
+    # /vendor/dsp is initially unlabelled so we need to mount
+    # it as rw, restore AOSP labels, then remount read-only.
+    # Do not forget the trailing slash for restorecon, or SELinux will try to
+    # label the device itself.
+    restorecon_recursive /vendor/dsp/
+    mount rootfs rootfs /vendor/dsp ro remount
 
     restorecon_recursive /persist
 


### PR DESCRIPTION
The mountpoint for the dsp partition has moved from `/dsp` to `/vendor/dsp`.

`/dsp` will remain a symlink until the migration to `/vendor` is complete.
    
Also note that calling `restorecon` on `/dsp` (without trailing slash) will result in a temporarily unlabled direcory until later in the init process, causing adsprpcd to fail.