### PR TITLE
init: Update vendor services

### DIFF
--- a/hardware/liblights/android.hardware.light@2.0-service.sony.rc
+++ b/hardware/liblights/android.hardware.light@2.0-service.sony.rc
@@ -1,4 +1,7 @@
-service light-hal-2-0 /vendor/bin/hw/android.hardware.light@2.0-service.sony
+service vendor.light-hal-2-0 /vendor/bin/hw/android.hardware.light@2.0-service.sony
+    interface android.hardware.light@2.0::ILight default
     class hal
     user system
     group system
+    # shutting off lights while powering-off
+    shutdown critical

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -119,15 +119,6 @@ include $(BUILD_PREBUILT)
 
 
 include $(CLEAR_VARS)
-LOCAL_MODULE := charger.rc
-LOCAL_MODULE_CLASS := ETC
-LOCAL_SRC_FILES := vendor/etc/init/charger.rc
-LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
-include $(BUILD_PREBUILT)
-
-
-include $(CLEAR_VARS)
 LOCAL_MODULE := ipacm.rc
 LOCAL_MODULE_CLASS := ETC
 LOCAL_SRC_FILES := vendor/etc/init/ipacm.rc

--- a/rootdir/vendor/etc/init/android.hardware.gatekeeper@1.0-service-qti.rc
+++ b/rootdir/vendor/etc/init/android.hardware.gatekeeper@1.0-service-qti.rc
@@ -1,4 +1,4 @@
-service gatekeeper-1-0 /odm/bin/hw/android.hardware.gatekeeper@1.0-service-qti
+service vendor.gatekeeper-1-0 /odm/bin/hw/android.hardware.gatekeeper@1.0-service-qti
     class early_hal
     user system
     group system

--- a/rootdir/vendor/etc/init/android.hardware.gatekeeper@1.0-service-qti.rc
+++ b/rootdir/vendor/etc/init/android.hardware.gatekeeper@1.0-service-qti.rc
@@ -1,4 +1,5 @@
 service vendor.gatekeeper-1-0 /odm/bin/hw/android.hardware.gatekeeper@1.0-service-qti
+    interface android.hardware.gatekeeper@1.0::IGatekeeper default
     class early_hal
     user system
     group system

--- a/rootdir/vendor/etc/init/android.hardware.keymaster@3.0-service-qti.rc
+++ b/rootdir/vendor/etc/init/android.hardware.keymaster@3.0-service-qti.rc
@@ -1,4 +1,5 @@
 service vendor.keymaster-3-0 /odm/bin/hw/android.hardware.keymaster@3.0-service-qti
+    interface android.hardware.keymaster@3.0::IKeymasterDevice default
     class early_hal
     user system
     group system drmrpc

--- a/rootdir/vendor/etc/init/android.hardware.keymaster@3.0-service-qti.rc
+++ b/rootdir/vendor/etc/init/android.hardware.keymaster@3.0-service-qti.rc
@@ -1,4 +1,4 @@
-service keymaster-3-0 /odm/bin/hw/android.hardware.keymaster@3.0-service-qti
+service vendor.keymaster-3-0 /odm/bin/hw/android.hardware.keymaster@3.0-service-qti
     class early_hal
     user system
     group system drmrpc

--- a/rootdir/vendor/etc/init/android.hardware.keymaster@4.0-service-qti.rc
+++ b/rootdir/vendor/etc/init/android.hardware.keymaster@4.0-service-qti.rc
@@ -1,4 +1,5 @@
 service vendor.keymaster-4-0 /odm/bin/hw/android.hardware.keymaster@4.0-service-qti
+    interface android.hardware.keymaster@4.0::IKeymasterDevice default
     class early_hal
     user system
     group system drmrpc

--- a/rootdir/vendor/etc/init/android.hardware.keymaster@4.0-service-qti.rc
+++ b/rootdir/vendor/etc/init/android.hardware.keymaster@4.0-service-qti.rc
@@ -1,4 +1,4 @@
-service keymaster-4-0 /odm/bin/hw/android.hardware.keymaster@4.0-service-qti
+service vendor.keymaster-4-0 /odm/bin/hw/android.hardware.keymaster@4.0-service-qti
     class early_hal
     user system
     group system drmrpc

--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -18,7 +18,7 @@ on charger
     start irsc_util
 
 # Offline charger
-service charger /charger
+service vendor.charger /charger
     class charger
     group root system log
     critical

--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -34,7 +34,7 @@ on init
 
     # qseecomd needs /dev/block/bootdevice
     # vold needs keymaster that needs qseecomd
-    start qseecomd
+    start vendor.qseecomd
 
     # Enable subsystem restart
     write /sys/module/subsystem_restart/parameters/enable_ramdumps 0
@@ -94,7 +94,7 @@ on fs
     restorecon_recursive /mnt/vendor/persist
 
 on post-fs
-    # Wait qseecomd started
+    # Wait for qseecomd to be started
     wait_for_prop vendor.sys.listeners.registered true
 
 on late-fs

--- a/rootdir/vendor/etc/init/qmuxd.rc
+++ b/rootdir/vendor/etc/init/qmuxd.rc
@@ -13,4 +13,5 @@ service qmuxd /odm/bin/qmuxd
 on property:ro.boot.baseband=apq
     setprop ro.radio.noril yes
     stop vendor.ril-daemon
+    stop vendor.ril-daemon2
     enable qmuxd

--- a/rootdir/vendor/etc/init/qmuxd.rc
+++ b/rootdir/vendor/etc/init/qmuxd.rc
@@ -12,5 +12,5 @@ service qmuxd /odm/bin/qmuxd
 
 on property:ro.boot.baseband=apq
     setprop ro.radio.noril yes
-    stop ril-daemon
+    stop vendor.ril-daemon
     enable qmuxd

--- a/rootdir/vendor/etc/init/qseecom.rc
+++ b/rootdir/vendor/etc/init/qseecom.rc
@@ -1,5 +1,5 @@
 # QCOM Secure
-service qseecomd /odm/bin/qseecomd
+service vendor.qseecomd /odm/bin/qseecomd
     class core
     user root
     group root

--- a/rootdir/vendor/etc/init/rild2.rc
+++ b/rootdir/vendor/etc/init/rild2.rc
@@ -1,5 +1,5 @@
 # DSDS second ril
-service ril-daemon2 /vendor/bin/hw/rild -c 2
+service vendor.ril-daemon2 /vendor/bin/hw/rild -c 2
     class main
     user radio
     disabled
@@ -7,4 +7,4 @@ service ril-daemon2 /vendor/bin/hw/rild -c 2
     capabilities BLOCK_SUSPEND NET_ADMIN NET_RAW
 
 on property:persist.radio.multisim.config=dsds
-    enable ril-daemon2
+    enable vendor.ril-daemon2


### PR DESCRIPTION
- Add `interface` information to services' `init.rc` files, allows for dynamic HALs and maybe more in Q
- Rename services to follow the `vendor.*` pattern as upstream does
- Remove unused `charger.rc` definition

Most of these changes bring our configs in line with crosshatch.

**Attention:** Test carefully whether some blob relies on the old naming scheme, e.g. for `qseecomd`.