### PR TITLE
Adapt LED flashing time to android-dictated pause-times

### DIFF
--- a/hardware/liblights/Light.cpp
+++ b/hardware/liblights/Light.cpp
@@ -271,6 +271,15 @@ namespace android {
                                 writeStr(RED_LED_DUTY_PCTS_FILE, getScaledDutyPcts(red));
                                 writeStr(GREEN_LED_DUTY_PCTS_FILE, getScaledDutyPcts(green));
                                 writeStr(BLUE_LED_DUTY_PCTS_FILE, getScaledDutyPcts(blue));
+
+                                writeInt(RED_LED_BASE   + "pause_lo", offMS);
+                                writeInt(GREEN_LED_BASE + "pause_lo", offMS);
+                                writeInt(BLUE_LED_BASE  + "pause_lo", offMS);
+
+                                writeInt(RED_LED_BASE   + "pause_hi", onMS);
+                                writeInt(GREEN_LED_BASE + "pause_hi", onMS);
+                                writeInt(BLUE_LED_BASE  + "pause_hi", onMS);
+
                                 writeInt(RGB_BLINK_FILE, 1);
                             } else {
                                 if (red) {

--- a/hardware/liblights/Light.h
+++ b/hardware/liblights/Light.h
@@ -55,32 +55,41 @@ struct lights_t {
 static constexpr int RAMP_SIZE = 8;
 static constexpr int BRIGHTNESS_RAMP[RAMP_SIZE] = {0, 14, 28, 42, 56, 70, 84, 100};
 
+const static std::string RED_LED_BASE
+        = "/sys/class/leds/led:rgb_red/";
+
+const static std::string GREEN_LED_BASE
+        = "/sys/class/leds/led:rgb_green/";
+
+const static std::string BLUE_LED_BASE
+        = "/sys/class/leds/led:rgb_blue/";
+
 const static std::string RED_LED_FILE
-        = "/sys/class/leds/led:rgb_red/brightness";
+        = RED_LED_BASE + "brightness";
 
 const static std::string GREEN_LED_FILE
-        = "/sys/class/leds/led:rgb_green/brightness";
+        = GREEN_LED_BASE + "brightness";
 
 const static std::string BLUE_LED_FILE
-        = "/sys/class/leds/led:rgb_blue/brightness";
+        = BLUE_LED_BASE + "brightness";
 
 const static std::string RED_LED_DUTY_PCTS_FILE
-        = "/sys/class/leds/led:rgb_red/duty_pcts";
+        = RED_LED_BASE + "duty_pcts";
 
 const static std::string GREEN_LED_DUTY_PCTS_FILE
-        = "/sys/class/leds/led:rgb_green/duty_pcts";
+        = GREEN_LED_BASE + "duty_pcts";
 
 const static std::string BLUE_LED_DUTY_PCTS_FILE
-        = "/sys/class/leds/led:rgb_blue/duty_pcts";
+        = BLUE_LED_BASE + "duty_pcts";
 
 const static std::string RED_BLINK_FILE
-        = "/sys/class/leds/led:rgb_red/blink";
+        = RED_LED_BASE + "blink";
 
 const static std::string GREEN_BLINK_FILE
-        = "/sys/class/leds/led:rgb_green/blink";
+        = GREEN_LED_BASE + "blink";
 
 const static std::string BLUE_BLINK_FILE
-        = "/sys/class/leds/led:rgb_blue/blink";
+        = BLUE_LED_BASE + "blink";
 
 const static std::string RGB_BLINK_FILE
         = "/sys/class/leds/rgb/rgb_blink";


### PR DESCRIPTION
Android provides on- and off-times in `LightState` when requesting LED flash (for notifications). Because our default timings (set in dt) are rather short and appear trippy, adhere to the framework-orchestrated timings which are more forgiving 

TODO:
- Create and merge PR's to allow access to these new files. I'll get them up soon.
- This assumes all rgbsync (those with `/sys/class/leds/rgb/rgb_blink`) have these pause properties available. Please confirm that before merging.
  I have not seen this property on Suzu, which doesn't have rgbsync either. Those platforms should stay unharmed.
- Test *without* the last commit. Scaling rgb channels with the `brightness` attribute is more efficient than scaling and applying the entire `duty_pcts` curve, but doesn't seem to work on akatsuki at least (this could also be a bug in the qpnp led driver).

Tested on SoMC Akatsuki DSDS.