### PR TITLE
[Q-COMPAT] Power: Add interface info to .rc

### DIFF
--- a/hardware/power/Hints.cpp
+++ b/hardware/power/Hints.cpp
@@ -376,7 +376,6 @@ retry_send:
 int RQBalanceHintsHandler::manage_powerserver(bool start)
 {
     int ret;
-    struct stat st = {};
     struct passwd *pwd;
     struct passwd *grp;
     uid_t uid;

--- a/hardware/power/android.hardware.power@1.3-service.sony.rc
+++ b/hardware/power/android.hardware.power@1.3-service.sony.rc
@@ -1,4 +1,9 @@
 service vendor.power-hal-1-3 /vendor/bin/hw/android.hardware.power@1.3-service.sony
+    # 1.0 is somehow still required even though 1.0-3 are allowed by P/Q FCM
+    interface android.hardware.power@1.0::IPower default
+    interface android.hardware.power@1.1::IPower default
+    interface android.hardware.power@1.2::IPower default
+    interface android.hardware.power@1.3::IPower default
     class hal
     user root
     group system


### PR DESCRIPTION
Android's servicemanager somehow still wants to start @1.0 at boot, so annotate that version as well.
Tested on Q/master, please confirm on P.

(Also sneak in the removal of the unused `st` var in `Hints.cpp`)