### PR TITLE
[WIP] common-packages: Add netutils-wrapper

### DIFF
--- a/common-packages.mk
+++ b/common-packages.mk
@@ -79,6 +79,10 @@ PRODUCT_PACKAGES += \
     wpa_supplicant.conf \
     libwpa_client
 
+# Wrapped net utils for /vendor access.
+PRODUCT_PACKAGES += \
+	netutils-wrapper-1.0
+
 # NFC packages
 PRODUCT_PACKAGES += \
     NfcNci \


### PR DESCRIPTION
netutils-wrapper is a wrapper for netd to call /system tools such as /system/bin/ip from a vendor context.
This avoids selinux denials from netd and similar tools.

(Needs testing on Pie)