### PR TITLE
[DONOTMERGE] Adjust permission xml files target location

### DIFF
--- a/common-perm.mk
+++ b/common-perm.mk
@@ -56,8 +56,8 @@ PRODUCT_COPY_FILES += \
 
 # Transmit power
 PRODUCT_COPY_FILES += \
-    $(COMMON_PATH)/rootdir/system/etc/permissions/privapp-permissions-transmitpower.xml:system/etc/permissions/privapp-permissions-transmitpower.xml
+    $(COMMON_PATH)/rootdir/system/etc/permissions/privapp-permissions-transmitpower.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/privapp-permissions-transmitpower.xml
 
 # Extended Settings
 PRODUCT_COPY_FILES += \
-    $(COMMON_PATH)/rootdir/system/etc/permissions/privapp-permissions-extendedsettings.xml:system/etc/permissions/privapp-permissions-extendedsettings.xml
+    $(COMMON_PATH)/rootdir/system/etc/permissions/privapp-permissions-extendedsettings.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/privapp-permissions-extendedsettings.xml

--- a/common-perm.mk
+++ b/common-perm.mk
@@ -52,7 +52,7 @@ endif
 
 # Common System Permissions
 PRODUCT_COPY_FILES += \
-    $(COMMON_PATH)/rootdir/system/etc/permissions/privapp-permissions-extension.xml:system/etc/permissions/privapp-permissions-extension.xml
+    $(COMMON_PATH)/rootdir/system/etc/permissions/privapp-permissions-extension.xml:$(TARGET_COPY_OUT_SYSTEM)/etc/permissions/privapp-permissions-extension.xml
 
 # Transmit power
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
- Use `TARGET_COPY_OUT_SYSTEM` instead of "system" so system-as-root targets won't have issues later on

- Copy vendor app perms to vendor: ExtendedSettings and TransPower are vendor apps now, so copy the accompanying priv-app permission xml files to `TARGET_COPY_OUT_VENDOR`