### PR TITLE
health: Do not spam logcat with battery stats

### DIFF
--- a/hardware/health/libhealthd_board.cpp
+++ b/hardware/health/libhealthd_board.cpp
@@ -40,5 +40,5 @@ void healthd_board_init(struct healthd_config *) {
 int healthd_board_battery_update(struct android::BatteryProperties *props) {
     ::device::sony::health::health_board_battery_update(props);
     // return 0 to log periodic polled battery status to kernel log
-    return 0;
+    return 1;
 }


### PR DESCRIPTION
The setting was left enabled in the testing phase but can be turned off now.