### PR TITLE
[COMMON] hw: health: Fix permissions for battery_charge_full

### DIFF
--- a/hardware/health/android.hardware.health@2.0-service.sony.rc
+++ b/hardware/health/android.hardware.health@2.0-service.sony.rc
@@ -1,6 +1,8 @@
 on fs
     # Create battery stats dir
     mkdir /mnt/vendor/persist/battery 0700 system system
+    # Set permissions to for battery capacity
+    chown system system /sys/class/power_supply/bms/charge_full
 
 service vendor.health-hal-2-0 /vendor/bin/hw/android.hardware.health@2.0-service.sony
     interface android.hardware.health@2.0::IHealth default


### PR DESCRIPTION
If permissions aren't set, the HAL will be unable to store
the measured battery capacity, hence raising the risk of
battery swelling due to extended wear.


PR solves the following message:
01-29 22:24:23.574   508   508 E /vendor/bin/hw/android.hardware.health@2.0-service.sony: Write max battery capacity to sysfs error: Permission denied

After solving the issue, the parameter is getting set as per this example:
01-29 22:26:19.978   508   508 I /vendor/bin/hw/android.hardware.health@2.0-service.sony: Successfully restored max battery capacity of 2456 mAh
