### PR TITLE
[o-mr1] common-perm: Copy vendor app perms to vendor

### DIFF
--- a/common-perm.mk
+++ b/common-perm.mk
@@ -50,8 +50,8 @@ PRODUCT_COPY_FILES += \
 
 # Transmit power
 PRODUCT_COPY_FILES += \
-    $(COMMON_PATH)/rootdir/system/etc/permissions/privapp-permissions-transmitpower.xml:system/etc/permissions/privapp-permissions-transmitpower.xml
+    $(COMMON_PATH)/rootdir/system/etc/permissions/privapp-permissions-transmitpower.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/privapp-permissions-transmitpower.xml
 
 # Extended Settings
 PRODUCT_COPY_FILES += \
-    $(COMMON_PATH)/rootdir/system/etc/permissions/privapp-permissions-extendedsettings.xml:system/etc/permissions/privapp-permissions-extendedsettings.xml
+    $(COMMON_PATH)/rootdir/system/etc/permissions/privapp-permissions-extendedsettings.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/privapp-permissions-extendedsettings.xml


### PR DESCRIPTION
(Backport to `o-mr1` branch)

ExtendedSettings and TransPower are vendor apps now, so copy the accompanying priv-app permission xml files to TARGET_COPY_OUT_VENDOR