### PR TITLE
[DONOTMERGE] [Q-COMPAT] qcom/utils.mk: Use ?= for definitions

### DIFF
--- a/hardware/qcom/utils.mk
+++ b/hardware/qcom/utils.mk
@@ -1,8 +1,6 @@
 # vars for use by utils
-empty :=
-space := $(empty) $(empty)
-colon := $(empty):$(empty)
-underscore := $(empty)_$(empty)
+colon ?= $(empty):$(empty)
+underscore ?= $(empty)_$(empty)
 
 # $(call match-word,w1,w2)
 # checks if w1 == w2


### PR DESCRIPTION
**DO NOT MERGE** Not tested on P yet.

"empty", "space" etc. might already be defined and a redefinition throws a build error on Android Q.