### PR TITLE
[Q-COMPAT] common: Set PRODUCT_BUILD_RECOVERY_IMAGE=true

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -37,12 +37,14 @@ PRODUCT_ENFORCE_RRO_TARGETS := \
     Telephony \
     framework-res
 
-PRODUCT_USE_VNDK_OVERRIDE := true
-
 PRODUCT_DEXPREOPT_SPEED_APPS += SystemUI
 
-PRODUCT_ENFORCE_VINTF_MANIFEST_OVERRIDE := true
+# Treble properties
 
+# Match running HAL services against vintf manifest
+PRODUCT_ENFORCE_VINTF_MANIFEST_OVERRIDE := true
+# Force using VNDK regardless of shipping API level
+PRODUCT_USE_VNDK_OVERRIDE := true
 # Force split of sepolicy into /system/etc/selinux and (/system)/vendor/etc/selinux
 # for all devices, regardless of shipping API level
 PRODUCT_SEPOLICY_SPLIT_OVERRIDE := true

--- a/common.mk
+++ b/common.mk
@@ -51,6 +51,9 @@ PRODUCT_SEPOLICY_SPLIT_OVERRIDE := true
 # Force moving all vendor props into /vendor/build.prop
 BOARD_PROPERTY_OVERRIDES_SPLIT_ENABLED := true
 
+# Force building a recovery image: Needed for OTA packaging to work since Q
+PRODUCT_BUILD_RECOVERY_IMAGE := true
+
 BUILD_KERNEL := true
 -include $(KERNEL_PATH)/common-headers/KernelHeaders.mk
 


### PR DESCRIPTION
This is needed to get OTA packaging to work since Android Q since certain OTA parameters are extracted from an intermediate recovery image. Don't as why...

On Pie, a recovery image is built by default anyway, so this commit changes nothing on Pie.

Relavant: https://r.android.com/951796

Changing:
```
ifeq (,$(filter true, $(TARGET_NO_KERNEL) $(TARGET_NO_RECOVERY)))
[... build recoveryimage]
```
to:
```
ifeq ($(BOARD_USES_RECOVERY_AS_BOOT),true)
  BUILDING_RECOVERY_IMAGE := true
else ifeq ($(PRODUCT_BUILD_RECOVERY_IMAGE),)
  ifdef BOARD_RECOVERYIMAGE_PARTITION_SIZE
    ifeq (,$(filter true, $(TARGET_NO_KERNEL) $(TARGET_NO_RECOVERY)))
      BUILDING_RECOVERY_IMAGE := true
    endif
  endif
else ifeq ($(PRODUCT_BUILD_RECOVERY_IMAGE),true)
  BUILDING_RECOVERY_IMAGE := true
endif
[... build recoveryimage]
```

---

Also, move the treble buildvars in `common.mk` together.