### PR TITLE
Drop android.hardware.power@1.0 service and impl

### DIFF
--- a/common-packages.mk
+++ b/common-packages.mk
@@ -99,8 +99,7 @@ PRODUCT_PACKAGES += \
 
 # OSS Power HAL
 PRODUCT_PACKAGES += \
-    librqbalance \
-    android.hardware.power@1.3-service.sony
+    librqbalance
 
 # OSS WIFI and BT MAC tool
 PRODUCT_PACKAGES += \

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -128,11 +128,6 @@ PRODUCT_PACKAGES += \
     android.hardware.thermal@1.0-impl \
     android.hardware.thermal@1.0-service
 
-# Power
-PRODUCT_PACKAGES += \
-    android.hardware.power@1.0-impl \
-    android.hardware.power@1.0-service
-
 ifeq ($(AB_OTA_UPDATER),true)
 # Boot control
 PRODUCT_PACKAGES += \

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -128,6 +128,10 @@ PRODUCT_PACKAGES += \
     android.hardware.thermal@1.0-impl \
     android.hardware.thermal@1.0-service
 
+# Power
+PRODUCT_PACKAGES += \
+    android.hardware.power@1.3-service.sony
+
 ifeq ($(AB_OTA_UPDATER),true)
 # Boot control
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
* Since we are providing our own service and
  power.$(TARGET_DEVICE) is dead there's no
  reason to build it.