### PR TITLE
PowerHAL: power-helper: Fix WLAN STATS file path for k4.14

### DIFF
--- a/hardware/power/power-helper.c
+++ b/hardware/power/power-helper.c
@@ -56,7 +56,7 @@
 #endif
 
 #ifndef WLAN_STATS_FILE
-#define WLAN_STATS_FILE "/d/wlan0/power_stats"
+#define WLAN_STATS_FILE "/sys/kernel/wlan/power_stats"
 #endif
 
 #define LINE_SIZE 128


### PR DESCRIPTION
On kernel 4.14 the power stats for WLAN is in sysfs instead.