### PR TITLE
[COMMON] init: per-service: Set pm-service to real-time ioprio

### DIFF
--- a/rootdir/vendor/etc/init/per-service.rc
+++ b/rootdir/vendor/etc/init/per-service.rc
@@ -3,4 +3,5 @@ service vendor.per_mgr /odm/bin/pm-service
     class core
     user system
     group system
+    ioprio rt 4
     shutdown critical


### PR DESCRIPTION
Following Qualcomm and Google, set this service to
real-time io priority to ensure that the commands will
get to the peripherals as soon as possible (in real-time).

Sources
SDM845: https://source.codeaurora.org/quic/la/platform/vendor/qcom/skunk/tree/init.target.rc?h=LA.UM.7.3.r1-07400-sdm845.0#n156
SDM710: https://source.codeaurora.org/quic/la/platform/vendor/qcom/skunk/tree/init.target.rc?h=LA.UM.7.8.r4-00800-SDM710.0#n156
SDM660: https://source.codeaurora.org/quic/la/platform/vendor/qcom/falcon_64/tree/init.target.rc?h=LA.UM.7.6.2.r1-08500-89xx.0#n116
Google: https://android.googlesource.com/device/google/bonito/+/refs/heads/master/init.hardware.rc#476