### PR TITLE
[2/4] init: Allow system to access lge_touch/glove_mode in sysfs.

### DIFF
--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -211,6 +211,8 @@ on boot
     # Glove mode
     chown system system /sys/devices/virtual/input/clearpad/glove
     chmod 0660 /sys/devices/virtual/input/clearpad/glove
+    chown system system /sys/devices/virtual/input/lge_touch/glove_mode
+    chmod 0660 /sys/devices/virtual/input/lge_touch/glove_mode
 
     # Allow access for CCID command/response timeout configuration
     chown system system /sys/module/ccid_bridge/parameters/bulk_msg_timeout


### PR DESCRIPTION
Just like clearpads' glove attribute.

For https://github.com/sonyxperiadev/packages_apps_ExtendedSettings/pull/49.