### PR TITLE
common.mk: Force split props for all devices

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -29,6 +29,8 @@ PRODUCT_ENFORCE_RRO_TARGETS := \
 # Force split of sepolicy into /system/etc/selinux and (/system)/vendor/etc/selinux
 # for all devices, regardless of shipping API level
 PRODUCT_SEPOLICY_SPLIT_OVERRIDE := true
+# Force moving all vendor props into /vendor/build.prop
+BOARD_PROPERTY_OVERRIDES_SPLIT_ENABLED := true
 
 # Codecs Configuration
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
Move all vendor props into `(/system)/vendor/build.prop`
Mainly for treble compliance but also to declutter the platform repos that already define this.

This buildvar can be set for all devices, it just doesn't change that much for older devices without a phsyical `/vendor` partition.