### PR TITLE
Health HAL: Actually save read battery cycles, rate-limit LearnedCapacity backup

### DIFF
--- a/hardware/health/CycleCountBackupRestore.cpp
+++ b/hardware/health/CycleCountBackupRestore.cpp
@@ -26,7 +26,7 @@ namespace device {
 namespace sony {
 namespace health {
 
-static constexpr int kBackupTrigger = 20;
+static constexpr int kCCBackupTrigger = 20;
 
 CycleCountBackupRestore::CycleCountBackupRestore() {
     sw_cycles_ = 0;
@@ -55,14 +55,15 @@ void CycleCountBackupRestore::Backup(int battery_level) {
     }
     saved_soc_ = battery_level;
     // To avoid writting file too often just rate limit it
-    if (soc_inc_ >= kBackupTrigger) {
+    if (soc_inc_ >= kCCBackupTrigger) {
+        LOG(VERBOSE) << "CC: Triggered Read(kSysCycleFile) and UpdateAndSave() !";
         Read(kSysCycleFile, hw_cycles_);
         UpdateAndSave();
         soc_inc_ = 0;
     }
 }
 
-void CycleCountBackupRestore::Read(const std::string &path, int cycles) {
+void CycleCountBackupRestore::Read(const std::string &path, int &cycles) {
     std::string buffer;
 
     if (!android::base::ReadFileToString(path, &buffer)) {

--- a/hardware/health/CycleCountBackupRestore.h
+++ b/hardware/health/CycleCountBackupRestore.h
@@ -44,7 +44,7 @@ class CycleCountBackupRestore {
     int saved_soc_;
     int soc_inc_;
 
-    void Read(const std::string &path, int cycles);
+    void Read(const std::string &path, int &cycles);
     void Write(int cycles, const std::string &path);
     void UpdateAndSave();
 };

--- a/hardware/health/LearnedCapacityBackupRestore.cpp
+++ b/hardware/health/LearnedCapacityBackupRestore.cpp
@@ -26,12 +26,16 @@ namespace device {
 namespace sony {
 namespace health {
 
+static constexpr int kLCBackupTrigger = 8;
+
 static constexpr int kBuffSize = 256;
 /* Battery capacity is given in microampere hours */
 /* Divide by 1000 to get milliampere hours("mAh") */
 static constexpr int kCapConversionFactor = 1000;
 
-LearnedCapacityBackupRestore::LearnedCapacityBackupRestore() {}
+LearnedCapacityBackupRestore::LearnedCapacityBackupRestore() {
+    cap_inc_ = 0;
+}
 
 void LearnedCapacityBackupRestore::Restore() {
     ReadFromPersistStorage();
@@ -40,8 +44,12 @@ void LearnedCapacityBackupRestore::Restore() {
 }
 
 void LearnedCapacityBackupRestore::Backup() {
-    ReadFromSRAM();
-    UpdateAndSave();
+    if (++cap_inc_ >= kLCBackupTrigger) {
+        LOG(VERBOSE) << "LC: Triggered ReadFromSRAM() and UpdateAndSave() !";
+        ReadFromSRAM();
+        UpdateAndSave();
+        cap_inc_ = 0;
+    }
 }
 
 void LearnedCapacityBackupRestore::ReadFromPersistStorage() {

--- a/hardware/health/LearnedCapacityBackupRestore.h
+++ b/hardware/health/LearnedCapacityBackupRestore.h
@@ -40,6 +40,7 @@ class LearnedCapacityBackupRestore {
    private:
     int sw_cap_;
     int hw_cap_;
+    int cap_inc_;
 
     void ReadFromPersistStorage();
     void SaveToPersistStorage();


### PR DESCRIPTION
### Actually save read battery cycles
Major derp, the `cycles` arg to `::Read()` was discarded instead of updated.
Update from `int` to `int &` to make the health HAL actually store battery cycles.

### Rate-limit LearnedCapacity backup
Only check values on every 8th call, saving some read/writes.