### PR TITLE
[DONOTMERGE] overlay: Enable system-wide camera button launch

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -261,4 +261,9 @@
 
     <!-- Flag indicating whether we should enable smart battery. -->
     <bool name="config_smart_battery_available">true</bool>
+
+    <!-- Allow the gesture of long-pressing the camera button to launch a camera application
+         from anywhere. Enable only if the device has a physical camera button. -->
+    <bool name="config_cameraButtonLaunchEnabled">true</bool>
+
 </resources>


### PR DESCRIPTION
This is needed for an upcoming change that changes our previous patch on top of AOSP (https://r.android.com/727815) for launching the camera application on camera button long-press.

See [AOSP gerrit topic camera-button-long-press](https://android-review.googlesource.com/q/topic:"camera-button-long-press")