### PR TITLE
[COMMON] Keymaster 4 support

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -124,3 +124,9 @@ else
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hw.radio_ss.xml
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.hw.radio_ss.xml
 endif
+
+ifeq ($(TARGET_KEYMASTER_V4),true)
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hw.keymaster_v4.xml
+else
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hw.keymaster_v3.xml
+endif

--- a/common-perm.mk
+++ b/common-perm.mk
@@ -44,6 +44,12 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/com.nxp.mifare.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/com.nxp.mifare.xml \
     frameworks/native/data/etc/android.software.midi.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.software.midi.xml
 
+# Keymaster 4 and StrongBox Permissions
+ifeq ($(TARGET_KEYMASTER_V4),true)
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.software.device_id_attestation.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.software.device_id_attestation.xml
+endif
+
 # Common System Permissions
 PRODUCT_COPY_FILES += \
     $(COMMON_PATH)/rootdir/system/etc/permissions/privapp-permissions-extension.xml:system/etc/permissions/privapp-permissions-extension.xml

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -43,10 +43,6 @@ PRODUCT_PACKAGES += \
     android.hardware.wifi@1.1 \
     android.hardware.wifi@1.0-service
 
-# Bluetooth
-PRODUCT_PACKAGES += \
-    android.hardware.bluetooth@1.0-service
-
 # NFC packages
 PRODUCT_PACKAGES += \
     android.hardware.nfc@1.1-impl \

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -72,17 +72,7 @@ PRODUCT_PACKAGES += \
     android.hardware.biometrics.fingerprint@2.1 \
     android.hardware.biometrics.fingerprint@2.1-service.sony
 
-ifneq ($(TARGET_LEGACY_KEYMASTER),true)
-# Keymaster
-PRODUCT_PACKAGES += \
-    android.hardware.keymaster@3.0-impl-qti \
-    android.hardware.keymaster@3.0-service-qti
-
-# Gatekeeper
-PRODUCT_PACKAGES += \
-    android.hardware.gatekeeper@1.0-impl-qti \
-    android.hardware.gatekeeper@1.0-service-qti
-else
+ifeq ($(TARGET_LEGACY_KEYMASTER),true)
 # Keymaster
 PRODUCT_PACKAGES += \
     android.hardware.keymaster@3.0-impl \
@@ -92,6 +82,20 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     android.hardware.gatekeeper@1.0-impl \
     android.hardware.gatekeeper@1.0-service
+else ifeq ($(TARGET_KEYMASTER_V4),true)
+# Keymaster 4
+PRODUCT_PACKAGES += \
+    android.hardware.keymaster@4.0-service-qti
+else
+# Keymaster
+PRODUCT_PACKAGES += \
+    android.hardware.keymaster@3.0-impl-qti \
+    android.hardware.keymaster@3.0-service-qti
+
+# Gatekeeper
+PRODUCT_PACKAGES += \
+    android.hardware.gatekeeper@1.0-impl-qti \
+    android.hardware.gatekeeper@1.0-service-qti
 endif
 
 # DRM

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -86,6 +86,11 @@ else ifeq ($(TARGET_KEYMASTER_V4),true)
 # Keymaster 4
 PRODUCT_PACKAGES += \
     android.hardware.keymaster@4.0-service-qti
+
+# Gatekeeper
+PRODUCT_PACKAGES += \
+    android.hardware.gatekeeper@1.0-impl-qti \
+    android.hardware.gatekeeper@1.0-service-qti
 else
 # Keymaster
 PRODUCT_PACKAGES += \

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -33,6 +33,18 @@ LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 endif
 
+ifeq ($(TARGET_KEYMASTER_V4), true)
+include $(CLEAR_VARS)
+LOCAL_MODULE := android.hardware.keymaster@4.0-service-qti
+LOCAL_SRC_FILES := vendor/etc/init/android.hardware.keymaster@4.0-service-qti.rc
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_STEM := android.hardware.keymaster@4.0-service-qti
+LOCAL_MODULE_SUFFIX := .rc
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
+include $(BUILD_PREBUILT)
+endif
+
 include $(CLEAR_VARS)
 LOCAL_MODULE := init.qcom.devstart.sh
 LOCAL_MODULE_CLASS := EXECUTABLES

--- a/rootdir/vendor/etc/init/android.hardware.keymaster@4.0-service-qti.rc
+++ b/rootdir/vendor/etc/init/android.hardware.keymaster@4.0-service-qti.rc
@@ -1,0 +1,4 @@
+service keymaster-4-0 /odm/bin/hw/android.hardware.keymaster@4.0-service-qti
+    class early_hal
+    user system
+    group system drmrpc

--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -350,6 +350,6 @@ on property:sys.boot_completed=1
     # Enable ZRAM on boot_complete
     swapon_all /vendor/etc/fstab.${ro.hardware}
 
-on property:sys.listeners.registered=true
+on property:vendor.sys.listeners.registered=true
     # load IPA FWs
     start ipastart_sh

--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -94,7 +94,7 @@ on fs
 
 on post-fs
     # Wait qseecomd started
-    wait_for_prop sys.listeners.registered true
+    wait_for_prop vendor.sys.listeners.registered true
 
 on late-fs
     # Wait for hwservicemanager ready since fsck might be triggered in mount_all --late

--- a/vintf/android.hw.keymaster_v3.xml
+++ b/vintf/android.hw.keymaster_v3.xml
@@ -1,0 +1,11 @@
+<manifest version="1.0" type="device" target-level="2">
+    <hal format="hidl">
+        <name>android.hardware.keymaster</name>
+        <transport>hwbinder</transport>
+        <version>3.0</version>
+        <interface>
+            <name>IKeymasterDevice</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>

--- a/vintf/android.hw.keymaster_v4.xml
+++ b/vintf/android.hw.keymaster_v4.xml
@@ -1,0 +1,11 @@
+<manifest version="1.0" type="device" target-level="2">
+    <hal format="hidl">
+        <name>android.hardware.keymaster</name>
+        <transport>hwbinder</transport>
+        <version>4.0</version>
+        <interface>
+            <name>IKeymasterDevice</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -143,15 +143,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.keymaster</name>
-        <transport>hwbinder</transport>
-        <version>3.0</version>
-        <interface>
-            <name>IKeymasterDevice</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.light</name>
         <transport>hwbinder</transport>
         <version>2.0</version>


### PR DESCRIPTION
Add support for Keymaster 4, required for KM4 devices (currently
only SoMC Tama Akatsuki).

!!!!BEWARE!!!!
This PR will break current blobs, because of the new ones having
the "vendor." prefix to the sys.listeners.registered property!
There is a wait_for_prop in the rc that have been changed to reflect
the new property!