### PR TITLE
gpt-utils: dereference symlinks pointing to device path

### DIFF
--- a/hardware/gpt-utils/gpt-utils.cpp
+++ b/hardware/gpt-utils/gpt-utils.cpp
@@ -1072,12 +1072,14 @@ static int get_dev_path_from_partition_name(const char *partname,
                 if (stat(path, &st)) {
                         goto error;
                 }
-                if (readlink(path, buf, buflen) < 0)
-                {
+                char resolved[PATH_MAX] = {0};
+                if (!realpath(path, resolved)) {
                         goto error;
-                } else {
-                        buf[PATH_TRUNCATE_LOC] = '\0';
                 }
+                int pos = (int)strlen(resolved) - 1;
+                for (; pos >= 0 && isdigit(resolved[pos]); pos--) ;
+                resolved[pos + 1] = '\0';
+                strncpy(buf, resolved, buflen);
         } else {
                 snprintf(buf, buflen, BLK_DEV_FILE);
         }


### PR DESCRIPTION
This PR fixes the issue of getting the correct device name in Sailfish. In contrast to AOSP, Sailfish populates /dev with relative and not absolute links. As a result, current `get_dev_path_from_partition_name` was failing. This implementation gets a symlink, de-references it, and then guesses device name on the basis of de-referencing result.

Let me know if this is of any interest and, if it is, I should submit it towards master branch.

Acknowledgements: Basic idea is coming from Adam Pigg implementation for one of Sailfish ports, implementation discussed with Marijn 