### PR TITLE
common-treble/vintf: Remove widevine refs

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -100,8 +100,7 @@ endif
 PRODUCT_PACKAGES += \
     android.hardware.drm@1.0-impl \
     android.hardware.drm@1.0-service \
-    android.hardware.drm@1.2-service.clearkey \
-    android.hardware.drm@1.1-service.widevine
+    android.hardware.drm@1.2-service.clearkey
 
 ifneq ($(BOARD_USE_LEGACY_USB),true)
 # Usb HAL

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -67,8 +67,6 @@
         </interface>
         <fqname>@1.2::ICryptoFactory/clearkey</fqname>
         <fqname>@1.2::IDrmFactory/clearkey</fqname>
-        <fqname>@1.1::ICryptoFactory/widevine</fqname>
-        <fqname>@1.1::IDrmFactory/widevine</fqname>
     </hal>
     <hal format="hidl">
         <name>android.hardware.gatekeeper</name>


### PR DESCRIPTION
The widevine service is proprietary and not shipped with AOSP.
Declaring it in the `vintf` manifest will result in an endless loop of `servicemanager` trying to start the service.

Downstream projects are advised to revert this commit if they are shipping the widevine blobs.