### PR TITLE
init: Enable adsprpcd instead of starting

### DIFF
--- a/rootdir/vendor/etc/init/adsprpcd.rc
+++ b/rootdir/vendor/etc/init/adsprpcd.rc
@@ -1,6 +1,6 @@
 # ADSP FastRPC
 service vendor.adsprpcd /odm/bin/adsprpcd
-   class late_start
+   class main
    user media
    group media
    disabled
@@ -15,4 +15,4 @@ on property:ro.board.platform=sdm660
     enable vendor.audiopd
 
 on property:vendor.qcom.adspup=1
-    start vendor.adsprpcd
+    enable vendor.adsprpcd


### PR DESCRIPTION
This fixes the issue of the first boot on `forceencrypt` taking down `adsprpcd` without starting it back up again.

```
init    : processing action (vold.decrypt=trigger_shutdown_framework) from (/init.rc:715)
init    : Service 'vendor.adsprpcd' (pid 592) received signal 9
```

See: https://android.googlesource.com/platform/system/core/+/refs/tags/android-9.0.0_r39/rootdir/init.rc#716

`class main` brings it in sync with `cdsprpcd`, which is also in that class.

We can put it into `main` because the adsp and slpi devices will have been and remain booted already when the `vold.decrypt=trigger_shutdown_framework` prop triggers, no need to wait until `late_start` to start the `adsprpcd` service back up again.

btw... TOLD YA! :)