### PR TITLE
[DONOTMERGE] [Q-ONLY] common: Put more RROs into /vendor

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -24,7 +24,12 @@ SONY_BUILD_SYMLINKS := $(COMMON_PATH)/sony_build_symlinks.mk
 DEVICE_PACKAGE_OVERLAYS += $(COMMON_PATH)/overlay
 
 PRODUCT_ENFORCE_RRO_TARGETS := \
-    framework-res
+    framework-res \
+    Bluetooth \
+    Settings \
+    SettingsProvider \
+    SystemUI \
+    Telephony
 
 PRODUCT_DEXPREOPT_SPEED_APPS += SystemUI
 


### PR DESCRIPTION
Only merge into Q branch!

---

Since between the various devices we are modifying more overlays than just `framework-res`, we want our modifications to be treble-compatible and land in the `/vendor` partition as `$APPNAME__auto_generated_rro.apk`.

Since https://r.android.com/810894 it is possible to add other targets than `framework-res` to the list of the packages for which RROs are generated.

This commit aids treble compliance so that our devices retain their overlays when running GSIs.