### PR TITLE
Bump vintf manifest target-level to 3

### DIFF
--- a/vintf/android.hw.keymaster_v3.xml
+++ b/vintf/android.hw.keymaster_v3.xml
@@ -1,4 +1,4 @@
-<manifest version="1.0" type="device" target-level="2">
+<manifest version="1.0" type="device">
     <hal format="hidl">
         <name>android.hardware.keymaster</name>
         <transport>hwbinder</transport>

--- a/vintf/android.hw.keymaster_v4.xml
+++ b/vintf/android.hw.keymaster_v4.xml
@@ -1,4 +1,4 @@
-<manifest version="1.0" type="device" target-level="2">
+<manifest version="1.0" type="device">
     <hal format="hidl">
         <name>android.hardware.keymaster</name>
         <transport>hwbinder</transport>

--- a/vintf/android.hw.radio_ds.xml
+++ b/vintf/android.hw.radio_ds.xml
@@ -1,4 +1,4 @@
-<manifest version="1.0" type="device" target-level="2">
+<manifest version="1.0" type="device">
     <hal format="hidl">
         <name>android.hardware.radio</name>
         <transport>hwbinder</transport>

--- a/vintf/android.hw.radio_ss.xml
+++ b/vintf/android.hw.radio_ss.xml
@@ -1,4 +1,4 @@
-<manifest version="1.0" type="device" target-level="2">
+<manifest version="1.0" type="device">
     <hal format="hidl">
         <name>android.hardware.radio</name>
         <transport>hwbinder</transport>

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -1,4 +1,4 @@
-<manifest version="1.0" type="device" target-level="2">
+<manifest version="1.0" type="device" target-level="3">
     <hal format="hidl">
         <name>android.hardware.audio</name>
         <transport>hwbinder</transport>

--- a/vintf/vendor.hw.radio_ds.xml
+++ b/vintf/vendor.hw.radio_ds.xml
@@ -1,4 +1,4 @@
-<manifest version="1.0" type="device" target-level="2">
+<manifest version="1.0" type="device">
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.am</name>
         <transport>hwbinder</transport>

--- a/vintf/vendor.hw.radio_ss.xml
+++ b/vintf/vendor.hw.radio_ss.xml
@@ -1,4 +1,4 @@
-<manifest version="1.0" type="device" target-level="2">
+<manifest version="1.0" type="device">
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.am</name>
         <transport>hwbinder</transport>

--- a/vintf/vendor.nxp.nfc.interfaces.xml
+++ b/vintf/vendor.nxp.nfc.interfaces.xml
@@ -1,4 +1,4 @@
-<manifest version="1.0" type="device" target-level="2">
+<manifest version="1.0" type="device">
     <hal format="hidl">
         <name>vendor.nxp.nxpnfc</name>
         <transport>hwbinder</transport>


### PR DESCRIPTION
We are already qualifying for level 3 which is the compatibility_matrix released with Android Pie.
Aside, remove superfluous `target-level` defines in the other manifest files.

Tested on Mermaid+Discovery on Android 10 (Q), and on Discovery on Android 9 (Pie).

For completeness, please do a quick test locally on your device of choice on Android 9 to be extra sure.