### PR TITLE
gpt-utils: dereference symlinks pointing to device path

### DIFF
--- a/hardware/gpt-utils/gpt-utils.cpp
+++ b/hardware/gpt-utils/gpt-utils.cpp
@@ -1079,6 +1079,9 @@ static int get_dev_path_from_partition_name(const char *partname,
                 int pos = (int)strlen(resolved) - 1;
                 while (pos >= 0 && isdigit(resolved[pos])) pos--;
                 resolved[pos + 1] = '\0';
+		if (buflen < pos + 2) {
+			goto error;
+		}
                 strncpy(buf, resolved, buflen);
         } else {
                 snprintf(buf, buflen, BLK_DEV_FILE);

--- a/hardware/gpt-utils/gpt-utils.cpp
+++ b/hardware/gpt-utils/gpt-utils.cpp
@@ -1072,12 +1072,14 @@ static int get_dev_path_from_partition_name(const char *partname,
                 if (stat(path, &st)) {
                         goto error;
                 }
-                if (readlink(path, buf, buflen) < 0)
-                {
+                char resolved[PATH_MAX] = {0};
+                if (!realpath(path, resolved)) {
                         goto error;
-                } else {
-                        buf[PATH_TRUNCATE_LOC] = '\0';
                 }
+                int pos = (int)strlen(resolved) - 1;
+                while (pos >= 0 && isdigit(resolved[pos])) pos--;
+                resolved[pos + 1] = '\0';
+                strncpy(buf, resolved, buflen);
         } else {
                 snprintf(buf, buflen, BLK_DEV_FILE);
         }

--- a/hardware/gpt-utils/gpt-utils.cpp
+++ b/hardware/gpt-utils/gpt-utils.cpp
@@ -1074,14 +1074,16 @@ static int get_dev_path_from_partition_name(const char *partname,
                 }
                 char resolved[PATH_MAX] = {0};
                 if (!realpath(path, resolved)) {
+                        ALOGE("%s: Cannot find realpath for %s", __func__, path);
                         goto error;
                 }
                 int pos = (int)strlen(resolved) - 1;
                 while (pos >= 0 && isdigit(resolved[pos])) pos--;
                 resolved[pos + 1] = '\0';
-		if (buflen < pos + 2) {
-			goto error;
-		}
+                if (buflen < pos + 2) {
+                        ALOGE("%s: Insufficient buffer to hold %s", __func__, resolved);
+                        goto error;
+                }
                 strncpy(buf, resolved, buflen);
         } else {
                 snprintf(buf, buflen, BLK_DEV_FILE);


### PR DESCRIPTION
This PR fixes the issue of getting the correct device name in Sailfish. In contrast to AOSP, Sailfish populates /dev with relative and not absolute links. As a result, current `get_dev_path_from_partition_name` was failing. This implementation gets a symlink, de-references it, and then guesses device name on the basis of de-referencing result.

I have tested earlier version on Sailfish for some time now and it works as expected. I have not tested on AOSP, though. The last version has `for` loop replaced by `while` - haven't tested that on device yet. But its expected to be equivalent to the tested one.

Acknowledgements: Basic idea is coming from Adam Pigg implementation for one of Sailfish ports, implementation discussed with Marijn