### PR TITLE
[COMMON] init: common: Reduce swappiness to 25

### DIFF
--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -345,7 +345,7 @@ on boot
 on property:sys.boot_completed=1
     # Enable ZRAM on boot_complete
     swapon_all /vendor/etc/fstab.${ro.hardware}
-    write /proc/sys/vm/swappiness 100
+    write /proc/sys/vm/swappiness 25
 
 on property:vendor.sys.listeners.registered=true
     # load IPA FWs


### PR DESCRIPTION
Setting swappiness to 100 makes us to use swap (in our case
ZRAM) too much, instead of our dear RAM: while this is sort of
okay, meaning that we are compressing pages way more often,
this is a handheld device on ARM64 and running on battery.

Swappiness set to 100 will increase the power usage for no real
reason, not to mention the impacts on the device's performance
due to the increased computational overhead, hence set it to 25
so that we definitely prefer using the system memory and, when
we're about to run out of it, way before OOM or LMK kicks in, we
compress our pages to try to squeeze more data in.
Only at this point it is worth it to trade some performance and
battery to provide an overall better user experience.