### PR TITLE
allow override default_network common prop on dsds

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -32,8 +32,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 endif
 
 # Default to LTE/GSM/WCDMA.
+ifneq ($(PRODUCT_DEVICE_DS),true)
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.telephony.default_network=9
+endif
 
 # System props for the data modules
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
dsds targets have own ro.telephony.default_network that one from common is not needed to copy in build.prop

Signed-off-by: David Viteri <davidteri91@gmail.com>