### PR TITLE
vintf: Upgrade wifi hal to 1.3

### DIFF
--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -239,7 +239,7 @@
     <hal format="hidl">
         <name>android.hardware.wifi</name>
         <transport>hwbinder</transport>
-        <version>1.2</version>
+        <version>1.3</version>
         <interface>
             <name>IWifi</name>
             <instance>default</instance>


### PR DESCRIPTION
All work fine on both 1.2 and 1.3, we update it for more new features