### PR TITLE
radio: update treble radio

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -22,8 +22,8 @@ PRODUCT_PACKAGES += \
 # RIL
 PRODUCT_PACKAGES += \
     android.hardware.radio@1.2-radio-service \
-    android.hardware.radio.config@1.0 \
-    android.hardware.radio.deprecated@1.0
+    android.hardware.radio@1.2-sap-service \
+    android.hardware.radio.config@1.0-service
 
 # Audio
 PRODUCT_PACKAGES += \

--- a/vintf/android.hw.radio_ds.xml
+++ b/vintf/android.hw.radio_ds.xml
@@ -2,26 +2,9 @@
     <hal format="hidl">
         <name>android.hardware.radio</name>
         <transport>hwbinder</transport>
-        <version>1.2</version>
-        <interface>
-            <name>IRadio</name>
-            <instance>slot1</instance>
-            <instance>slot2</instance>
-        </interface>
-        <interface>
-            <name>ISap</name>
-            <instance>slot1</instance>
-            <instance>slot2</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
-        <name>android.hardware.radio.deprecated</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>IOemHook</name>
-            <instance>slot1</instance>
-            <instance>slot2</instance>
-        </interface>
+        <fqname>@1.2::ISap/slot1</fqname>
+        <fqname>@1.2::ISap/slot2</fqname>
+        <fqname>@1.2::IRadio/slot1</fqname>
+        <fqname>@1.2::IRadio/slot2</fqname>
     </hal>
 </manifest>

--- a/vintf/android.hw.radio_ss.xml
+++ b/vintf/android.hw.radio_ss.xml
@@ -2,23 +2,7 @@
     <hal format="hidl">
         <name>android.hardware.radio</name>
         <transport>hwbinder</transport>
-        <version>1.2</version>
-        <interface>
-            <name>IRadio</name>
-            <instance>slot1</instance>
-        </interface>
-        <interface>
-            <name>ISap</name>
-            <instance>slot1</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
-        <name>android.hardware.radio.deprecated</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>IOemHook</name>
-            <instance>slot1</instance>
-        </interface>
+        <fqname>@1.2::ISap/slot1</fqname>
+        <fqname>@1.2::IRadio/slot1</fqname>
     </hal>
 </manifest>

--- a/vintf/vendor.hw.radio_ds.xml
+++ b/vintf/vendor.hw.radio_ds.xml
@@ -95,5 +95,4 @@
         <fqname>@1.0::IUimRemoteServiceServer/uimRemoteServer0</fqname>
         <fqname>@1.0::IUimRemoteServiceServer/uimRemoteServer1</fqname>
     </hal>
-
 </manifest>

--- a/vintf/vendor.hw.radio_ss.xml
+++ b/vintf/vendor.hw.radio_ss.xml
@@ -79,5 +79,4 @@
         </interface>
         <fqname>@1.0::IUimRemoteServiceServer/uimRemoteServer0</fqname>
     </hal>
-
 </manifest>


### PR DESCRIPTION
following crosshatch
add sap-service
remove deprecated-interface which is completely removed in P ... see https://android.googlesource.com/platform/hardware/interfaces/+/android-9.0.0_r21/radio/deprecated/1.0/IOemHook.hal?autodive=0%2F%2F%2F%2F%2F%2F#23

Signed-off-by: David Viteri <davidteri91@gmail.com>