### PR TITLE
common-prop: Add back rild.libpath

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -134,6 +134,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # RILD
 PRODUCT_PROPERTY_OVERRIDES += \
+    rild.libpath=/odm/lib64/libril-qc-qmi-1.so \
     vendor.rild.libpath=/odm/lib64/libril-qc-qmi-1.so \
     ril.subscription.types=NV,RUIM
 


### PR DESCRIPTION
The legacy prop is still needed for devices which cannot be made fully
"compatible"