### PR TITLE
[WIP] init: adb_tcp: Use "compatible" ES adb port prop

### DIFF
--- a/rootdir/vendor/etc/init/adb_tcp.rc
+++ b/rootdir/vendor/etc/init/adb_tcp.rc
@@ -1,11 +1,11 @@
 # ADB over network
-on property:adb.network.port.es=*
-    setprop service.adb.tcp.port ${adb.network.port.es}
+on property:vendor.adb.network.port.es=*
+    setprop service.adb.tcp.port ${vendor.adb.network.port.es}
 
-on property:service.adb.tcp.port=5555
+on property:vendor.adb.network.port.es=5555
     stop adbd
     start adbd
 
-on property:service.adb.tcp.port=-1
+on property:vendor.adb.network.port.es=-1
     stop adbd
     start adbd


### PR DESCRIPTION
Needs change in ExtendedSettings to update from `adb.network.*` to `vendor.adb.network`.

(Original PR content was to rename per-proxy and also act on the renamed multisim prop)