### PR TITLE
common: Upgrade wifi hal version

### DIFF
--- a/rootdir/vendor/etc/init/wpa_supplicant.rc
+++ b/rootdir/vendor/etc/init/wpa_supplicant.rc
@@ -7,6 +7,7 @@ service wpa_supplicant /vendor/bin/hw/wpa_supplicant \
     # group wifi inet keystore
     interface android.hardware.wifi.supplicant@1.0::ISupplicant default
     interface android.hardware.wifi.supplicant@1.1::ISupplicant default
+    interface android.hardware.wifi.supplicant@1.2::ISupplicant default
     class main
     socket wpa_wlan0 dgram 660 wifi wifi
     disabled

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -248,7 +248,7 @@
     <hal format="hidl">
         <name>android.hardware.wifi.hostapd</name>
         <transport>hwbinder</transport>
-        <version>1.0</version>
+        <version>1.1</version>
         <interface>
             <name>IHostapd</name>
             <instance>default</instance>
@@ -257,7 +257,7 @@
     <hal format="hidl">
         <name>android.hardware.wifi.supplicant</name>
         <transport>hwbinder</transport>
-        <version>1.1</version>
+        <version>1.2</version>
         <interface>
             <name>ISupplicant</name>
             <instance>default</instance>


### PR DESCRIPTION
Tested on tama, kernel 4.9, **Android-10.0.0_r3**.

After checking log, I found this:
`10-01 08:23:02.928  1140  1420 E SupplicantStaIfaceHal: Method getKeyMgmtCapabilities is not supported in existing HAL`
and
`10-01 08:23:02.989   575   575 I hwservicemanager: getTransport: Cannot find entry android.hardware.wifi.hostapd@1.1::IHostapd/default in either framework or device manifest.`

`10-01 08:23:02.928   575   575 I hwservicemanager: getTransport: Cannot find entry android.hardware.wifi.supplicant@1.2::ISupplicant/default in either framework or device`

We need to upgrade the wifi hal to support Q. Code from [Google](https://android.googlesource.com/platform/frameworks/opt/net/wifi/+/master/service/java/com/android/server/wifi/SupplicantStaIfaceHal.java#3102).