### PR TITLE
common-prop: reduce cost of scrypt for FBE CE

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -181,3 +181,7 @@ else
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.vendor.keymaster.version=v3
 endif
+
+# Reduce cost of scrypt for FBE CE decryption
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.crypto.scrypt_params=15:3:1


### PR DESCRIPTION
FBE CE switched from PBKDF2 to scrypt and scrypt's parameters are defined by 𝑁:𝑟:𝑝. However, in
Android we don't set 𝑁 directly. Instead, we set it via log(𝑁, 2) in the ro.crypto.scrypt_params
property whereby setting ro.crypto.scrypt_params=16:3:1 (AOSP's current default) would give a
value of 𝑁=65536. Google considered 𝑁=13 as optimal for marlin, due to memory and CPU usage scaling
linearly with 𝑁, however this also would affect security negatively. Use a value of 15 (suggested
by Golang's increase in 2018) which is still less than AOSP's default but also provides a
performance boost while maintaining decent security.

For the reasoning on why AOSP have made sure 𝑁 is to be a power of two, this is due to random
selection one of the 𝑁 memory slots at each iteration - converting the hash output to an integer
and reducing it mod 𝑁. If 𝑁 is a power of two, that operation can be optimized into faster
binary masking.

We're planning to move from the previous insecure yoshino-only configuration on scrypt to a better
configuration for all devices alongside https://github.com/sonyxperiadev/device-sony-yoshino/pull/141.

Signed-off-by: Laster K. (lazerl0rd) <officiallazerl0rd@gmail.com>