### PR TITLE
lights: Adjust slightly off brightness conversion for maximum accuracy.

### DIFF
--- a/hardware/liblights/Android.mk
+++ b/hardware/liblights/Android.mk
@@ -32,6 +32,9 @@ LOCAL_SHARED_LIBRARIES := \
     libhidltransport \
     android.hardware.light@2.0
 
+# We want the full operator-precedence experience:
+LOCAL_CFLAGS += -Wno-parentheses
+
 ifeq ($(TARGET_USES_UCOMM_BACKLIGHT),true)
     LOCAL_SHARED_LIBRARIES += libucommunicator
 endif

--- a/hardware/liblights/Light.cpp
+++ b/hardware/liblights/Light.cpp
@@ -29,345 +29,360 @@ extern "C" {
 #endif
 
 namespace android {
-    namespace hardware {
-        namespace light {
-            namespace V2_0 {
-                namespace implementation {
-                    static_assert(LIGHT_FLASH_NONE == static_cast<int>(Flash::NONE),
-                                  "Flash::NONE must match legacy value.");
-                    static_assert(LIGHT_FLASH_TIMED == static_cast<int>(Flash::TIMED),
-                                  "Flash::TIMED must match legacy value.");
-                    static_assert(LIGHT_FLASH_HARDWARE == static_cast<int>(Flash::HARDWARE),
-                                  "Flash::HARDWARE must match legacy value.");
+namespace hardware {
+namespace light {
+namespace V2_0 {
+namespace implementation {
+static_assert(LIGHT_FLASH_NONE == static_cast<int>(Flash::NONE),
+    "Flash::NONE must match legacy value.");
+static_assert(LIGHT_FLASH_TIMED == static_cast<int>(Flash::TIMED),
+    "Flash::TIMED must match legacy value.");
+static_assert(LIGHT_FLASH_HARDWARE == static_cast<int>(Flash::HARDWARE),
+    "Flash::HARDWARE must match legacy value.");
 
-                    static_assert(BRIGHTNESS_MODE_USER == static_cast<int>(Brightness::USER),
-                                  "Brightness::USER must match legacy value.");
-                    static_assert(BRIGHTNESS_MODE_SENSOR == static_cast<int>(Brightness::SENSOR),
-                                  "Brightness::SENSOR must match legacy value.");
-                    static_assert(BRIGHTNESS_MODE_LOW_PERSISTENCE ==
-                                  static_cast<int>(Brightness::LOW_PERSISTENCE),
-                                  "Brightness::LOW_PERSISTENCE must match legacy value.");
+static_assert(BRIGHTNESS_MODE_USER == static_cast<int>(Brightness::USER),
+    "Brightness::USER must match legacy value.");
+static_assert(BRIGHTNESS_MODE_SENSOR == static_cast<int>(Brightness::SENSOR),
+    "Brightness::SENSOR must match legacy value.");
+static_assert(BRIGHTNESS_MODE_LOW_PERSISTENCE == static_cast<int>(Brightness::LOW_PERSISTENCE),
+    "Brightness::LOW_PERSISTENCE must match legacy value.");
 
-                    Light *Light::sInstance = nullptr;
+Light *Light::sInstance = nullptr;
 
-                    Light::Light() {
-                        LOG(INFO) << "%s";
-                        openHal();
-                        sInstance = this;
-                    }
+Light::Light()
+{
+    LOG(INFO) << "%s";
+    openHal();
+    sInstance = this;
+}
 
-                    void Light::openHal(){
-                        int lcd_max = 0;
-                        LOG(INFO) << __func__ << ": Setup HAL";
-                        mDevice = static_cast<lights_t *>(malloc(sizeof(lights_t)));
-                        memset(mDevice, 0, sizeof(lights_t));
+void Light::openHal()
+{
+    int lcd_max = 0;
+    LOG(INFO) << __func__ << ": Setup HAL";
+    mDevice = static_cast<lights_t *>(malloc(sizeof(lights_t)));
+    memset(mDevice, 0, sizeof(lights_t));
 
-                        mDevice->g_last_backlight_mode = BRIGHTNESS_MODE_USER;
-                        mDevice->g_lock = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
-                        mDevice->g_lcd_lock = (pthread_mutex_t) PTHREAD_MUTEX_INITIALIZER;
+    mDevice->g_last_backlight_mode = BRIGHTNESS_MODE_USER;
+    mDevice->g_lock = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
+    mDevice->g_lcd_lock = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
 
-                        lcd_max = readInt(LCD_MAX_FILE);
+    lcd_max = readInt(LCD_MAX_FILE);
 
-                        if (lcd_max == 4095)
-                            mDevice->backlight_bits = 12;
-                        else if (lcd_max == 1023)
-                            mDevice->backlight_bits = 10;
-                        else
-                            mDevice->backlight_bits = 8;
-                    }
+    if (lcd_max == 4095)
+        mDevice->backlight_bits = 12;
+    else if (lcd_max == 1023)
+        mDevice->backlight_bits = 10;
+    else
+        mDevice->backlight_bits = 8;
+}
 
-                    // Methods from ::android::hardware::light::V2_0::ILight follow.
-                    Return<Status> Light::setLight(Type type, const LightState &state) {
-                        switch (type) {
-                            case Type::BACKLIGHT:
-                                LOG(DEBUG) << __func__ << " : Type::BACKLIGHT";
-                                setLightBacklight(state);
-                                break;
-                            case Type::BATTERY:
-                                LOG(DEBUG) << __func__ << " : Type::BATTERY";
-                                setLightBattery(state);
-                                break;
-                            case Type::NOTIFICATIONS:
-                                LOG(DEBUG) << __func__ << " : Type::NOTIFICATIONS";
-                                setLightNotifications(state);
-                                break;
-                            default:
-                                LOG(DEBUG) << __func__ << " : Unknown light type";
-                                return Status::LIGHT_NOT_SUPPORTED;
-                        }
-                        return Status::SUCCESS;
-                    }
+// Methods from ::android::hardware::light::V2_0::ILight follow.
+Return<Status> Light::setLight(Type type, const LightState &state)
+{
+    switch (type) {
+    case Type::BACKLIGHT:
+        LOG(DEBUG) << __func__ << " : Type::BACKLIGHT";
+        setLightBacklight(state);
+        break;
+    case Type::BATTERY:
+        LOG(DEBUG) << __func__ << " : Type::BATTERY";
+        setLightBattery(state);
+        break;
+    case Type::NOTIFICATIONS:
+        LOG(DEBUG) << __func__ << " : Type::NOTIFICATIONS";
+        setLightNotifications(state);
+        break;
+    default:
+        LOG(DEBUG) << __func__ << " : Unknown light type";
+        return Status::LIGHT_NOT_SUPPORTED;
+    }
+    return Status::SUCCESS;
+}
 
-                    ILight *Light::getInstance() {
-                        if (!sInstance) {
-                            sInstance = new Light();
-                        }
-                        return sInstance;
-                    }
+ILight *Light::getInstance()
+{
+    if (!sInstance) {
+        sInstance = new Light();
+    }
+    return sInstance;
+}
 
-                    int Light::writeInt(const std::string &path, int value) {
-                        std::ofstream stream(path);
+int Light::writeInt(const std::string &path, int value)
+{
+    std::ofstream stream(path);
 
-                        if (!stream) {
-                            LOG(ERROR) << "Failed to open " << path << ", error=" << errno
-                                       << "(" << strerror(errno) << ")";
-                            return -errno;
-                        }
+    if (!stream) {
+        LOG(ERROR) << "Failed to open " << path << ", error=" << errno
+                   << "(" << strerror(errno) << ")";
+        return -errno;
+    }
 
-                        stream << value << std::endl;
+    stream << value << std::endl;
 
-                        return 0;
-                    }
+    return 0;
+}
 
-                    int Light::readInt(const std::string &path) {
-                        std::ifstream stream(path);
-                        int value = 0;
+int Light::readInt(const std::string &path)
+{
+    std::ifstream stream(path);
+    int value = 0;
 
-                        if (!stream) {
-                            LOG(ERROR) << "Failed to open " << path << ", error=" << errno
-                                       << "(" << strerror(errno) << ")";
-                            return -errno;
-                        }
+    if (!stream) {
+        LOG(ERROR) << "Failed to open " << path << ", error=" << errno
+                   << "(" << strerror(errno) << ")";
+        return -errno;
+    }
 
-                        stream >> value;
+    stream >> value;
 
-                        return value;
-                    }
+    return value;
+}
 
-                    int Light::writeStr(const std::string &path, const std::string &value) {
-                        std::ofstream stream(path);
+int Light::writeStr(const std::string &path, const std::string &value)
+{
+    std::ofstream stream(path);
 
-                        if (!stream) {
-                            LOG(ERROR) << "Failed to open " << path << ", error=" << errno
-                                       << "(" << strerror(errno) << ")";
-                            return -errno;
-                        }
+    if (!stream) {
+        LOG(ERROR) << "Failed to open " << path << ", error=" << errno
+                   << "(" << strerror(errno) << ")";
+        return -errno;
+    }
 
-                        stream << value << std::endl;
+    stream << value << std::endl;
 
-                        return 0;
-                    }
+    return 0;
+}
 
-                    std::string Light::getScaledDutyPcts(int brightness) {
-                        std::string buf, pad;
+std::string Light::getScaledDutyPcts(int brightness)
+{
+    std::string buf, pad;
 
-                        if (brightness <= 0) {
-                            return "0";
-                        }
+    if (brightness <= 0) {
+        return "0";
+    }
 
-                        for (auto i : BRIGHTNESS_RAMP) {
-                            buf += pad;
-                            buf += std::to_string(i * brightness / 255);
-                            pad = ",";
-                        }
+    for (auto i : BRIGHTNESS_RAMP) {
+        buf += pad;
+        buf += std::to_string(i * brightness / 255);
+        pad = ",";
+    }
 
-                        return buf;
-                    }
+    return buf;
+}
 
-                    int Light::isLit(const LightState &state) {
-                        return state.color & 0x00ffffff;
-                    }
+int Light::isLit(const LightState &state)
+{
+    return state.color & 0x00ffffff;
+}
 
-                    bool Light::isRgbSyncAvailable() {
-                        std::ifstream stream(RGB_BLINK_FILE);
-                        return stream.good();
-                    }
+bool Light::isRgbSyncAvailable()
+{
+    std::ifstream stream(RGB_BLINK_FILE);
+    return stream.good();
+}
 
-                    int Light::rgbToBrightness(const LightState &state) {
-                        int color = state.color & 0x00ffffff;
-                        return ((77 * ((color >> 16) & 0x00ff))
-                                + (150 * ((color >> 8) & 0x00ff)) + (29 * (color & 0x00ff))) >> 8;
-                    }
+int Light::rgbToBrightness(const LightState &state)
+{
+    int color = state.color & 0x00ffffff;
+    return ((77 * ((color >> 16) & 0x00ff))
+               + (150 * ((color >> 8) & 0x00ff)) + (29 * (color & 0x00ff)))
+        >> 8;
+}
 
-                    int Light::setLightBacklight(const LightState &state) {
-                        int err = 0;
-                        int brightness = rgbToBrightness(state);
+int Light::setLightBacklight(const LightState &state)
+{
+    int err = 0;
+    int brightness = rgbToBrightness(state);
 #ifdef LOW_PERSISTENCE_DISPLAY
-                        unsigned int lpEnabled = state.brightnessMode == Brightness::LOW_PERSISTENCE;
+    unsigned int lpEnabled = state.brightnessMode == Brightness::LOW_PERSISTENCE;
 #endif
 
-                        if (!mDevice) {
-                            return -1;
-                        }
+    if (!mDevice) {
+        return -1;
+    }
 
-                        pthread_mutex_lock(&mDevice->g_lcd_lock);
+    pthread_mutex_lock(&mDevice->g_lcd_lock);
 
 #ifdef LOW_PERSISTENCE_DISPLAY
-                        int currState = static_cast<int>(state.brightnessMode);
-                        // If we're not in lp mode and it has been enabled or if we are in lp mode
-                        // and it has been disabled send an ioctl to the display with the update
-                        if ((mDevice->g_last_backlight_mode != currState && lpEnabled) ||
-                                (!lpEnabled && mDevice->g_last_backlight_mode == BRIGHTNESS_MODE_LOW_PERSISTENCE)) {
-                            if ((err = writeInt(PERSISTENCE_FILE, lpEnabled)) != 0) {
-                                LOG(ERROR) << __func__ << " : Failed to write to " << PERSISTENCE_FILE << ": " << strerror(errno);
-                            }
-                            if (lpEnabled != 0) {
-                                // Try to get the brigntess though property, otherwise it will
-                                // set the default brightness, which is defined in BoardConfig.mk.
-                                brightness = property_get_int32(LP_MODE_BRIGHTNESS_PROPERTY,
-                                        DEFAULT_LOW_PERSISTENCE_MODE_BRIGHTNESS);
-                            }
-                        }
-                        mDevice->g_last_backlight_mode = static_cast<int>(state.brightnessMode);
+    int currState = static_cast<int>(state.brightnessMode);
+    // If we're not in lp mode and it has been enabled or if we are in lp mode
+    // and it has been disabled send an ioctl to the display with the update
+    if ((mDevice->g_last_backlight_mode != currState && lpEnabled) || (!lpEnabled && mDevice->g_last_backlight_mode == BRIGHTNESS_MODE_LOW_PERSISTENCE)) {
+        if ((err = writeInt(PERSISTENCE_FILE, lpEnabled)) != 0) {
+            LOG(ERROR) << __func__ << " : Failed to write to " << PERSISTENCE_FILE << ": " << strerror(errno);
+        }
+        if (lpEnabled != 0) {
+            // Try to get the brigntess though property, otherwise it will
+            // set the default brightness, which is defined in BoardConfig.mk.
+            brightness = property_get_int32(LP_MODE_BRIGHTNESS_PROPERTY,
+                DEFAULT_LOW_PERSISTENCE_MODE_BRIGHTNESS);
+        }
+    }
+    mDevice->g_last_backlight_mode = static_cast<int>(state.brightnessMode);
 #endif
 
-                        if (!err) {
-                            if (mDevice->backlight_bits > 8) {
-                                int sbits = mDevice->backlight_bits - 8;
-                                brightness = (brightness << sbits) | (brightness >> sbits);
-                            }
+    if (!err) {
+        if (mDevice->backlight_bits > 8) {
+            int sbits = mDevice->backlight_bits - 8;
+            brightness = (brightness << sbits) | (brightness >> sbits);
+        }
 #ifdef UCOMMSVR_BACKLIGHT
-                            err = ucommsvr_set_backlight(brightness);
+        err = ucommsvr_set_backlight(brightness);
 #else
-                            err = writeInt(LCD_FILE, brightness);
+        err = writeInt(LCD_FILE, brightness);
 #endif
-                        }
+    }
 
-                        pthread_mutex_unlock(&mDevice->g_lcd_lock);
-                        return err;
-                    }
+    pthread_mutex_unlock(&mDevice->g_lcd_lock);
+    return err;
+}
 
+int Light::setSpeakerLightLocked(const LightState &state)
+{
+    int red, green, blue;
+    bool blink;
+    int onMS, offMS;
+    unsigned int colorRGB;
 
-                    int Light::setSpeakerLightLocked(const LightState& state) {
-                        int red, green, blue;
-                        bool blink;
-                        int onMS, offMS;
-                        unsigned int colorRGB;
+    if (!mDevice) {
+        return -1;
+    }
 
-                        if (!mDevice) {
-                            return -1;
-                        }
+    switch (state.flashMode) {
+    case Flash::TIMED:
+        onMS = state.flashOnMs;
+        offMS = state.flashOffMs;
+        break;
+    case Flash::NONE:
+    default:
+        onMS = 0;
+        offMS = 0;
+        break;
+    }
 
-                        switch (state.flashMode) {
-                            case Flash::TIMED:
-                                onMS = state.flashOnMs;
-                                offMS = state.flashOffMs;
-                                break;
-                            case Flash::NONE:
-                            default:
-                                onMS = 0;
-                                offMS = 0;
-                                break;
-                        }
-
-                        colorRGB = state.color;
+    colorRGB = state.color;
 
 #if 0
-                        LOG(DEBUG) << "set_speaker_light_locked mode " << state->flashMode <<
-                                " colorRGB=" << colorRGB << " onMS=" << onMS << " offMS=" << offMS;
+    LOG(DEBUG) << "set_speaker_light_locked mode " << state->flashMode <<
+            " colorRGB=" << colorRGB << " onMS=" << onMS << " offMS=" << offMS;
 #endif
 
-                        red = (colorRGB >> 16) & 0xFF;
-                        green = (colorRGB >> 8) & 0xFF;
-                        blue = colorRGB & 0xFF;
-                        blink = onMS > 0 && offMS > 0;
+    red = (colorRGB >> 16) & 0xFF;
+    green = (colorRGB >> 8) & 0xFF;
+    blue = colorRGB & 0xFF;
+    blink = onMS > 0 && offMS > 0;
 
-                        if (isRgbSyncAvailable()) {
-                            writeInt(RGB_BLINK_FILE, 0);
-                        }
+    if (isRgbSyncAvailable()) {
+        writeInt(RGB_BLINK_FILE, 0);
+    }
 
-                        if (blink) {
-                            if (isRgbSyncAvailable()) {
-                                writeStr(RED_LED_DUTY_PCTS_FILE, getScaledDutyPcts(red));
-                                writeStr(GREEN_LED_DUTY_PCTS_FILE, getScaledDutyPcts(green));
-                                writeStr(BLUE_LED_DUTY_PCTS_FILE, getScaledDutyPcts(blue));
+    if (blink) {
+        if (isRgbSyncAvailable()) {
+            writeStr(RED_LED_DUTY_PCTS_FILE, getScaledDutyPcts(red));
+            writeStr(GREEN_LED_DUTY_PCTS_FILE, getScaledDutyPcts(green));
+            writeStr(BLUE_LED_DUTY_PCTS_FILE, getScaledDutyPcts(blue));
 
-                                writeInt(RED_LED_BASE   + "pause_lo", offMS);
-                                writeInt(GREEN_LED_BASE + "pause_lo", offMS);
-                                writeInt(BLUE_LED_BASE  + "pause_lo", offMS);
+            writeInt(RED_LED_BASE + "pause_lo", offMS);
+            writeInt(GREEN_LED_BASE + "pause_lo", offMS);
+            writeInt(BLUE_LED_BASE + "pause_lo", offMS);
 
-                                writeInt(RED_LED_BASE   + "pause_hi", onMS);
-                                writeInt(GREEN_LED_BASE + "pause_hi", onMS);
-                                writeInt(BLUE_LED_BASE  + "pause_hi", onMS);
+            writeInt(RED_LED_BASE + "pause_hi", onMS);
+            writeInt(GREEN_LED_BASE + "pause_hi", onMS);
+            writeInt(BLUE_LED_BASE + "pause_hi", onMS);
 
-                                writeInt(RGB_BLINK_FILE, 1);
-                            } else {
-                                if (red) {
-                                    if (writeInt(RED_BLINK_FILE, onMS == offMS ? 2 : 1)) {
-                                        writeInt(RED_LED_FILE, 0);
-                                    }
-                               }
-                               if (green) {
-                                    if (writeInt(GREEN_BLINK_FILE, onMS == offMS ? 2 : 1)) {
-                                        writeInt(GREEN_LED_FILE, 0);
-                                    }
-                               }
-                               if (blue) {
-                                    if (writeInt(BLUE_BLINK_FILE, onMS == offMS ? 2 : 1)) {
-                                        writeInt(BLUE_LED_FILE, 0);
-                                    }
-                               }
-                            }
-                        } else {
-                            writeInt(RED_LED_FILE, red);
-                            writeInt(GREEN_LED_FILE, green);
-                            writeInt(BLUE_LED_FILE, blue);
-                        }
+            writeInt(RGB_BLINK_FILE, 1);
+        } else {
+            if (red) {
+                if (writeInt(RED_BLINK_FILE, onMS == offMS ? 2 : 1)) {
+                    writeInt(RED_LED_FILE, 0);
+                }
+            }
+            if (green) {
+                if (writeInt(GREEN_BLINK_FILE, onMS == offMS ? 2 : 1)) {
+                    writeInt(GREEN_LED_FILE, 0);
+                }
+            }
+            if (blue) {
+                if (writeInt(BLUE_BLINK_FILE, onMS == offMS ? 2 : 1)) {
+                    writeInt(BLUE_LED_FILE, 0);
+                }
+            }
+        }
+    } else {
+        writeInt(RED_LED_FILE, red);
+        writeInt(GREEN_LED_FILE, green);
+        writeInt(BLUE_LED_FILE, blue);
+    }
 
-                        return 0;
-                    }
+    return 0;
+}
 
-                    void Light::handleSpeakerBatteryLocked() {
-                        if (isLit(batteryState)) {
-                            setSpeakerLightLocked(batteryState);
-                        } else {
-                            setSpeakerLightLocked(notificationState);
-                        }
-                    }
+void Light::handleSpeakerBatteryLocked()
+{
+    if (isLit(batteryState)) {
+        setSpeakerLightLocked(batteryState);
+    } else {
+        setSpeakerLightLocked(notificationState);
+    }
+}
 
-                    int Light::setLightBattery(const LightState& state) {
-                        if(!mDevice) {
-                            return -1;
-                        }
+int Light::setLightBattery(const LightState &state)
+{
+    if (!mDevice) {
+        return -1;
+    }
 
-                        pthread_mutex_lock(&mDevice->g_lock);
-                        batteryState = state;
-                        handleSpeakerBatteryLocked();
-                        pthread_mutex_unlock(&mDevice->g_lock);
-                        return 0;
-                    }
+    pthread_mutex_lock(&mDevice->g_lock);
+    batteryState = state;
+    handleSpeakerBatteryLocked();
+    pthread_mutex_unlock(&mDevice->g_lock);
+    return 0;
+}
 
-                    int Light::setLightNotifications(const LightState& state) {
-                        if(!mDevice) {
-                            return -1;
-                        }
+int Light::setLightNotifications(const LightState &state)
+{
+    if (!mDevice) {
+        return -1;
+    }
 
-                        pthread_mutex_lock(&mDevice->g_lock);
-                        notificationState = state;
-                        handleSpeakerBatteryLocked();
-                        pthread_mutex_unlock(&mDevice->g_lock);
-                        return 0;
-                    }
+    pthread_mutex_lock(&mDevice->g_lock);
+    notificationState = state;
+    handleSpeakerBatteryLocked();
+    pthread_mutex_unlock(&mDevice->g_lock);
+    return 0;
+}
 
-                    const static std::map<Type, const char *> kLogicalLights = {
-                            {Type::BACKLIGHT,     LIGHT_ID_BACKLIGHT},
-                            {Type::BATTERY,       LIGHT_ID_BATTERY},
-                            {Type::NOTIFICATIONS, LIGHT_ID_NOTIFICATIONS}
-                    };
+const static std::map<Type, const char *> kLogicalLights = {
+    { Type::BACKLIGHT, LIGHT_ID_BACKLIGHT },
+    { Type::BATTERY, LIGHT_ID_BATTERY },
+    { Type::NOTIFICATIONS, LIGHT_ID_NOTIFICATIONS }
+};
 
-                    Return<void> Light::getSupportedTypes(getSupportedTypes_cb _hidl_cb) {
-                        Type *types = new Type[kLogicalLights.size()];
+Return<void> Light::getSupportedTypes(getSupportedTypes_cb _hidl_cb)
+{
+    Type *types = new Type[kLogicalLights.size()];
 
-                        int idx = 0;
-                        for (auto const &pair : kLogicalLights) {
-                            Type type = pair.first;
+    int idx = 0;
+    for (auto const &pair : kLogicalLights) {
+        Type type = pair.first;
 
-                            types[idx++] = type;
-                        }
+        types[idx++] = type;
+    }
 
-                        {
-                            hidl_vec<Type> hidl_types{};
-                            hidl_types.setToExternal(types, kLogicalLights.size());
+    {
+        hidl_vec<Type> hidl_types{};
+        hidl_types.setToExternal(types, kLogicalLights.size());
 
-                            _hidl_cb(hidl_types);
-                        }
+        _hidl_cb(hidl_types);
+    }
 
-                        delete[] types;
+    delete[] types;
 
-                        return Void();
-                    }
-                } // namespace implementation
-            }  // namespace V2_0
-        }  // namespace light
-    }  // namespace hardware
-}  // namespace android
+    return Void();
+}
+} // namespace implementation
+} // namespace V2_0
+} // namespace light
+} // namespace hardware
+} // namespace android

--- a/hardware/liblights/Light.h
+++ b/hardware/liblights/Light.h
@@ -18,97 +18,81 @@
 #define ANDROID_HARDWARE_LIGHT_V2_0_LIGHT_H
 
 #include <android/hardware/light/2.0/ILight.h>
-#include <hardware/hardware.h>
-#include <hardware/lights.h>
-#include <hidl/MQDescriptor.h>
 #include <hidl/Status.h>
-#include <map>
+
+#include <mutex>
+#include <vector>
 
 #include <cutils/properties.h>
 
 #include <errno.h>
-#include <fcntl.h>
-#include <pthread.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include <linux/msm_mdp.h>
-
-#include <sys/ioctl.h>
-#include <sys/types.h>
-
-#include <hardware/lights.h>
 
 #define DEFAULT_LOW_PERSISTENCE_MODE_BRIGHTNESS 255
 
 #define LP_MODE_BRIGHTNESS_PROPERTY "sys.display.low_persistence_mode_brightness"
 
-struct lights_t {
-    pthread_mutex_t g_lock;
-    pthread_mutex_t g_lcd_lock;
-    int g_last_backlight_mode;
-    int backlight_bits;
-};
-
 static constexpr int RAMP_SIZE = 8;
 static constexpr int BRIGHTNESS_RAMP[RAMP_SIZE] = { 0, 14, 28, 42, 56, 70, 84, 100 };
 
-const static std::string RED_LED_BASE
+static const std::string RED_LED_BASE
     = "/sys/class/leds/led:rgb_red/";
 
-const static std::string GREEN_LED_BASE
+static const std::string GREEN_LED_BASE
     = "/sys/class/leds/led:rgb_green/";
 
-const static std::string BLUE_LED_BASE
+static const std::string BLUE_LED_BASE
     = "/sys/class/leds/led:rgb_blue/";
 
-const static std::string RED_LED_FILE
+static const std::string RED_LED_FILE
     = RED_LED_BASE + "brightness";
 
-const static std::string GREEN_LED_FILE
+static const std::string GREEN_LED_FILE
     = GREEN_LED_BASE + "brightness";
 
-const static std::string BLUE_LED_FILE
+static const std::string BLUE_LED_FILE
     = BLUE_LED_BASE + "brightness";
 
-const static std::string RED_LED_DUTY_PCTS_FILE
+static const std::string RED_LED_DUTY_PCTS_FILE
     = RED_LED_BASE + "duty_pcts";
 
-const static std::string GREEN_LED_DUTY_PCTS_FILE
+static const std::string GREEN_LED_DUTY_PCTS_FILE
     = GREEN_LED_BASE + "duty_pcts";
 
-const static std::string BLUE_LED_DUTY_PCTS_FILE
+static const std::string BLUE_LED_DUTY_PCTS_FILE
     = BLUE_LED_BASE + "duty_pcts";
 
-const static std::string RED_BLINK_FILE
+static const std::string RED_BLINK_FILE
     = RED_LED_BASE + "blink";
 
-const static std::string GREEN_BLINK_FILE
+static const std::string GREEN_BLINK_FILE
     = GREEN_LED_BASE + "blink";
 
-const static std::string BLUE_BLINK_FILE
+static const std::string BLUE_BLINK_FILE
     = BLUE_LED_BASE + "blink";
 
-const static std::string RGB_BLINK_FILE
+static const std::string RGB_BLINK_FILE
     = "/sys/class/leds/rgb/rgb_blink";
 
 #ifdef DRMSDE_BACKLIGHT
-const static std::string LCD_FILE
+static const std::string LCD_FILE
     = "/sys/class/backlight/panel0-backlight/brightness";
 
-const static std::string LCD_MAX_FILE
+static const std::string LCD_MAX_FILE
     = "/sys/class/backlight/panel0-backlight/max_brightness";
 #else
-const static std::string LCD_FILE
+static const std::string LCD_FILE
     = "/sys/class/leds/lcd-backlight/brightness";
 
-const static std::string LCD_MAX_FILE
+static const std::string LCD_MAX_FILE
     = "/sys/class/leds/lcd-backlight/max_brightness";
 #endif
 
-const static std::string PERSISTENCE_FILE
+static const std::string PERSISTENCE_FILE
     = "/sys/class/graphics/fb0/msm_fb_persist_mode";
 
 namespace android {
@@ -130,30 +114,32 @@ struct Light : public ILight {
 public:
     Light();
 
-    static ILight *getInstance();
-
     // Methods from ::android::hardware::light::V2_0::ILight follow.
     Return<Status> setLight(Type type, const LightState &state) override;
     Return<void> getSupportedTypes(getSupportedTypes_cb _hidl_cb) override;
 
 private:
-    static Light *sInstance;
-    lights_t *mDevice;
+    std::mutex mLock;
+    std::mutex mLcdLock;
+    int mBacklightBits;
+
+    Brightness mLastBacklightMode;
     LightState batteryState;
     LightState notificationState;
+
     int setLightBacklight(const LightState &state);
     int setLightBattery(const LightState &state);
     int setLightNotifications(const LightState &state);
     void handleSpeakerBatteryLocked();
     int setSpeakerLightLocked(const LightState &state);
-    std::string getScaledDutyPcts(int brightness);
-    int isLit(const LightState &state);
-    bool isRgbSyncAvailable();
-    int rgbToBrightness(const LightState &state);
+
+    static std::string getScaledDutyPcts(int brightness);
+    static int isLit(const LightState &state);
+    static bool isRgbSyncAvailable();
+    static int rgbToBrightness(const LightState &state);
     static int writeInt(const std::string &path, int value);
     static int readInt(const std::string &path);
     static int writeStr(const std::string &path, const std::string &value);
-    void openHal();
 };
 } // namespace implementation
 } // namespace V2_0

--- a/hardware/liblights/Light.h
+++ b/hardware/liblights/Light.h
@@ -121,7 +121,7 @@ public:
 private:
     std::mutex mLock;
     std::mutex mLcdLock;
-    int mBacklightBits;
+    int mBacklightMax;
 
     Brightness mLastBacklightMode;
     LightState batteryState;

--- a/hardware/liblights/Light.h
+++ b/hardware/liblights/Light.h
@@ -20,6 +20,7 @@
 #include <android/hardware/light/2.0/ILight.h>
 #include <hidl/Status.h>
 
+#include <algorithm>
 #include <mutex>
 #include <vector>
 
@@ -121,7 +122,8 @@ public:
 private:
     std::mutex mLock;
     std::mutex mLcdLock;
-    int mBacklightMax;
+    int mBacklightMax = 0;
+    int mBacklightShift = 0;
 
     Brightness mLastBacklightMode;
     LightState batteryState;

--- a/hardware/liblights/service.cpp
+++ b/hardware/liblights/service.cpp
@@ -33,7 +33,7 @@ using android::hardware::light::V2_0::implementation::Light;
 int main()
 {
     LOG(INFO) << __func__ << " : Start HAL";
-    android::sp<ILight> light = Light::getInstance();
+    android::sp<ILight> light = new Light();
 
     configureRpcThreadpool(1, true /*callerWillJoin*/);
 

--- a/hardware/liblights/service.cpp
+++ b/hardware/liblights/service.cpp
@@ -17,20 +17,21 @@
 
 #define LOG_TAG "android.hardware.light@2.0-service.sony"
 
-#include <hidl/HidlSupport.h>
-#include <hidl/HidlTransportSupport.h>
+#include "Light.h"
 #include <android-base/logging.h>
 #include <android/hardware/light/2.0/ILight.h>
-#include "Light.h"
+#include <hidl/HidlSupport.h>
+#include <hidl/HidlTransportSupport.h>
 
-using android::hardware::light::V2_0::ILight;
-using android::hardware::light::V2_0::implementation::Light;
+using android::NO_ERROR;
+using android::sp;
 using android::hardware::configureRpcThreadpool;
 using android::hardware::joinRpcThreadpool;
-using android::sp;
-using android::NO_ERROR;
+using android::hardware::light::V2_0::ILight;
+using android::hardware::light::V2_0::implementation::Light;
 
-int main() {
+int main()
+{
     LOG(INFO) << __func__ << " : Start HAL";
     android::sp<ILight> light = Light::getInstance();
 


### PR DESCRIPTION
This change fixes a slight mistake that was introduced when trying to
improve accuracy.
https://github.com/sonyxperiadev/device-sony-common/commit/6199c66e80d7538c8f6633b742d83679e6bbf2a4
That patch aims to ensure maximum brightness is reached - which indeed
happens for value 0xff - but adds a small discrepancy as outlined below.

Consider the following example:

```python3
bits = 10
sbits = bits - 8
maxval = (1 << bits) - 1

for brightness in range(256):
    print(f'{brightness} => '
          f'original: {brightness << sbits | brightness >> sbits}, '
          f'proper: {round(brightness * maxval / 255)}, '
          f'fixed: {brightness << sbits | brightness >> (8 - sbits)}')
```

When running the example (see output below) a consistent (yet small)
bump can be observed because the highest bits are replicated in the
lower bits of the left-shifted value. This results an overlap between
the lowest and highest bits instead of filling just the zeroes that were
introduced by the left shift.
This also means that going over the limit of 4 extra bits (so 12 bits in
total) results in a too large right shift, making it unable to reach
maximum brightness.
The "fixed" value in the rightmost column solves both issues by making
sure that only the most significant bits end up in the lowest bits.

However, this only works for values up to 16 bits. While it is not
likely to see anything higher than 12, better be safe than
sorry. Adjusting brightness is not a hot code path *by any means* so we
can justify an integer division ;)

Sample output:

224 => original: 952, proper: 899, fixed: 899
225 => original: 956, proper: 903, fixed: 903
226 => original: 952, proper: 907, fixed: 907
227 => original: 956, proper: 911, fixed: 911
228 => original: 953, proper: 915, fixed: 915
229 => original: 957, proper: 919, fixed: 919
230 => original: 953, proper: 923, fixed: 923
231 => original: 957, proper: 927, fixed: 927
232 => original: 954, proper: 931, fixed: 931
233 => original: 958, proper: 935, fixed: 935
234 => original: 954, proper: 939, fixed: 939
235 => original: 958, proper: 943, fixed: 943
236 => original: 955, proper: 947, fixed: 947
237 => original: 959, proper: 951, fixed: 951
238 => original: 955, proper: 955, fixed: 955
239 => original: 959, proper: 959, fixed: 959

Edit:
Before you comment this: Yes, I'm aware that using `round` is not accurate as the `/ 255` which truncates. Rounding up (eg. `(brightness * max + 254) / 25`) isn't accurate either, so I've pushed a `+ 254 / 2` (which is `127`) that gives a perfectly rounded value.