### PR TITLE
sony-common: Enable 64 bit DRM plugins compilation

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -94,6 +94,9 @@ TARGET_NO_RPC := true
 BOARD_CHARGER_DISABLE_INIT_BLANK := true
 BOARD_CHARGER_ENABLE_SUSPEND := true
 
+# DRM
+TARGET_ENABLE_MEDIADRM_64 := true
+
 # Enable dex-preoptimization to speed up first boot sequence
 ifeq ($(HOST_OS),linux)
   ifneq ($(TARGET_BUILD_VARIANT),eng)

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -108,7 +108,7 @@ endif
 
 # DRM
 PRODUCT_PACKAGES += \
-    android.hardware.drm@1.0-impl:32 \
+    android.hardware.drm@1.0-impl \
     android.hardware.drm@1.0-service \
     android.hardware.drm@1.1-service.clearkey
 


### PR DESCRIPTION
This will generate DRM plugins, HALs & oemcrypto_test in 64 bit.

Change-Id: I451db39edea3446d9816fcaba77caa8d3b097afb