### PR TITLE
[COMMON] CommonConfig: Add 32-bits toolchain prefix for VDSO32

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -43,6 +43,7 @@ BOARD_MKBOOTIMG_ARGS := --ramdisk_offset $(BOARD_RAMDISK_OFFSET) --tags_offset $
 TARGET_KERNEL_ARCH := arm64
 TARGET_KERNEL_HEADER_ARCH := arm64
 TARGET_KERNEL_CROSS_COMPILE_PREFIX := aarch64-linux-android-
+TARGET_KERNEL_CROSS_COMPILE_32BITS_PREFIX := arm-linux-androideabi-
 BOARD_KERNEL_IMAGE_NAME := Image.gz-dtb
 
 # Use mke2fs to create ext4 images


### PR DESCRIPTION
The kernel recently got VDSO32 support and it now requires us
to compile kernel code targeting ARM/AArch32 (the VDSO32 compat
code does actually target 32-bits...) to get the feature to work.

Define the 32-bits toolchain to use to compile the VDSO32 in kernel.