### PR TITLE
init.common.rc: Permissions for dsi_panel_driver on SDE devices.

### DIFF
--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -295,6 +295,8 @@ on boot
     # Display Calibration
     chown system graphics /sys/devices/mdss_dsi_panel/pcc_profile
     chmod 0664 /sys/devices/mdss_dsi_panel/pcc_profile
+    chown system graphics /sys/devices/dsi_panel_driver/pcc_profile
+    chmod 0664 /sys/devices/dsi_panel_driver/pcc_profile
 
     # FB1 permissions
     chown system graphics /sys/class/graphics/fb1/avi_itc


### PR DESCRIPTION
These permissions are needed to allow (for example) Extended Settings to
change PCC profiles on SDE-enabled devices.