### PR TITLE
hardware: camera: Only create library symlink for the relevant platform.

### DIFF
--- a/hardware/camera/Android.mk
+++ b/hardware/camera/Android.mk
@@ -24,9 +24,8 @@ SONY_SYMLINKS := $(foreach p,$(library_names), \
     /odm/lib/$p:$(TARGET_COPY_OUT_VENDOR)/lib/$p \
 )
 
-# Special exception for camera.qcom.so that is also linked to as camera.sdm845.so:
-SONY_SYMLINKS += /odm/lib/hw/camera.qcom.so:$(TARGET_COPY_OUT_VENDOR)/lib/hw/camera.sdm845.so
-SONY_SYMLINKS += /odm/lib/hw/camera.qcom.so:$(TARGET_COPY_OUT_VENDOR)/lib/hw/camera.sm8150.so
+# Special exception for camera.qcom.so that is also linked to as camera.$(TARGET_BOARD_PLATFORM).so:
+SONY_SYMLINKS += /odm/lib/hw/camera.qcom.so:$(TARGET_COPY_OUT_VENDOR)/lib/hw/camera.$(TARGET_BOARD_PLATFORM).so
 
 include $(SONY_BUILD_SYMLINKS)
 


### PR DESCRIPTION
sdm845 doesn't need the sm8150 link, and vice-versa.