### PR TITLE
common init: Drop /dsp restorecon+remount, update persist mountpoint

### DIFF
--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -85,11 +85,6 @@ on fs
 
     mount_all /vendor/etc/fstab.${ro.hardware}
 
-    # /dsp is initially unlabelled so we need to mount
-    # it as rw, restore AOSP labels, then remount
-    restorecon_recursive /dsp
-    mount rootfs rootfs /dsp ro remount
-
     restorecon_recursive /persist
 
 on post-fs

--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -85,7 +85,7 @@ on fs
 
     mount_all /vendor/etc/fstab.${ro.hardware}
 
-    restorecon_recursive /persist
+    restorecon_recursive /mnt/vendor/persist
 
 on post-fs
     # Wait qseecomd started


### PR DESCRIPTION
init: Drop /(vendor/)dsp restorecon and remount
Since we are now using stock labels(adsprpcd_file) and remounting a partition under /(system/)vendor is a neverallow in sepolicy anyway, drop the remount and restorecon.

init.rc: Update persist mountpoint
/persist has moved to /mnt/vendor/persist. Update init to reflect that.

N.b.: /vendor/dsp needs to be changed to read-only in the platform fstab files, change incoming.
https://github.com/sonyxperiadev/device-sony-tone/blob/a225e85d32a2574d6efe656f03a1ee0297851850/rootdir/vendor/etc/fstab.tone#L12