### PR TITLE
gpt-utils: Add fsync() in gpt_disk_commit()

### DIFF
--- a/hardware/gpt-utils/gpt-utils.cpp
+++ b/hardware/gpt-utils/gpt-utils.cpp
@@ -1531,6 +1531,7 @@ int gpt_disk_commit(struct gpt_disk *disk)
                                 __func__);
                 goto error;
         }
+        fsync(fd);
         close(fd);
         return 0;
 error:


### PR DESCRIPTION
After writing the contents to disk (such as marking a boot slot as
successful), we should additionally do an fsync() to make sure we commit
this information to disk before returning.

Bug: 131176531
Change-Id: I40c74bc8a39e4b32408bd73ecbdfd54eb8da957b
(cherry picked from commit d518ce7c6d3c2e3740da1269dfa8830d46fe5bd1)