### PR TITLE
[WIP] init: Force restorecon for /mnt/vendor/persist

### DIFF
--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -91,7 +91,10 @@ on fs
     # Start devices as soon as partitions are moounted
     start devstart_sh
 
-    restorecon_recursive /mnt/vendor/persist
+    # Remove "security.restorecon_last" xattr from /mnt/vendor/persist/
+    exec u:r:vendor_init:s0 root root -- /vendor/bin/toybox_vendor setfattr -x security.restorecon_last /mnt/vendor/persist/
+    # And force restoring of SELinux labels
+    restorecon_recursive /mnt/vendor/persist/
 
 on post-fs
     # Wait for qseecomd to be started

--- a/rootdir/vendor/etc/init/sensors.rc
+++ b/rootdir/vendor/etc/init/sensors.rc
@@ -5,12 +5,6 @@ on post-fs-data
     # Fix sensors permissions
     chown system system /mnt/vendor/persist/sensors
 
-    # Fix labels when coming from stock
-    # Note: The restorecon in hw/init.common.rc may skip the persist folder
-    # since it only checks whether the sepolicy file_contexts file has changed
-    # and not the actual folder contents.
-    restorecon_recursive /mnt/vendor/persist/sensors/
-
     # /dev/sensors only supports an ioctl to get the current SLPI timestamp;
     # allow the sensors daemon to perform this as non-root
     chown root system /dev/sensors


### PR DESCRIPTION
**NOTE:** This a simpler alternative to https://github.com/sonyxperiadev/device-sony-common/pull/600

The `restorecon_recursive` directive in init is only applied if the `file_contexts` file changed between builds, but not necessarily if any file or folder inside `/mnt/vendor/persist/` has changed.

The restorecon code checks whether an xattr named `security.restorecon_last` contains a string that matches the current combined hashes of the SELinux context files and skips restoring labels
if there is a match, see https://android.googlesource.com/platform/external/selinux/+/refs/tags/android-9.0.0_r35/libselinux/src/android/android_platform.c#1546

Force wiping that xattr so that restorecon always runs since it's not very expensive (there are currently only about 50 files on /persist).

The restorecon is needed to fix issues such as wrong stock labels on `/mnt/vendor/persist/sensors/`:
`sensors_persist_file` -> `persist_sensors_file`

ATTENTION: Needs accompanying SELinux labels and contexts!
-> See https://github.com/sonyxperiadev/device-sony-sepolicy/compare/master...ix5:restorecon-sensors-simpler?expand=1