### PR TITLE
Move PRODUCT_DEXPREOPT_SPEED_APPS to common.mk.

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -106,7 +106,6 @@ ifeq ($(HOST_OS),linux)
   endif
 endif
 WITH_DEXPREOPT_BOOT_IMG_AND_SYSTEM_SERVER_ONLY ?= true
-PRODUCT_DEXPREOPT_SPEED_APPS += SystemUI
 
 BUILD_KERNEL := true
 -include $(KERNEL_PATH)/common-headers/KernelHeaders.mk

--- a/common.mk
+++ b/common.mk
@@ -26,6 +26,8 @@ DEVICE_PACKAGE_OVERLAYS += $(COMMON_PATH)/overlay
 PRODUCT_ENFORCE_RRO_TARGETS := \
     framework-res
 
+PRODUCT_DEXPREOPT_SPEED_APPS += SystemUI
+
 # Force split of sepolicy into /system/etc/selinux and (/system)/vendor/etc/selinux
 # for all devices, regardless of shipping API level
 PRODUCT_SEPOLICY_SPLIT_OVERRIDE := true


### PR DESCRIPTION
`PRODUCT_` variables must be defined within the product chain
(`inherit-product`, starting with files defined in `PRODUCT_MAKEFILES`).

Outside of this chain, the variable is readonly:
> device/sony/common/CommonConfig.mk:114: error: cannot assign to readonly variable: PRODUCT_DEXPREOPT_SPEED_APPS