### PR TITLE
common-prop: Set vulkan lib name

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -138,6 +138,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.opengles.version=196610
 
+# Vulkan lib name(will be loaded by the hal as vulkan.qcom.so)
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.hardware.vulkan=qcom
+
 # Vendor version
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.odm.expect.version=$(PLATFORM_VERSION)_$(SOMC_KERNEL_VERSION)_$(SOMC_PLATFORM)_$(TARGET_VENDOR_VERSION)


### PR DESCRIPTION
The libvulkan loader will try to load `vulkan.%s.so` until a loadable name is found, where %s would be the following two properties:
- `ro.hardware.vulkan`
- `ro.board.platform`

See [libvulkan/driver.cpp](https://android.googlesource.com/platform/frameworks/native/+/53457dbae92cb6fb12fac06cf0e874ff3c49528d/vulkan/libvulkan/driver.cpp#137)

Since software binaries version 5, the vulkan lib has been renamed from `vulkan.$(TARGET_BOARD_PLATFORM).so` to `vulkan.qcom.so`.

Set `ro.hardware.vulkan` to `qcom` so that `vulkan.qcom.so` will be loaded.