### PR TITLE
[1/2] [WIP] health: Add support for storage stats and health

### DIFF
--- a/hardware/health/Android.bp
+++ b/hardware/health/Android.bp
@@ -13,6 +13,8 @@ cc_binary {
         "HealthService.cpp",
         "CycleCountBackupRestore.cpp",
         "LearnedCapacityBackupRestore.cpp",
+        "StorageStats.cpp",
+        "Mock.cpp",
     ],
     static_libs: [
         "android.hardware.health@2.0-impl",
@@ -20,8 +22,6 @@ cc_binary {
         "libbatterymonitor",
         // libhealthservice is needed for health_service_main()
         "libhealthservice",
-        // Storage is needed by the HAL definition, use default
-        "libhealthstoragedefault",
     ],
     shared_libs: [
         "android.hardware.health@2.0",
@@ -37,6 +37,14 @@ cc_binary {
         // We only need BatteryService.h
         "libbatteryservice_headers",
     ],
+
+    product_variables: {
+        debuggable: {
+            cflags: [
+                "-DHEALTH_DEBUG",
+            ],
+        }
+    },
 
     // Only availbale in current Android Q master.
     // Nead to remove health section from common/vintf/manifext.xml as well

--- a/hardware/health/HealthService.cpp
+++ b/hardware/health/HealthService.cpp
@@ -19,22 +19,28 @@
 
 #define LOG_TAG "android.hardware.health@2.0-service.sony"
 
+#include <batteryservice/BatteryService.h>
+
+#include <health2/Health.h>
 /* For health_service_main() */
 #include <health2/service.h>
-
-#include <batteryservice/BatteryService.h>
-#include <health2/Health.h>
 #include <healthd/healthd.h>
 
 #include "CycleCountBackupRestore.h"
 #include "LearnedCapacityBackupRestore.h"
+#include "StorageStats.h"
 
 namespace {
 using ::device::sony::health::CycleCountBackupRestore;
 using ::device::sony::health::LearnedCapacityBackupRestore;
+using ::device::sony::health::StorageStats;
 static CycleCountBackupRestore ccBackupRestore;
 static LearnedCapacityBackupRestore lcBackupRestore;
+static StorageStats storageStats;
 }  // namespace
+
+using android::hardware::health::V2_0::DiskStats;
+using android::hardware::health::V2_0::StorageInfo;
 
 /* healthd_board_init() is called from health@2.0:Health.cpp when
  * the IHealth object is initialized */
@@ -54,7 +60,20 @@ int healthd_board_battery_update(struct android::BatteryProperties *props) {
     return 0;
 }
 
+void get_storage_info(std::vector<StorageInfo> &vec_storage_info) {
+    storageStats.GetStorageInfo(vec_storage_info);
+}
+
+void get_disk_stats(std::vector<DiskStats> &vec_stats) {
+    storageStats.GetDiskStats(vec_stats);
+}
+
 int main() {
+
+    /* Determine whether internal storage is EMMC or UFS based on ro.boot.bootdevice */
+    storageStats.GetStorageVariant();
+    /* Use sysfs paths based on bootdevice */
+    storageStats.FillStoragePaths();
 
     /* Setting the instance name explicitly is better */
     return health_service_main("default");

--- a/hardware/health/Mock.cpp
+++ b/hardware/health/Mock.cpp
@@ -1,0 +1,75 @@
+/*
+ * Simulate a failing EMMC disk.
+ * As of version 9.0 Pie 2019-07-12, Android only logs the storage health
+ * statistics but does not act upon them, however third-party programs might
+ * get access to the HAL data.
+ *
+ *
+ * Copyright (C) 2018 The Android Open Source Project
+ * Copyright (C) 2019 Felix Elsner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HEALTH_DEBUG
+
+#define LOG_TAG "HealthTestingMock"
+
+#include <android-base/properties.h>
+#include <android-base/logging.h>
+
+#include "Mock.h"
+
+namespace device {
+namespace sony {
+namespace health {
+
+using android::hardware::health::V2_0::DiskStats;
+using android::hardware::health::V2_0::StorageInfo;
+
+HealthTestingMock::HealthTestingMock() {
+    if (android::base::GetProperty("persist.vendor.health.fake_storage", "") == "1") {
+        kHealthMockDebugPropSet = true;
+        LOG(VERBOSE) << "Supplying fake storage and disk stats, don't panic...";
+    }
+}
+
+void HealthTestingMock::FakeStorageInfo(StorageInfo *storage_info) {
+    if (!kHealthMockDebugPropSet) {
+        return;
+    }
+    storage_info->attr.isInternal = true;
+    storage_info->attr.isBootDevice = true;
+    storage_info->attr.name = "MMC0";
+
+    storage_info->eol = 0x03; // "Urgent" -> Battery pretty much dead
+    storage_info->version = "emmc 5.1";
+    storage_info->lifetimeA = 0x0b; // "Exceeded Maximum Device Life Time"
+    storage_info->lifetimeB = 0x0b; // "Exceeded Maximum Device Life Time"
+}
+
+void HealthTestingMock::FakeDiskStats(DiskStats *disk_stats) {
+    if (!kHealthMockDebugPropSet) {
+        return;
+    }
+    disk_stats->attr.isInternal = true;
+    disk_stats->attr.isBootDevice = true;
+    disk_stats->attr.name = "MMC0";
+    // TODO: Implement stat mocking
+}
+
+}  // namespace health
+}  // namespace sony
+}  // namespace device
+
+#endif  // HEALTH_DEBUG

--- a/hardware/health/Mock.h
+++ b/hardware/health/Mock.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ * Copyright (C) 2019 Felix Elsner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DEVICE_SONY_HEALTH_MOCK_H
+#define DEVICE_SONY_HEALTH_MOCK_H
+
+#include <health2/Health.h>
+
+namespace device {
+namespace sony {
+namespace health {
+
+class HealthTestingMock {
+  public:
+    HealthTestingMock();
+
+    void FakeStorageInfo(StorageInfo *storage_info);
+    void FakeDiskStats(DiskStats *disk_stats);
+
+    bool kHealthMockDebugPropSet;
+};
+
+}  // namespace health
+}  // namespace sony
+}  // namespace device
+
+#endif  // DEVICE_SONY_HEALTH_MOCK_H

--- a/hardware/health/README.md
+++ b/hardware/health/README.md
@@ -9,6 +9,10 @@ devices with a few small modifications as well.
 Most notably, the sysfs paths might be different and the persist partition might
 be mounted at `/persist` instead of `/mnt/vendor/persist`.
 
+This HAL has a `HealthTestingMock` for debugging purposes. It is only available
+in userdebug/eng builds. The prop `persist.vendor.health.fake_storage=1` will
+trigger fake stats.
+
 ## License
 Apache License version 2, see [LICENSE.txt](LICENSE.txt).
 

--- a/hardware/health/StorageStats.cpp
+++ b/hardware/health/StorageStats.cpp
@@ -1,0 +1,382 @@
+/*
+ * Report storage health and disk stats by reading EMMC/UFS sysfs nodes.
+ *
+ * Storage health is expected to be expressed according to EMMC spec:
+ * JEDEC Standard Specification No.JESD84-B50.
+ * A lifetime value of 0x01 is good, 0x07 is bad.
+ * A storage pre-EOL info value of 0x01 is good, 0x03 is bad.
+ * As reference, Kingston Technology Company Inc. spec sheet EMMC08G-W100-A06U
+ * from 1/22/2015 can be used.
+ *
+ * As of 9.0 Pie, Android only logs the statistics and does not seem to act
+ * upon them.
+ *
+ * Storage health reporting is not available for UFS since there is no kernel
+ * support for UFS health as of 2019-07-12.
+ *
+ * Copyright (C) 2018 The Android Open Source Project
+ * Copyright (C) 2019 Felix Elsner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <errno.h>
+#include <stdexcept>
+
+#include <android-base/file.h>
+#include <android-base/logging.h>
+#include <android-base/properties.h>
+#include <android-base/strings.h>
+
+#include <fstream>
+
+#include "StorageStats.h"
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
+#ifdef HEALTH_DEBUG
+#include "Mock.h"
+#endif  // HEALTH_DEBUG
+
+namespace device {
+namespace sony {
+namespace health {
+
+using android::base::ReadFileToString;
+
+using android::hardware::health::V2_0::DiskStats;
+using android::hardware::health::V2_0::StorageInfo;
+
+#ifdef HEALTH_DEBUG
+static HealthTestingMock mock;
+#endif  // HEALTH_DEBUG
+
+static const std::string kBlockPath = "/sys/block/mmcblk0";
+/* Expected to resolve to e.g. */
+/* /sys/devices/platform/soc/7464900.sdhci/mmc_host/mmc0/mmc0:0001/block/mmcblk0 */
+/* We want the raw emmc/ufs infos from here as well: */
+/* /sys/devices/platform/soc/7464900.sdhci/mmc_host/mmc0/mmc0:0001/ */
+
+// Moved from "/sys/devices/soc" on 4.4
+static const std::string kSocPath = "/sys/devices/platform/soc";
+
+static std::string kEmmcDir;
+static std::string kEmmcSocDir;
+static std::string kEmmcEolFile;       // Format: 01
+static std::string kEmmcLifetimeFile;  // Format: 0x02 0x02
+static std::string kEmmcVersionFile;   // Format: 0x8
+static std::string kDiskStatsFile;
+static const std::string kEmmcName = "MMC0";
+/* TODO: Average voltage */
+
+static std::string kUfsDir;
+static std::string kUfsSocDir;
+static std::string kUfsEolFile;
+static std::string kUfsLifetimeAFile;
+static std::string kUfsLifetimeBFile;
+static std::string kUfsVersionFile;
+static const std::string kUfsName = "UFS0";
+
+// From system/core/storaged/storaged_info.cpp
+static const char *kEmmcVersionString[9] = {
+    "4.0", "4.1", "4.2", "4.3", "Obsolete", "4.41", "4.5", "5.0", "5.1"};
+
+static bool kStoragePathsAvailable;
+
+// Only log errors reading/scanning stats files once
+// TODO: Decide whether to ditch these and spam logcat to *really* alert users
+static bool kLoggedErrorForPathsUnavailable = false;
+static bool kLoggedErrorForEol = false;
+static bool kLoggedErrorForVersion = false;
+static bool kLoggedErrorForLifetime = false;
+static bool kLoggedErrorForDiskStats = false;
+
+void read_emmc_eol(StorageInfo *storage_info) {
+    std::string buffer;
+    if (!ReadFileToString(kEmmcEolFile, &buffer)) {
+        if (!kLoggedErrorForEol) {
+            LOG(WARNING) << "Could not read " << kEmmcEolFile;
+            kLoggedErrorForEol = true;
+        }
+        return;
+    }
+    buffer = android::base::Trim(buffer);
+    // TODO: Maybe just use sscanf()
+    try {
+        storage_info->eol = (uint16_t)std::stoul(buffer, nullptr, 0);
+    } catch (std::invalid_argument) {
+        if (!kLoggedErrorForEol) {
+            LOG(WARNING) << "Could not parse " << kEmmcEolFile << ": invalid argument";
+            kLoggedErrorForEol = true;
+        }
+    } catch (std::out_of_range) {
+        if (!kLoggedErrorForEol) {
+            LOG(WARNING) << "Could not parse " << kEmmcEolFile << ": '"
+                         << buffer << "' out of range";
+            kLoggedErrorForEol = true;
+        }
+    } catch (...) {
+        // BAD BAD BAD
+        LOG(ERROR) << "Unexpected exception while parsing " << kEmmcEolFile
+                   << ", buffer contents: '" << buffer << "'. FIX THIS!!!";
+    }
+}
+
+void read_emmc_version(StorageInfo *storage_info) {
+    uint16_t version;
+    std::string buffer;
+    if (!ReadFileToString(kEmmcVersionFile, &buffer)) {
+        if (!kLoggedErrorForVersion) {
+            LOG(WARNING) << "Could not read " << kEmmcVersionFile;
+            kLoggedErrorForVersion = true;
+        }
+        return;
+    }
+    buffer = android::base::Trim(buffer);
+    if (sscanf(buffer.c_str(), "0x%hx", &version) < 1) {
+        if (!kLoggedErrorForVersion) {
+            LOG(WARNING) << "Could not scan " << kEmmcVersionFile;
+            kLoggedErrorForVersion = true;
+        }
+        return;
+    }
+    if (version < 7 || version > ARRAY_SIZE(kEmmcVersionString)) {
+        if (!kLoggedErrorForVersion) {
+            LOG(WARNING) << "Invalid emmc version: " << buffer;
+            kLoggedErrorForVersion = true;
+        }
+        return;
+    }
+    storage_info->version = "emmc " + std::string(kEmmcVersionString[version]);
+}
+
+void read_emmc_lifetimes(StorageInfo *storage_info) {
+    std::string lifetimes;
+    uint16_t lifetime_a = 0, lifetime_b = 0;
+    if (!ReadFileToString(kEmmcLifetimeFile, &lifetimes)) {
+        if (!kLoggedErrorForLifetime) {
+            LOG(WARNING) << "Could not read " << kEmmcLifetimeFile << ": "
+                         << strerror(errno);
+            kLoggedErrorForLifetime = true;
+        }
+        return;
+    }
+    lifetimes = android::base::Trim(lifetimes);
+    if ((sscanf(lifetimes.c_str(), "0x%2hx 0x%2hx", &lifetime_a, &lifetime_b) < 2)
+            || (lifetime_a == 0 && lifetime_b == 0)) {
+        if (!kLoggedErrorForLifetime) {
+            LOG(WARNING) << "Could not scan " << kEmmcLifetimeFile;
+            LOG(WARNING) << "Contents do not match '0x\%hx 0x\%hx' scheme: "
+                         << lifetimes;
+            kLoggedErrorForLifetime = true;
+        }
+        return;
+    }
+    storage_info->lifetimeA = lifetime_a;
+    storage_info->lifetimeB = lifetime_b;
+}
+
+// TODO: Maybe replace with standard android::base::ReadFileToString ?
+// TODO: Nicer logging
+template <typename T>
+bool read_value_from_file(const std::string &path, T *field) {
+    std::ifstream stream(path);
+    if (!stream.is_open()) {
+        LOG(WARNING) << "Could not read " << path;
+        return false;
+    }
+    stream.unsetf(std::ios_base::basefield);
+    stream >> *field;
+    return true;
+}
+
+void read_ufs_version(StorageInfo *storage_info) {
+    // TODO: Maybe use decimal values, but it seems hex is the way to go
+    std::string version;
+    if (!ReadFileToString(kUfsVersionFile, &version)) {
+        if (!kLoggedErrorForVersion) {
+            LOG(WARNING) << "Could not read " << kUfsVersionFile;
+            kLoggedErrorForVersion = true;
+        }
+        return;
+    }
+    version = android::base::Trim(version);
+    storage_info->version = "ufs " + version;  // "ufs 0x08"
+}
+
+
+StorageStats::StorageStats() {
+}
+
+void StorageStats::GetStorageVariant() {
+    const std::string bootdevice = android::base::GetProperty("ro.boot.bootdevice", "0");
+    if (bootdevice == "0") {
+        LOG(WARNING) << "Could not determine bootdevice storage type from props,"
+                     << " storage health info will be unavailable";
+        return;  // FAIL
+    }
+    if (bootdevice.find(".sdhci") != std::string::npos) {
+        kStorageVariant = STORAGE_TYPE_EMMC;
+        kEmmcSocDir = kSocPath + "/" + bootdevice;
+    } else if (bootdevice.find(".ufshc") != std::string::npos) {
+        kStorageVariant = STORAGE_TYPE_UFS;
+        kUfsSocDir = kSocPath + "/" + bootdevice;
+    } else {
+        LOG(WARNING) << "Bootdevice type '" << bootdevice << "' not recognized"
+                     << ", storage health info will be unavailable";
+    }
+}
+
+void StorageStats::FillStoragePaths() {
+    switch (kStorageVariant) {
+        case STORAGE_TYPE_EMMC:
+            kStoragePathsAvailable = ResolveEmmcPaths();
+            kEmmcEolFile = kEmmcDir + "/pre_eol_info";    // Format: 01
+            kEmmcLifetimeFile = kEmmcDir + "/life_time";  // Format: 0x02 0x02
+            // TODO: Maybe use "fwrev", "hwrev" instead?
+            kEmmcVersionFile = kEmmcDir + "/rev";         // Format: 0x8
+            kDiskStatsFile = kBlockPath + "/stat";
+            break;
+        case STORAGE_TYPE_UFS:
+            kUfsEolFile = kUfsSocDir + "/health/eol";
+            // TODO: Format might be different
+            kUfsLifetimeAFile = kUfsSocDir + "/health/lifetimeA";
+            kUfsLifetimeBFile = kUfsSocDir + "/health/lifetimeB";
+            kUfsVersionFile = kUfsSocDir + "/version";
+            // TODO: Get path for UFS specifically
+            kDiskStatsFile =  "/sys/block/sda/stat";
+            break;
+        default:
+            kStoragePathsAvailable = false;
+            return;
+    }
+}
+
+/* Resolve the symlink from /sys/block/mmcblk0 and strip off the "block" part */
+/* TODO: Might be easier to read from here: */
+/* kEmmcDir = "/sys/bus/mmc/devices/mmc0:0001/"; */
+bool StorageStats::ResolveEmmcPaths() {
+    // TODO: Does this need to be freed? Compiler doesn't think so
+    const char *realpath_buf = realpath(kBlockPath.c_str(), nullptr);
+    if (realpath_buf == nullptr) {
+        LOG(WARNING) << "Could not resolve " << kBlockPath
+                     << ", storage health info will be unavailable";
+        return false;
+    }
+    kEmmcDir.clear();  // TODO: Necessary?
+    kEmmcDir.assign(realpath_buf);
+    /* Trim the trailing part to get the mmc non-block sysfs paths */
+    /* Full path would look like: */
+    /* /sys/devices/platform/soc/7464900.sdhci/mmc_host/mmc0/mmc0:0001/block/mmcblk0 */
+    /* But the node name could also be called "mmc0":aaaa or something similar */
+    const std::size_t pos = kEmmcDir.find("/block/mmcblk0");
+    if (pos == std::string::npos) {
+        LOG(WARNING) << "Could not find a valid EMMC/SDHCI sysfs node in path " << kEmmcDir;
+        LOG(WARNING) << "Storage health info will be unavailable";
+        return false;
+    }
+    kEmmcDir = kEmmcDir.substr(0, pos);
+    return true;
+}
+
+void StorageStats::GetStorageInfo(std::vector<StorageInfo> &vec_storage_info) {
+    vec_storage_info.resize(1);
+    StorageInfo *storage_info = &vec_storage_info[0];
+#ifdef HEALTH_DEBUG
+    if (mock.kHealthMockDebugPropSet) {
+        mock.FakeStorageInfo(storage_info);
+        return;
+    }
+#endif  // HEALTH_DEBUG
+    if (!kStoragePathsAvailable) {
+        if (!kLoggedErrorForPathsUnavailable) {
+            LOG(WARNING) << "Could not get storage info because EMMC/UFS paths"
+                         << " are not accessible";
+            kLoggedErrorForPathsUnavailable = true;
+        }
+        return;
+    }
+    storage_info->attr.isInternal = true;
+    storage_info->attr.isBootDevice = true;
+
+    switch (kStorageVariant) {
+        case STORAGE_TYPE_EMMC:
+            // TODO: Pass storage_info->version, ->eol etc. instead of the whole obj
+            read_emmc_version(storage_info);
+            read_emmc_eol(storage_info);
+            read_emmc_lifetimes(storage_info);
+            storage_info->attr.name = kEmmcName;
+            break;
+        case STORAGE_TYPE_UFS:
+            // Not available since there is no kernel support for UFS health
+            // reporting as of 2019-07-12
+            return;
+            /*
+            read_ufs_version(storage_info);
+            read_value_from_file(kUfsEolFile, &(storage_info)->eol);
+            read_value_from_file(kUfsLifetimeAFile, &(storage_info)->lifetimeA);
+            read_value_from_file(kUfsLifetimeBFile, &(storage_info)->lifetimeB);
+            storage_info->attr.name = kUfsName;
+            break;
+            */
+    }
+}
+
+// Based on crosshatch's HealthService.cpp
+void StorageStats::GetDiskStats(std::vector<DiskStats> &vec_stats) {
+    vec_stats.resize(1);
+    DiskStats *stats = &vec_stats[0];
+#ifdef HEALTH_DEBUG
+    if (mock.kHealthMockDebugPropSet) {
+        // Not implemented yet
+        mock.FakeDiskStats(stats);
+        return;
+    }
+#endif  // HEALTH_DEBUG
+    stats->attr.isInternal = true;
+    stats->attr.isBootDevice = true;
+    switch (kStorageVariant) {
+        case STORAGE_TYPE_EMMC:
+            stats->attr.name = kEmmcName;
+            break;
+        case STORAGE_TYPE_UFS:
+            stats->attr.name = kUfsName;
+            break;
+    }
+
+    std::ifstream stream(kDiskStatsFile);
+    if (stream.is_open()) {
+        // Regular diskstats entries
+        stream >> stats->reads
+               >> stats->readMerges
+               >> stats->readSectors
+               >> stats->readTicks
+               >> stats->writes
+               >> stats->writeMerges
+               >> stats->writeSectors
+               >> stats->writeTicks
+               >> stats->ioInFlight
+               >> stats->ioTicks
+               >> stats->ioInQueue;
+    } else {
+        if (!kLoggedErrorForDiskStats) {
+            LOG(WARNING) << "Could not open disk stats file " << kDiskStatsFile
+                << ": " << strerror(errno);
+            kLoggedErrorForDiskStats = true;
+        }
+    }
+}
+
+}  // namespace health
+}  // namespace sony
+}  // namespace device

--- a/hardware/health/StorageStats.h
+++ b/hardware/health/StorageStats.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ * Copyright (C) 2019 Felix Elsner
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DEVICE_SONY_HEALTH_STORAGESTATS_H
+#define DEVICE_SONY_HEALTH_STORAGESTATS_H
+
+#include <health2/Health.h>
+
+namespace device {
+namespace sony {
+namespace health {
+
+class StorageStats {
+   public:
+    StorageStats();
+
+    void GetStorageVariant();
+    void FillStoragePaths();
+    void GetStorageInfo(std::vector<StorageInfo> &vec_storage_info);
+    void GetDiskStats(std::vector<DiskStats> &vec_stats);
+
+   private:
+    bool ResolveEmmcPaths();
+
+    enum storagevariants {
+        STORAGE_TYPE_EMMC = 1,
+        STORAGE_TYPE_UFS = 2
+    };
+    int kStorageVariant;
+};
+
+}  // namespace health
+}  // namespace sony
+}  // namespace device
+
+#endif  // #ifndef DEVICE_SONY_HEALTH_STORAGESTATS_H


### PR DESCRIPTION
## health: Add support for storage stats and health

This implements the missing health@2.0 function calls:
- `get_storage_info()`
- `get_disk_stats()`

Also introduce a `HealthTestingMock` for debugging purposes. It is only available in userdebug/eng builds.
The prop `persist.vendor.health.fake_storage=1` will trigger fake stats.

Storage health reporting is not available for UFS since there is no kernel support for UFS health as of 2019-07-12.

Since the SODP devices all have different emmc nodes, attempt to resolve `/sys/block/mmcblk0` to e.g.
`/sys/devices/platform/soc/7464900.sdhci/mmc_host/mmc0/mmc0:0001/block/mmcblk0`, which gives use the emmc node at `/sys/devices/platform/soc/7464900.sdhci/mmc_host/mmc0/mmc0:0001`

For UFS devices, construct the sysfs paths based on the property `ro.boot.bootdevice`, which would look like e.g. `7464900.ufshci`, giving us a path such as: `/sys/devices/platform/soc/7464900.ufshci`.
(Currently unused of course)

The nodes will have to labeled in the individual platforms' sepolicy dirs:
- [common sepolicy](https://github.com/sonyxperiadev/device-sony-sepolicy/pull/530)
- [tone](https://github.com/sonyxperiadev/device-sony-tone/pull/183)
- ...

SODP devices report pre-EOL info, two lifetime values and an EMMC revision.

Disk statistics are taken from the generic `stat` file, just as the default implemention of `storaged` and the crosshatch/bonito health HAL do.


## health: Refactor and simplify, drop healthd shims

<strike>This change drastically simplifies the code, which had been written under the assumption that AOSP would drop healthd soon. The wrapper libraries make little sense, just drop them.</strike>
**Update:** The "simplify" commits have been split out into https://github.com/sonyxperiadev/device-sony-common/pull/647