### PR TITLE
manifest: Add tetheroffload config and control hals.

### DIFF
--- a/rootdir/vendor/etc/init/ipacm.rc
+++ b/rootdir/vendor/etc/init/ipacm.rc
@@ -3,6 +3,8 @@ on post-fs-data
     mkdir /data/vendor/ipa 0770 radio radio
 
 service ipacm /vendor/bin/ipacm
+    interface android.hardware.tetheroffload.config@1.0::IOffloadConfig default
+    interface android.hardware.tetheroffload.control@1.0::IOffloadControl default
     class main
     user radio
     group radio inet

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -237,6 +237,16 @@
         </interface>
     </hal>
     <hal format="hidl">
+        <name>android.hardware.tetheroffload.config</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::IOffloadConfig/default</fqname>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.tetheroffload.control</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::IOffloadControl/default</fqname>
+    </hal>
+    <hal format="hidl">
         <name>android.hardware.usb</name>
         <transport>hwbinder</transport>
         <version>1.0</version>


### PR DESCRIPTION
Hal definitions from https://android.googlesource.com/device/google/crosshatch/+/618a01fe100bd98902e59ee9447cae975d4ce3b4

We still have to adapt the HAL itself to build for properly for the respective platforms.