### PR TITLE
[WIP] common-prop: Prefix "vendor." to rild.libpath

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -131,7 +131,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # RILD
 PRODUCT_PROPERTY_OVERRIDES += \
-    rild.libpath=/odm/lib64/libril-qc-qmi-1.so \
+    vendor.rild.libpath=/odm/lib64/libril-qc-qmi-1.so \
     ril.subscription.types=NV,RUIM
 
 # OpenGLES version


### PR DESCRIPTION
This is needed when switching to whitelisted "compatible" properties only.