### PR TITLE
[Q-COMPAT] Change toybox run context, update selinux xattr

### DIFF
--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -95,7 +95,7 @@ on fs
     start cdspstart_sh
 
     # Remove "security.restorecon_last" xattr from /mnt/vendor/persist/
-    exec u:r:vendor_init:s0 root root -- /vendor/bin/toybox_vendor setfattr -x security.restorecon_last /mnt/vendor/persist/
+    exec u:r:vendor_toolbox:s0 root root -- /vendor/bin/toybox_vendor setfattr -x security.restorecon_last /mnt/vendor/persist/
     # And force restoring of SELinux labels
     restorecon_recursive /mnt/vendor/persist/
 

--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -94,8 +94,10 @@ on fs
     # CDSP devices
     start cdspstart_sh
 
-    # Remove "security.restorecon_last" xattr from /mnt/vendor/persist/
+    # (Android <= 9): Remove "security.restorecon_last" xattr from /mnt/vendor/persist/
     exec u:r:vendor_toolbox:s0 root root -- /vendor/bin/toybox_vendor setfattr -x security.restorecon_last /mnt/vendor/persist/
+    # (Android >= 10): Remove "security.sehash" xattr from /mnt/vendor/persist/
+    exec u:r:vendor_toolbox:s0 root root -- /vendor/bin/toybox_vendor setfattr -x security.sehash /mnt/vendor/persist/
     # And force restoring of SELinux labels
     restorecon_recursive /mnt/vendor/persist/
 


### PR DESCRIPTION
### init: Change toybox SELinux run context 
Entering the `vendor_init` context from other entrypoints is disallowed on Android Q, see:
https://android.googlesource.com/platform/system/sepolicy/+/44328c061d67636d4d8047ac69c4e778467eb4e8/public/vendor_init.te#263

### init: Wipe updated xattr from /persist/ 
`restorecon` now looks for the `security.sehash` xattr.

See https://android-review.googlesource.com/c/platform/external/selinux/+/916356

---

See https://github.com/sonyxperiadev/device-sony-sepolicy/pull/526 for updated sepolicy