### PR TITLE
init: Boot DSP before SLPI again

### DIFF
--- a/rootdir/vendor/etc/init/adspstart.rc
+++ b/rootdir/vendor/etc/init/adspstart.rc
@@ -4,6 +4,3 @@ service adspstart_sh /vendor/bin/init.qcom.adspstart.sh
     group root system
     disabled
     oneshot
-
-on property:vendor.qcom.slpiup=1
-    start adspstart_sh

--- a/rootdir/vendor/etc/init/cdsprpcd.rc
+++ b/rootdir/vendor/etc/init/cdsprpcd.rc
@@ -6,4 +6,3 @@ service vendor.cdsprpcd /odm/bin/cdsprpcd
 
 on property:vendor.qcom.cdspup=1
     enable vendor.cdsprpcd
-

--- a/rootdir/vendor/etc/init/cdspstart.rc
+++ b/rootdir/vendor/etc/init/cdspstart.rc
@@ -4,6 +4,3 @@ service cdspstart_sh /vendor/bin/init.qcom.cdspstart.sh
     group root system
     disabled
     oneshot
-
-on property:vendor.qcom.slpiup=1
-    start cdspstart_sh

--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -88,8 +88,11 @@ on fs
 
     mount_all /vendor/etc/fstab.${ro.hardware}
 
-    # Start devices as soon as partitions are moounted
-    start slpistart_sh
+    # Start DSP services as soon as partitions are mounted
+    # ADSP devices
+    start adspstart_sh
+    # CDSP devices
+    start cdspstart_sh
 
     # Remove "security.restorecon_last" xattr from /mnt/vendor/persist/
     exec u:r:vendor_init:s0 root root -- /vendor/bin/toybox_vendor setfattr -x security.restorecon_last /mnt/vendor/persist/

--- a/rootdir/vendor/etc/init/sensors.rc
+++ b/rootdir/vendor/etc/init/sensors.rc
@@ -23,6 +23,6 @@ service vendor.sensors /odm/bin/sensors.qcom
     group system
     disabled
 
-# Enable the service after adsp is up
-on property:vendor.qcom.adspup=1
+# Enable the service after ADSP and SLPI are up
+on property:vendor.qcom.slpiup=1
     enable vendor.sensors

--- a/rootdir/vendor/etc/init/slpistart.rc
+++ b/rootdir/vendor/etc/init/slpistart.rc
@@ -4,3 +4,6 @@ service slpistart_sh /vendor/bin/init.qcom.slpistart.sh
     group root system
     disabled
     oneshot
+
+on property:vendor.qcom.adspup=1
+    start slpistart_sh

--- a/rootdir/vendor/etc/init/sscrpcd.rc
+++ b/rootdir/vendor/etc/init/sscrpcd.rc
@@ -4,5 +4,5 @@ service vendor.sscrpcd /odm/bin/sscrpcd
     group system
     disabled
 
-on property:vendor.qcom.adspup=1
+on property:vendor.qcom.cdspup=1
     start vendor.sscrpcd


### PR DESCRIPTION
 init: Boot DSP before SLPI again

Before 8792c97, adsp and cdsp were booted before slpi:

    init.qcom.devstart.sh
    echo 1 > /sys/kernel/boot_adsp/boot
    echo 1 > /sys/kernel/boot_cdsp/boot
    echo 1 > /sys/kernel/boot_slpi/boot

8792c97 changed that behaviour to first booting SLPI via `init.qcom.devstart.sh`, setting `vendor.qcom.devup=1` and only then booting ADSP/CSDP via `init.qcom.(adsp|cdsp)start.sh`.

That and later commits caused race conditions that meant audio was gone on tone devices every other boot.

This commit restores the old behaviour of first booting ADSP/CDSP and then SLPI.