### PR TITLE
[WIP] common-treble: Remove unused lib definition

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -77,7 +77,6 @@ PRODUCT_PACKAGES += \
 
 # Fingerprint
 PRODUCT_PACKAGES += \
-    android.hardware.biometrics.fingerprint@2.1 \
     android.hardware.biometrics.fingerprint@2.1-service.sony
 
 ifneq ($(TARGET_LEGACY_KEYMASTER),true)


### PR DESCRIPTION
Edit: No need to depend on the interface itself, like Marijn says below.