### PR TITLE
Powerhal fixes

### DIFF
--- a/hardware/power/Hints.cpp
+++ b/hardware/power/Hints.cpp
@@ -414,11 +414,6 @@ int RQBalanceHintsHandler::manage_powerserver(bool start)
 
     psthread_run = true;
 
-    /* Create folder, if doesn't exist */
-    if (stat(POWERSERVER_DIR, &st) == -1) {
-        mkdir(POWERSERVER_DIR, 0773);
-    }
-
     /* Get socket in the UNIX domain */
     sock = socket(PF_UNIX, SOCK_SEQPACKET, 0);
     if (sock < 0) {

--- a/hardware/power/android.hardware.power@1.3-service.sony.rc
+++ b/hardware/power/android.hardware.power@1.3-service.sony.rc
@@ -3,3 +3,5 @@ service vendor.power-hal-1-3 /vendor/bin/hw/android.hardware.power@1.3-service.s
     user root
     group system
 
+on post-fs-data
+    mkdir /dev/socket/powerhal 0773 system system

--- a/hardware/power/common.h
+++ b/hardware/power/common.h
@@ -34,7 +34,7 @@
 #define SYS_CPU_HI_LIMIT	RQBALANCE_NODE "cluster_freq_vote_max"
 
 /* Android properties */
-#define PROP_DEBUGLVL			"persist.powerhal.debug_level"
+#define PROP_DEBUGLVL			"persist.vendor.powerhal.debug_level"
 
 /* PowerServer definitions */
 #define POWERSERVER_DIR			"/dev/socket/powerhal/"


### PR DESCRIPTION
### Push socket folder creation to init
Use init.rc mechanisms in order to create the powerhal socket folder `/dev/socket/powerhal` with the correct permissions and SELinux context. (Else the socket is created as `u:object_r:socket_device`!)

### Use persist.vendor.* naming for prop
The new naming scheme is customary now