### PR TITLE
vintf: Add vendor.nxp.INxpNfc HAL to manifest

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -116,6 +116,9 @@ include device/sony/sepolicy/sepolicy.mk
 DEVICE_MANIFEST_FILE := $(COMMON_PATH)/vintf/manifest.xml
 DEVICE_MATRIX_FILE   := $(COMMON_PATH)/vintf/compatibility_matrix.xml
 
+# Custom NXP vendor interfaces
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.nxp.nfc.interfaces.xml
+
 ifeq ($(PRODUCT_DEVICE_DS),true)
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hw.radio_ds.xml
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.hw.radio_ds.xml

--- a/vintf/vendor.nxp.nfc.interfaces.xml
+++ b/vintf/vendor.nxp.nfc.interfaces.xml
@@ -1,0 +1,11 @@
+<manifest version="1.0" type="device" target-level="2">
+    <hal format="hidl">
+        <name>vendor.nxp.nxpnfc</name>
+        <transport>hwbinder</transport>
+        <version>1.1</version>
+        <interface>
+            <name>INxpNfc</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>


### PR DESCRIPTION
`INxpNfc` is a vendor extension that is supported by the HAL code in `hardware/nxp/*`.