### PR TITLE
Add bluetooth qti service

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -43,10 +43,6 @@ PRODUCT_PACKAGES += \
     android.hardware.wifi@1.1 \
     android.hardware.wifi@1.0-service
 
-# Bluetooth
-PRODUCT_PACKAGES += \
-    android.hardware.bluetooth@1.0-service
-
 # NFC packages
 PRODUCT_PACKAGES += \
     android.hardware.nfc@1.1-impl \

--- a/hardware/interfaces/bluetooth/1.0/qti/Android.bp
+++ b/hardware/interfaces/bluetooth/1.0/qti/Android.bp
@@ -1,0 +1,20 @@
+cc_binary {
+    name: "android.hardware.bluetooth@1.0-service-qti",
+    defaults: ["hidl_defaults"],
+    relative_install_path: "hw",
+    vendor: true,
+    init_rc: ["android.hardware.bluetooth@1.0-service-qti.rc"],
+    srcs: ["service.cpp"],
+
+    shared_libs: [
+        "liblog",
+        "libcutils",
+        "libdl",
+        "libbase",
+        "libutils",
+        "libhardware",
+        "libhidlbase",
+        "libhidltransport",
+        "android.hardware.bluetooth@1.0",
+    ],
+}

--- a/hardware/interfaces/bluetooth/1.0/qti/android.hardware.bluetooth@1.0-service-qti.rc
+++ b/hardware/interfaces/bluetooth/1.0/qti/android.hardware.bluetooth@1.0-service-qti.rc
@@ -1,0 +1,15 @@
+service vendor.bluetooth-1-0-qti /vendor/bin/hw/android.hardware.bluetooth@1.0-service-qti
+    class hal
+    capabilities BLOCK_SUSPEND NET_ADMIN SYS_NICE
+    user bluetooth
+    group bluetooth diag wakelock
+    writepid /dev/stune/foreground/tasks
+
+on property:vts.native_server.on=1 && property:ro.build.type=userdebug
+    stop vendor.bluetooth-1-0-qti
+on property:vts.native_server.on=1 && property:ro.build.type=eng
+    stop vendor.bluetooth-1-0-qti
+on property:vts.native_server.on=0 && property:ro.build.type=userdebug
+    start vendor.bluetooth-1-0-qti
+on property:vts.native_server.on=0 && property:ro.build.type=eng
+    start vendor.bluetooth-1-0-qti

--- a/hardware/interfaces/bluetooth/1.0/qti/service.cpp
+++ b/hardware/interfaces/bluetooth/1.0/qti/service.cpp
@@ -1,0 +1,32 @@
+//
+// Copyright 2016 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#define LOG_TAG "android.hardware.bluetooth@1.0-service-qti"
+
+#include <android/hardware/bluetooth/1.0/IBluetoothHci.h>
+
+#include <hidl/LegacySupport.h>
+
+// Extra threads make priority inheritance faster.
+static const size_t kMaxThreads = 5;
+
+// Generated HIDL files
+using android::hardware::bluetooth::V1_0::IBluetoothHci;
+using android::hardware::defaultPassthroughServiceImplementation;
+
+int main() {
+    return defaultPassthroughServiceImplementation<IBluetoothHci>(kMaxThreads);
+}


### PR DESCRIPTION
Add a new bluetooth service that has more permissions than the default service.
Also, move the inclusion of the default service to the platforms that need it.