### PR TITLE
[Q-COMPAT] Move kernel includes to common.mk

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -103,8 +103,6 @@ ifeq ($(HOST_OS),linux)
 endif
 WITH_DEXPREOPT_BOOT_IMG_AND_SYSTEM_SERVER_ONLY ?= true
 
-BUILD_KERNEL := true
--include $(KERNEL_PATH)/common-headers/KernelHeaders.mk
 -include $(KERNEL_PATH)/common-kernel/KernelConfig.mk
 
 # Include build helpers for QCOM proprietary

--- a/common.mk
+++ b/common.mk
@@ -30,6 +30,9 @@ PRODUCT_ENFORCE_RRO_TARGETS := \
 # for all devices, regardless of shipping API level
 PRODUCT_SEPOLICY_SPLIT_OVERRIDE := true
 
+BUILD_KERNEL := true
+-include $(KERNEL_PATH)/common-headers/KernelHeaders.mk
+
 # Codecs Configuration
 PRODUCT_COPY_FILES += \
     frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_audio.xml \

--- a/common.mk
+++ b/common.mk
@@ -30,7 +30,7 @@ PRODUCT_ENFORCE_RRO_TARGETS := \
 # for all devices, regardless of shipping API level
 PRODUCT_SEPOLICY_SPLIT_OVERRIDE := true
 
-BUILD_KERNEL := true
+BUILD_KERNEL ?= true
 -include $(KERNEL_PATH)/common-headers/KernelHeaders.mk
 
 # Codecs Configuration


### PR DESCRIPTION
But keep the include for the prebuilt kernel in `CommonConfig.mk` since its makefile depends on `$(TARGET_DEVICE)` which is only set after `common.mk` has been read.

`common.mk`: Make `BUILD_KERNEL` customizable
Use `?=` instead of `:=` so it is possible to override the buildvar in `customization.mk`.