### PR TITLE
[1/2] common: Replace gatekeeper/keymaster passthrough blobs with AOSP variant

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -71,29 +71,26 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     android.hardware.biometrics.fingerprint@2.1-service.sony
 
+# Gatekeeper passthrough service
+PRODUCT_PACKAGES += \
+    android.hardware.gatekeeper@1.0-service
+
 ifeq ($(TARGET_LEGACY_KEYMASTER),true)
 # Keymaster
 PRODUCT_PACKAGES += \
     android.hardware.keymaster@3.0-impl \
     android.hardware.keymaster@3.0-service
-# Gatekeeper
+# Gatekeeper libhardware module passthrough
 PRODUCT_PACKAGES += \
-    android.hardware.gatekeeper@1.0-impl \
-    android.hardware.gatekeeper@1.0-service
+    android.hardware.gatekeeper@1.0-impl
 else ifeq ($(TARGET_KEYMASTER_V4),true)
-# Keymaster 4
+# Keymaster 4 passthrough service
 PRODUCT_PACKAGES += \
     android.hardware.keymaster@4.0-service-qti
-# Gatekeeper
-PRODUCT_PACKAGES += \
-    android.hardware.gatekeeper@1.0-service-qti
 else
-# Keymaster
+# Keymaster 3 passthrough service
 PRODUCT_PACKAGES += \
-    android.hardware.keymaster@3.0-service-qti
-# Gatekeeper
-PRODUCT_PACKAGES += \
-    android.hardware.gatekeeper@1.0-service-qti
+    android.hardware.keymaster@3.0-service
 endif
 
 # DRM

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -11,28 +11,7 @@ LOCAL_VENDOR_MODULE      := true
 include $(BUILD_PREBUILT)
 endif
 
-ifneq ($(TARGET_LEGACY_KEYMASTER), true)
-include $(CLEAR_VARS)
-LOCAL_MODULE := android.hardware.gatekeeper@1.0-service-qti
-LOCAL_SRC_FILES := vendor/etc/init/android.hardware.gatekeeper@1.0-service-qti.rc
-LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE_STEM := android.hardware.gatekeeper@1.0-service-qti
-LOCAL_MODULE_SUFFIX := .rc
-LOCAL_MODULE_CLASS := ETC
-LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
-include $(BUILD_PREBUILT)
-
-ifneq ($(TARGET_KEYMASTER_V4), true)
-include $(CLEAR_VARS)
-LOCAL_MODULE := android.hardware.keymaster@3.0-service-qti
-LOCAL_SRC_FILES := vendor/etc/init/android.hardware.keymaster@3.0-service-qti.rc
-LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE_STEM := android.hardware.keymaster@3.0-service-qti
-LOCAL_MODULE_SUFFIX := .rc
-LOCAL_MODULE_CLASS := ETC
-LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
-include $(BUILD_PREBUILT)
-else
+ifeq ($(TARGET_KEYMASTER_V4), true)
 include $(CLEAR_VARS)
 LOCAL_MODULE := android.hardware.keymaster@4.0-service-qti
 LOCAL_SRC_FILES := vendor/etc/init/android.hardware.keymaster@4.0-service-qti.rc
@@ -42,9 +21,7 @@ LOCAL_MODULE_SUFFIX := .rc
 LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
-endif
-
-endif # $(TARGET_LEGACY_KEYMASTER) != true
+endif # $(TARGET_KEYMASTER_V4) == true
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := init.qcom.slpistart.sh

--- a/rootdir/vendor/etc/init/android.hardware.gatekeeper@1.0-service-qti.rc
+++ b/rootdir/vendor/etc/init/android.hardware.gatekeeper@1.0-service-qti.rc
@@ -1,5 +1,0 @@
-service vendor.gatekeeper-1-0 /odm/bin/hw/android.hardware.gatekeeper@1.0-service-qti
-    interface android.hardware.gatekeeper@1.0::IGatekeeper default
-    class early_hal
-    user system
-    group system

--- a/rootdir/vendor/etc/init/android.hardware.keymaster@3.0-service-qti.rc
+++ b/rootdir/vendor/etc/init/android.hardware.keymaster@3.0-service-qti.rc
@@ -1,5 +1,0 @@
-service vendor.keymaster-3-0 /odm/bin/hw/android.hardware.keymaster@3.0-service-qti
-    interface android.hardware.keymaster@3.0::IKeymasterDevice default
-    class early_hal
-    user system
-    group system drmrpc


### PR DESCRIPTION
These blobs only provide a passthrough service for the implementations
stored in the shared libraries. AOSP provides an identical solution
complete with .rc files and "OSS code" (not that there's anything to see
apart registering a default passthrough implementation).

See
https://github.com/sonyxperiadev/device-sony-common/pull/617#issuecomment-536089919
for an expanded explanation.