### PR TITLE
common: Enforce all overlays to be a separate RRO on /vendor.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -29,13 +29,7 @@ SONY_BUILD_SYMLINKS := $(COMMON_PATH)/sony_build_symlinks.mk
 
 DEVICE_PACKAGE_OVERLAYS += $(COMMON_PATH)/overlay
 
-PRODUCT_ENFORCE_RRO_TARGETS := \
-    Bluetooth \
-    Settings \
-    SettingsProvider \
-    SystemUI \
-    Telephony \
-    framework-res
+PRODUCT_ENFORCE_RRO_TARGETS := *
 
 PRODUCT_DEXPREOPT_SPEED_APPS += SystemUI
 


### PR DESCRIPTION
For example SystemUI didn't show up despite the name being correct.
Instead of trying to collect all currently overriden targets, and not
forgetting to add them in the future, follow crosshatch and build _any_
overlay as RRO. This is the most compatible with GSIs.