### PR TITLE
[WIP] common-prop: camera: Disable CDS

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -149,6 +149,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.nfc.port=I2C
 
+# Camera
+PRODUCT_PROPERTY_OVERRIDES += \
+	persist.vendor.camera.CDS=Off
+
 # RILD
 PRODUCT_PROPERTY_OVERRIDES += \
     vendor.rild.libpath=/odm/lib64/libril-qc-qmi-1.so \


### PR DESCRIPTION
(Alternative: https://github.com/sonyxperiadev/camera/pull/114)

Turn off Correlated Double Sampling in our camera HAL.
CDS seems broken with the kernel 4.9 drivers (occasional green tint in pictures), so disable it.

More info:
https://source.codeaurora.org/quic/la/platform/hardware/qcom/camera/commit/?id=9eeafe30749482b8dbb14cbaeda6df59c5ec7b91
(Cause: "ISP ping pong buffer errors")
https://github.com/PixelExperience-Devices/device_xiaomi_santoni/commit/dcfcb1309ae4ef37603404c98b87c4766ba12e70

Capitalization is needed, see:
https://github.com/sonyxperiadev/camera/blob/b918437410698035cb1f0fe51e6721ae808de1c5/QCamera2/HAL3/QCamera3HWI.cpp#L142-L146
https://github.com/sonyxperiadev/camera/blob/b918437410698035cb1f0fe51e6721ae808de1c5/QCamera2/HAL3/QCamera3HWI.cpp#L10891