### PR TITLE
rootdir: vendor: declare aptX encoders as public libraries

### DIFF
--- a/rootdir/vendor/etc/public.libraries.txt
+++ b/rootdir/vendor/etc/public.libraries.txt
@@ -2,3 +2,5 @@ libadsprpc.so
 libcdsprpc.so
 libsdsprpc.so
 libOpenCL.so
+libaptX_encoder.so
+libaptXHD_encoder.so


### PR DESCRIPTION
Android is unable to load these libraries from /odm.
Trying to symlink the libraries to /system does not help because of namespace restrictions.
Resort to adding the libraries to public.libraries.txt as means of allowing Android to load them.