### PR TITLE
[Q-COMPAT] Move kernel includes to common.mk

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -103,10 +103,6 @@ ifeq ($(HOST_OS),linux)
 endif
 WITH_DEXPREOPT_BOOT_IMG_AND_SYSTEM_SERVER_ONLY ?= true
 
-BUILD_KERNEL := true
--include $(KERNEL_PATH)/common-headers/KernelHeaders.mk
--include $(KERNEL_PATH)/common-kernel/KernelConfig.mk
-
 # Include build helpers for QCOM proprietary
 -include vendor/qcom/proprietary/common/build/proprietary-build.mk
 

--- a/common.mk
+++ b/common.mk
@@ -30,6 +30,10 @@ PRODUCT_ENFORCE_RRO_TARGETS := \
 # for all devices, regardless of shipping API level
 PRODUCT_SEPOLICY_SPLIT_OVERRIDE := true
 
+BUILD_KERNEL := true
+-include $(KERNEL_PATH)/common-headers/KernelHeaders.mk
+-include $(KERNEL_PATH)/common-kernel/KernelConfig.mk
+
 # Codecs Configuration
 PRODUCT_COPY_FILES += \
     frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_audio.xml \


### PR DESCRIPTION
The `PRODUCT_VENDOR_KERNEL_HEADERS` buildvar in [common-headers/KernelHeaders](https://github.com/sonyxperiadev/device-sony-common-headers/blob/aosp/LE.UM.2.3.2.r1.4/KernelHeaders.mk) depends on `KERNEL_PATH` and needs to be set early because it will have been set read-only when `CommonConfig.mk` is read.