### PR TITLE
[WIP] Add manual restorecon script for /persist

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -84,6 +84,10 @@ PRODUCT_PACKAGES += \
     rdclean.sh
 endif
 
+# Partition fixes
+PRODUCT_PACKAGES += \
+    restorecon_persist.sh
+
 # Qcom scripts
 PRODUCT_PACKAGES += \
     init.qcom.devstart.sh \

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -11,6 +11,15 @@ LOCAL_VENDOR_MODULE      := true
 include $(BUILD_PREBUILT)
 endif
 
+include $(CLEAR_VARS)
+LOCAL_MODULE             := restorecon_persist.sh
+LOCAL_MODULE_CLASS       := EXECUTABLES
+LOCAL_SRC_FILES_arm64    := vendor/bin/restorecon_persist.sh
+LOCAL_INIT_RC_64         := vendor/etc/init/restorecon_persist.rc
+LOCAL_MODULE_TARGET_ARCH := arm64
+LOCAL_VENDOR_MODULE      := true
+include $(BUILD_PREBUILT)
+
 ifneq ($(TARGET_LEGACY_KEYMASTER), true)
 include $(CLEAR_VARS)
 LOCAL_MODULE := android.hardware.gatekeeper@1.0-service-qti

--- a/rootdir/vendor/bin/restorecon_persist.sh
+++ b/rootdir/vendor/bin/restorecon_persist.sh
@@ -1,0 +1,4 @@
+#!/vendor/bin/sh
+
+/vendor/bin/log -p w -t "vendor.restorecon_persist" "Resetting RESTORECON_LAST xattr for /mnt/vendor/persist/"
+/vendor/bin/toybox_vendor setfattr -x security.restorecon_last /mnt/vendor/persist/

--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -91,7 +91,10 @@ on fs
     # Start devices as soon as partitions are moounted
     start devstart_sh
 
-    restorecon_recursive /mnt/vendor/persist
+    # Remove RESTORECON_LAST xattr from /mnt/vendor/persist/
+    exec_start vendor.restorecon_persist
+    # And force restoring of SELinux labels
+    restorecon_recursive /mnt/vendor/persist/
 
 on post-fs
     # Wait for qseecomd to be started

--- a/rootdir/vendor/etc/init/restorecon_persist.rc
+++ b/rootdir/vendor/etc/init/restorecon_persist.rc
@@ -1,0 +1,7 @@
+service vendor.restorecon_persist /vendor/bin/restorecon_persist.sh
+    # /persist is not encrypted and sensor files need to be available early
+    class early_hal
+    user root
+    group root system
+    oneshot
+    disabled


### PR DESCRIPTION
The `restorecon_recursive` directive in init is only applied if the `file_contexts` file changed between builds, but not necessarily if any file or folder inside `/mnt/vendor/persist/` has changed.

The restorecon code checks whether an xattr named `security.restorecon_last` contains a string that matches the current combined hashes of the SELinux context files and skips restoring labels
if there is a match, see https://android.googlesource.com/platform/external/selinux/+/refs/tags/android-9.0.0_r35/libselinux/src/android/android_platform.c#1546

Force wiping that xattr so that restorecon always runs since it's not very expensive (there are currently only about 50 files on /persist).

The restorecon is needed to fix issues such as wrong stock labels on `/mnt/vendor/persist/sensors/`:
`sensors_persist_file` -> `persist_sensors_file`

ATTENTION: restorecon_persist.sh needs accompanying SELinux labels and contexts!
-> See https://github.com/sonyxperiadev/device-sony-sepolicy/pull/521