### PR TITLE
[WIP] common-prop: Enable direct boot from charger mode

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -181,3 +181,8 @@ else
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.vendor.keymaster.version=v3
 endif
+
+# Enable regular booting when long-pressing power button in charger mode
+# See system/core/healthd/healthd_mode_charger.cpp
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.enable_boot_charger_mode=true


### PR DESCRIPTION
Enable regular booting when long-pressing power button in charger mode
See [system/core/healthd/healthd_mode_charger.cpp](https://android.googlesource.com/platform/system/core/+/refs/tags/android-9.0.0_r39/healthd/healthd_mode_charger.cpp#431)