### PR TITLE
[Android 10] [TESTME] Use ro.hardware.<class>=qcom to point to harware libraries

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -181,3 +181,7 @@ endif
 # Reduce cost of scrypt for FBE CE decryption
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.crypto.scrypt_params=15:3:1
+
+# Look for vulkan.qcom.so instead of vulkan.$(BOARD_TARGET_PLATFORM).so
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.hardware.vulkan=qcom

--- a/hardware/adreno/Android.mk
+++ b/hardware/adreno/Android.mk
@@ -18,19 +18,13 @@ library_names := \
     libllvm-glnext.so \
     libllvm-qcom.so \
     librs_adreno.so \
-    librs_adreno_sha1.so \
-    hw/vulkan.qcom.so
+    librs_adreno_sha1.so
 
 # Create symlinks to 32- and 64-bit directories:
 SONY_SYMLINKS := $(foreach lib_dir,lib lib64, \
     $(foreach p,$(library_names), \
         /odm/$(lib_dir)/$p:$(TARGET_COPY_OUT_VENDOR)/$(lib_dir)/$p \
     ) \
-)
-
-# Special exception for vulkan.qcom.so that is also linked as vulkan.$(TARGET_BOARD_PLATFORM).so
-SONY_SYMLINKS += $(foreach lib_dir,lib lib64, \
-    /odm/$(lib_dir)/hw/vulkan.qcom.so:$(TARGET_COPY_OUT_VENDOR)/$(lib_dir)/hw/vulkan.$(TARGET_BOARD_PLATFORM).so \
 )
 
 include $(SONY_BUILD_SYMLINKS)

--- a/hardware/camera/Android.mk
+++ b/hardware/camera/Android.mk
@@ -24,9 +24,6 @@ SONY_SYMLINKS := $(foreach p,$(library_names), \
     /odm/lib/$p:$(TARGET_COPY_OUT_VENDOR)/lib/$p \
 )
 
-# Special exception for camera.qcom.so that is also linked to as camera.$(TARGET_BOARD_PLATFORM).so:
-SONY_SYMLINKS += /odm/lib/hw/camera.qcom.so:$(TARGET_COPY_OUT_VENDOR)/lib/hw/camera.$(TARGET_BOARD_PLATFORM).so
-
 include $(SONY_BUILD_SYMLINKS)
 
 endif


### PR DESCRIPTION
This fixes the camera that fails to start on Tama.

Together with https://github.com/sonyxperiadev/device-sony-kumano/pull/4 and https://github.com/sonyxperiadev/device-sony-tama/pull/64

> Android 10 adds a nice feature that verifies whether the realpath of a
> loaded module starts with the searched path the module came from. For
> symlinks this is not true (for example the realpath of the camera
> library is /odm/lib/hw/camera.qcom.so: this does _not_ start with
> /vendor/lib/hw where the search originated from).
>
> See the relevant change in libhardware:
> https://android.googlesource.com/platform/hardware/libhardware/+/e448a05fecab601c59b89a2f948e1ad18050e40f%5E%21/#F0
>
> Instead of creating a symlink on the odm partition, set
> ro.hardware.camera=qcom in the relevant platform repositories (currently
> only Tama and Kumano). This ensures libhardware also looks for
> camera.qcom.so in all search paths (vendor and odm libraries).


Do the same for vulkan symlinks (while not strictly necessary) to clean up.

### TODO:
Check other symlinks for removal. In principle, library folders in `/odm` are included in the search path (and VNDK rules) so there should be no problem loading these directly.

While the vulkan link can safely be removed on all platforms the link (without name change) for camera cannot, because "new" camera blobs try to load them explicitly from `/vendor`: `CHIUSECASE: chxutils.cpp:526 LibMap() Failed to load library /vendor/lib/hw/camera.qcom.so error dlopen failed: library "/vendor/lib/hw/camera.qcom.so" not found`

Tested on Mermaid and Akatsuki. _Please_ test other devices!