### PR TITLE
overlay: core: config: Enable night display on all platforms.

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -270,4 +270,9 @@
 
     <!-- Flag indicating whether we should enable smart battery. -->
     <bool name="config_smart_battery_available">true</bool>
+
+    <!-- Control whether Night display is available. This should only be enabled on devices
+         that have a HWC implementation that can apply the matrix passed to setColorTransform
+         without impacting power, performance, and app compatibility (e.g. protected content). -->
+    <bool name="config_nightDisplayAvailable">true</bool>
 </resources>


### PR DESCRIPTION
Fixes https://github.com/sonyxperiadev/bug_tracker/issues/319.

This property was apparently overlooked, since it is enabled on some custom roms built on top of Sony Open Devices, and works fine on most/all devices.
Work has gone into a fallback to apply the transformation in the GPU, due to an error in `libsdm-color`s `setColorTransform` on Loire devices (and others?). Nile shows a very similar issue since switching to SDE. @jerpelea Would it be possible to check these cases again in the closed-source blobs? For Loire, it'd be nice to use the (advertised) HW transformation (or get rid of that advertisement), and for Nile something else must be wrong; afaik it worked fine before SDE, so there's no point in using a GPU fallback now.
https://github.com/sonyxperiadev/bug_tracker/issues/80 for reference.

Commit description:
> This boolean is required to show and enable the night display settings.
Not all platforms strictly adhere to the power/performance requirements,
for example Loire requires a fallback to GPU transformations because the
reported HWC2.0 functionality doesn't work, and a similar issue arises
on Nile SDE that has yet to be solved. The power hit doesn't seem nearly
as bad, and enabling it allows more testing and eventually pinning the
issue in libsdm-color that prevents the hardware transformation from
happening.