### PR TITLE
Move vendor symlink creation to modules

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -2,6 +2,6 @@ ifeq ($(PRODUCT_PLATFORM_SOD),true)
 
 LOCAL_PATH := $(call my-dir)
 
-include $(call all-makefiles-under,$(LOCAL_PATH))
+include $(call all-subdir-makefiles)
 
 endif

--- a/common.mk
+++ b/common.mk
@@ -97,6 +97,10 @@ PRODUCT_PACKAGES += \
     init.qcom.devstart.sh \
     init.qcom.ipastart.sh
 
+# Depend on generation of adreno symlinks (from /vendor to /odm)
+PRODUCT_PACKAGES += \
+    adreno_symlinks
+
 # APN list
 PRODUCT_COPY_FILES += \
     device/sample/etc/old-apns-conf.xml:system/etc/old-apns-conf.xml \

--- a/common.mk
+++ b/common.mk
@@ -29,6 +29,10 @@ PRODUCT_DEFAULT_DEV_CERTIFICATE := vendor/oss/release-keys/testkey
 # Common path
 COMMON_PATH := device/sony/common
 
+# Build scripts
+SONY_CLEAR_VARS := $(COMMON_PATH)/sony_clear_vars.mk
+SONY_BUILD_SYMLINKS := $(COMMON_PATH)/sony_build_symlinks.mk
+
 DEVICE_PACKAGE_OVERLAYS += $(COMMON_PATH)/overlay
 
 PRODUCT_ENFORCE_RRO_TARGETS := \

--- a/common.mk
+++ b/common.mk
@@ -112,6 +112,9 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     firmware_folders
 
+PRODUCT_PACKAGES += \
+    odm_build_prop_version
+
 # APN list
 PRODUCT_COPY_FILES += \
     device/sample/etc/old-apns-conf.xml:system/etc/old-apns-conf.xml \

--- a/common.mk
+++ b/common.mk
@@ -101,9 +101,10 @@ PRODUCT_PACKAGES += \
     init.qcom.devstart.sh \
     init.qcom.ipastart.sh
 
-# Depend on generation of adreno symlinks (from /vendor to /odm)
+# Depend on symlink creation in /vendor:
 PRODUCT_PACKAGES += \
-    adreno_symlinks
+    adreno_symlinks \
+    camera_symlinks
 
 # APN list
 PRODUCT_COPY_FILES += \

--- a/common.mk
+++ b/common.mk
@@ -104,7 +104,8 @@ PRODUCT_PACKAGES += \
 # Depend on symlink creation in /vendor:
 PRODUCT_PACKAGES += \
     adreno_symlinks \
-    camera_symlinks
+    camera_symlinks \
+    qca_cld3_symlinks
 
 # APN list
 PRODUCT_COPY_FILES += \

--- a/common.mk
+++ b/common.mk
@@ -108,6 +108,10 @@ PRODUCT_PACKAGES += \
     qca_cld3_symlinks \
     tftp_symlinks
 
+# Create firmware mount point folders in /vendor:
+PRODUCT_PACKAGES += \
+    firmware_folders
+
 # APN list
 PRODUCT_COPY_FILES += \
     device/sample/etc/old-apns-conf.xml:system/etc/old-apns-conf.xml \

--- a/common.mk
+++ b/common.mk
@@ -105,7 +105,8 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     adreno_symlinks \
     camera_symlinks \
-    qca_cld3_symlinks
+    qca_cld3_symlinks \
+    tftp_symlinks
 
 # APN list
 PRODUCT_COPY_FILES += \

--- a/hardware/Android.mk
+++ b/hardware/Android.mk
@@ -1,3 +1,3 @@
 LOCAL_PATH := $(call my-dir)
 
-include $(call all-makefiles-under,$(LOCAL_PATH))
+include $(call all-subdir-makefiles)

--- a/hardware/adreno/Android.mk
+++ b/hardware/adreno/Android.mk
@@ -1,42 +1,41 @@
 # EGL libs
-$(shell mkdir -p $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib)
-$(shell mkdir -p $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib/hw)
-$(shell mkdir -p $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64)
-$(shell mkdir -p $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64/hw)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/egl egl && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libllvm-glnext.so libllvm-glnext.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libllvm-qgl.so libllvm-qgl.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libc2d30_bltlib.so libc2d30_bltlib.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libc2d30-a3xx.so libc2d30-a3xx.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libc2d30-a4xx.so libc2d30-a4xx.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libc2d30-a5xx.so libc2d30-a5xx.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libmm-qdcm.so libmm-qdcm.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/librs_adreno.so librs_adreno.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libadreno_utils.so libadreno_utils.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libCB.so libCB.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libgsl.so libgsl.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libC2D2.so libC2D2.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libRSDriver_adreno.so libRSDriver_adreno.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libOpenCL.so libOpenCL.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libllvm-qcom.so libllvm-qcom.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/librs_adreno_sha1.so librs_adreno_sha1.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib/hw > /dev/null && ln -sf /odm/lib/hw/vulkan.$(TARGET_BOARD_PLATFORM).so vulkan.$(TARGET_BOARD_PLATFORM).so && popd > /dev/null)
 
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/egl egl && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/libllvm-glnext.so libllvm-glnext.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/libllvm-qgl.so libllvm-qgl.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/libc2d30_bltlib.so libc2d30_bltlib.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/libc2d30-a3xx.so libc2d30-a3xx.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/libc2d30-a4xx.so libc2d30-a4xx.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/libc2d30-a5xx.so libc2d30-a5xx.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/libmm-qdcm.so libmm-qdcm.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/librs_adreno.so librs_adreno.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/libadreno_utils.so libadreno_utils.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/libCB.so libCB.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/libgsl.so libgsl.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/libC2D2.so libC2D2.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/libRSDriver_adreno.so libRSDriver_adreno.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/libOpenCL.so libOpenCL.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/libllvm-qcom.so libllvm-qcom.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64 > /dev/null && ln -sf /odm/lib64/librs_adreno_sha1.so librs_adreno_sha1.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib64/hw > /dev/null && ln -sf /odm/lib64/hw/vulkan.$(TARGET_BOARD_PLATFORM).so vulkan.$(TARGET_BOARD_PLATFORM).so && popd > /dev/null)
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := adreno_symlinks
+
+TARGET_DIRECTORY := $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)
+
+library_names := \
+    egl \
+    libC2D2.so \
+    libCB.so \
+    libOpenCL.so \
+    libRSDriver_adreno.so \
+    libadreno_utils.so \
+    libc2d30-a3xx.so \
+    libc2d30-a4xx.so \
+    libc2d30-a5xx.so \
+    libc2d30_bltlib.so \
+    libgsl.so \
+    libllvm-glnext.so \
+    libllvm-qcom.so \
+    libllvm-qgl.so \
+    libmm-qdcm.so \
+    librs_adreno.so \
+    librs_adreno_sha1.so \
+    hw/vulkan.$(TARGET_BOARD_PLATFORM).so
+
+# Create target directories
+CREATE_FOLDERS := lib/hw lib64/hw
+LOCAL_POST_INSTALL_CMD += mkdir -p $(foreach p,$(CREATE_FOLDERS),$(TARGET_DIRECTORY)/$p);
+
+# Create symlinks to 32- and 64-bit directories:
+LOCAL_POST_INSTALL_CMD += $(foreach lib_dir,lib lib64, \
+    $(foreach p,$(library_names), \
+        ln -sf /odm/$(lib_dir)/$p $(TARGET_DIRECTORY)/$(lib_dir)/$(dir $p); \
+    ) \
+)
+
+include $(BUILD_PHONY_PACKAGE)

--- a/hardware/adreno/Android.mk
+++ b/hardware/adreno/Android.mk
@@ -2,10 +2,9 @@
 
 LOCAL_PATH := $(call my-dir)
 
-include $(CLEAR_VARS)
+include $(SONY_CLEAR_VARS)
 LOCAL_MODULE := adreno_symlinks
-
-TARGET_DIRECTORY := $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)
 
 library_names := \
     egl \
@@ -27,15 +26,11 @@ library_names := \
     librs_adreno_sha1.so \
     hw/vulkan.$(TARGET_BOARD_PLATFORM).so
 
-# Create target directories
-CREATE_FOLDERS := lib/hw lib64/hw
-LOCAL_POST_INSTALL_CMD += mkdir -p $(foreach p,$(CREATE_FOLDERS),$(TARGET_DIRECTORY)/$p);
-
 # Create symlinks to 32- and 64-bit directories:
-LOCAL_POST_INSTALL_CMD += $(foreach lib_dir,lib lib64, \
+SONY_SYMLINKS := $(foreach lib_dir,lib lib64, \
     $(foreach p,$(library_names), \
-        ln -sf /odm/$(lib_dir)/$p $(TARGET_DIRECTORY)/$(lib_dir)/$(dir $p); \
+        /odm/$(lib_dir)/$p:$(TARGET_COPY_OUT_VENDOR)/$(lib_dir)/$p \
     ) \
 )
 
-include $(BUILD_PHONY_PACKAGE)
+include $(SONY_BUILD_SYMLINKS)

--- a/hardware/camera/Android.mk
+++ b/hardware/camera/Android.mk
@@ -1,21 +1,32 @@
+# Create symlinks for camera libraries. Currently only applicable
+# to sdm845 boards.
+
+LOCAL_PATH := $(call my-dir)
+
 ifneq ($(filter sdm845,$(TARGET_BOARD_PLATFORM)),)
 
-$(shell mkdir -p $(PRODUCT_OUT)/$(TARGET_COPY_OUT_ODM)/lib)
-$(shell mkdir -p $(PRODUCT_OUT)/$(TARGET_COPY_OUT_ODM)/lib/camera)
-$(shell mkdir -p $(PRODUCT_OUT)/$(TARGET_COPY_OUT_ODM)/lib64)
-$(shell mkdir -p $(PRODUCT_OUT)/$(TARGET_COPY_OUT_ODM)/lib64/camera)
+include $(SONY_CLEAR_VARS)
+LOCAL_MODULE := camera_symlinks
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)
 
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/hw/camera.qcom.so hw/camera.sdm845.so && popd > /dev/null)
+library_names := \
+    camera \
+    hw/camera.qcom.so \
+    hw/com.qti.chi.override.so \
+    libcamxfdalgov7.so \
+    libcamxfdengine.so \
+    libcamxstatscore.so \
+    libcamxtintlessalgo.so \
+    libcom.qti.chinodeutils.so
 
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/hw/camera.qcom.so hw/camera.qcom.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/hw/com.qti.chi.override.so hw/com.qti.chi.override.so && popd > /dev/null)
+# Create symlinks to 32-bit camera libraries:
+SONY_SYMLINKS := $(foreach p,$(library_names), \
+    /odm/lib/$p:$(TARGET_COPY_OUT_VENDOR)/lib/$p \
+)
 
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/camera camera && popd > /dev/null)
+# Special exception for camera.qcom.so that is also linked to as camera.sdm845.so:
+SONY_SYMLINKS += /odm/lib/hw/camera.qcom.so:$(TARGET_COPY_OUT_VENDOR)/lib/hw/camera.sdm845.so
 
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libcom.qti.chinodeutils.so libcom.qti.chinodeutils.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libcamxfdalgov7.so libcamxfdalgov7.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libcamxfdengine.so libcamxfdengine.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libcamxstatscore.so libcamxstatscore.so && popd > /dev/null)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/lib > /dev/null && ln -sf /odm/lib/libcamxtintlessalgo.so libcamxtintlessalgo.so && popd > /dev/null)
+include $(SONY_BUILD_SYMLINKS)
 
 endif

--- a/hardware/firmware/Android.mk
+++ b/hardware/firmware/Android.mk
@@ -1,4 +1,14 @@
 # Mount points
-$(shell mkdir -p $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/dsp)
-$(shell mkdir -p $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/firmware_mnt)
-$(shell mkdir -p $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/bt_firmware)
+
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := firmware_folders
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)
+
+LOCAL_POST_INSTALL_CMD := mkdir -p \
+    $(TARGET_OUT_VENDOR)/dsp \
+    $(TARGET_OUT_VENDOR)/firmware_mnt \
+    $(TARGET_OUT_VENDOR)/bt_firmware
+
+include $(BUILD_PHONY_PACKAGE)

--- a/hardware/qca_cld3/Android.mk
+++ b/hardware/qca_cld3/Android.mk
@@ -1,4 +1,13 @@
+LOCAL_PATH := $(call my-dir)
+
 ifeq ($(WIFI_DRIVER_BUILT),qca_cld3)
-$(shell mkdir -p $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR)/firmware/wlan/qca_cld)
-$(shell pushd $(PRODUCT_OUT)/$(TARGET_COPY_OUT_VENDOR) > /dev/null && ln -sf /data/vendor/wifi/wlan_mac.bin firmware/wlan/qca_cld/wlan_mac.bin && popd > /dev/null)
+
+include $(SONY_CLEAR_VARS)
+LOCAL_MODULE := qca_cld3_symlinks
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)
+
+SONY_SYMLINKS := /data/vendor/wifi/wlan_mac.bin:$(TARGET_COPY_OUT_VENDOR)/firmware/wlan/qca_cld/wlan_mac.bin
+
+include $(SONY_BUILD_SYMLINKS)
+
 endif

--- a/misc/Android.mk
+++ b/misc/Android.mk
@@ -1,3 +1,3 @@
 LOCAL_PATH := $(call my-dir)
 
-include $(call all-makefiles-under,$(LOCAL_PATH))
+include $(call all-subdir-makefiles)

--- a/misc/no-op/Android.mk
+++ b/misc/no-op/Android.mk
@@ -1,3 +1,3 @@
 LOCAL_PATH := $(call my-dir)
 
-#include $(call all-makefiles-under,$(LOCAL_PATH))
+#include $(call all-subdir-makefiles)

--- a/misc/version/Android.mk
+++ b/misc/version/Android.mk
@@ -1,1 +1,11 @@
-$(shell pushd $(PRODUCT_OUT)/odm/ > /dev/null && echo "ro.odm.version=$(PLATFORM_VERSION)_$(SOMC_KERNEL_VERSION)_$(SOMC_PLATFORM)_$(TARGET_VENDOR_VERSION)" >build.prop && popd > /dev/null)
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := odm_build_prop_version
+LOCAL_MODULE_PATH := $(TARGET_OUT_ODM)
+
+LOCAL_POST_INSTALL_CMD := echo \
+  "ro.odm.version=$(PLATFORM_VERSION)_$(SOMC_KERNEL_VERSION)_$(SOMC_PLATFORM)_$(TARGET_VENDOR_VERSION)" \
+  >$(TARGET_OUT_ODM)/build.prop
+
+include $(BUILD_PHONY_PACKAGE)

--- a/sony_build_symlinks.mk
+++ b/sony_build_symlinks.mk
@@ -1,0 +1,18 @@
+# Creates symlinks relative to the PRODUCT_OUT folder.
+# This is different from BOARD_ROOT_EXTRA_SYMLINKS in that it allows symlinks on other partitions.
+#
+# Links can be specified in TARGET:DIRECTORY or TARGET:LINK_NAME notation. This creates a link named LINK_NAME or DIRECTORY/$(basename TARGET) pointing to TARGET.
+#
+# This script is based on conversion from BOARD_ROOT_EXTRA_SYMLINKS to LOCAL_POST_INSTALL_CMD from system/core/rootdir/Android.mk.
+
+ifeq ($(SONY_SYMLINKS),)
+    $(warning "No symlinks set!")
+else
+LOCAL_POST_INSTALL_CMD := $(foreach s,$(SONY_SYMLINKS), \
+    $(eval p := $(subst :,$(space),$(s))) \
+    mkdir -p $(dir $(PRODUCT_OUT)/$(word 2,$(p))); \
+    ln -sf $(word 1,$(p)) $(PRODUCT_OUT)/$(word 2,$(p)); \
+)
+endif
+
+include $(BUILD_PHONY_PACKAGE)

--- a/sony_clear_vars.mk
+++ b/sony_clear_vars.mk
@@ -1,0 +1,3 @@
+SONY_SYMLINKS :=
+
+include $(CLEAR_VARS)


### PR DESCRIPTION
Fixes https://github.com/sonyxperiadev/bug_tracker/issues/253, should fix https://github.com/sonyxperiadev/bug_tracker/issues/283 as well.

Symlink creation is moved to it's own module to make sure these are executed during the build, not during module discovery. The amount of code has been reduced with loops and variables at the same time.

In the future we might be able to declare a build rule for every library (preferrably not a `foreach` that emits a module for all) to let the build system selectively regenerate the links.

Test:
1. `m installclean` followed by `m vendorimage` on current HEAD
2. Save all vendor links to a file: `find out/target/product/akatsuki/vendor -type l -exec echo -n {}" -> " \; -exec readlink {} \; | sort -u`
3. Check out this PR and run the commands from 1. again.
4. Generate another file with the new links (command from 2.).
5. Run a diff and see that the two files (and thus all the links) are identical.