### PR TITLE
[COMMON] liblights: Migrate to kernel 4.14 LED class for RGB tri-led

### DIFF
--- a/hardware/liblights/Light.cpp
+++ b/hardware/liblights/Light.cpp
@@ -63,6 +63,10 @@ Light::Light()
 Return<Status> Light::setLight(Type type, const LightState &state)
 {
     switch (type) {
+    case Type::ATTENTION:
+        LOG(DEBUG) << __func__ << " : Type::ATTENTION";
+        setLightNotifications(state);
+        break;
     case Type::BACKLIGHT:
         LOG(DEBUG) << __func__ << " : Type::BACKLIGHT";
         setLightBacklight(state);
@@ -152,8 +156,8 @@ int Light::isLit(const LightState &state)
 
 bool Light::isRgbSyncAvailable()
 {
-    std::ifstream stream(RGB_BLINK_FILE);
-    return stream.good();
+    /* ToDo: Check LED trigger mode here */
+    return true;
 }
 
 int Light::rgbToBrightness(const LightState &state)
@@ -242,42 +246,22 @@ int Light::setSpeakerLightLocked(const LightState &state)
     blue = colorRGB & 0xFF;
     blink = onMS > 0 && offMS > 0;
 
-    if (isRgbSyncAvailable()) {
-        writeInt(RGB_BLINK_FILE, 0);
-    }
+    writeInt(RED_LED_BREATH_FILE, 0);
+    writeInt(GREEN_LED_BREATH_FILE, 0);
+    writeInt(BLUE_LED_BREATH_FILE, 0);
 
     if (blink) {
-        if (isRgbSyncAvailable()) {
-            writeStr(RED_LED_DUTY_PCTS_FILE, getScaledDutyPcts(red));
-            writeStr(GREEN_LED_DUTY_PCTS_FILE, getScaledDutyPcts(green));
-            writeStr(BLUE_LED_DUTY_PCTS_FILE, getScaledDutyPcts(blue));
+        writeInt(RED_LED_BASE   + "delay_off", offMS);
+        writeInt(GREEN_LED_BASE + "delay_off", offMS);
+        writeInt(BLUE_LED_BASE  + "delay_off", offMS);
 
-            writeInt(RED_LED_BASE + "pause_lo", offMS);
-            writeInt(GREEN_LED_BASE + "pause_lo", offMS);
-            writeInt(BLUE_LED_BASE + "pause_lo", offMS);
+        writeInt(RED_LED_BASE   + "delay_on", onMS);
+        writeInt(GREEN_LED_BASE + "delay_on", onMS);
+        writeInt(BLUE_LED_BASE  + "delay_on", onMS);
 
-            writeInt(RED_LED_BASE + "pause_hi", onMS);
-            writeInt(GREEN_LED_BASE + "pause_hi", onMS);
-            writeInt(BLUE_LED_BASE + "pause_hi", onMS);
-
-            writeInt(RGB_BLINK_FILE, 1);
-        } else {
-            if (red) {
-                if (writeInt(RED_BLINK_FILE, onMS == offMS ? 2 : 1)) {
-                    writeInt(RED_LED_FILE, 0);
-                }
-            }
-            if (green) {
-                if (writeInt(GREEN_BLINK_FILE, onMS == offMS ? 2 : 1)) {
-                    writeInt(GREEN_LED_FILE, 0);
-                }
-            }
-            if (blue) {
-                if (writeInt(BLUE_BLINK_FILE, onMS == offMS ? 2 : 1)) {
-                    writeInt(BLUE_LED_FILE, 0);
-                }
-            }
-        }
+        writeInt(RED_LED_BREATH_FILE, 1);
+        writeInt(GREEN_LED_BREATH_FILE, 1);
+        writeInt(BLUE_LED_BREATH_FILE, 1);
     } else {
         writeInt(RED_LED_FILE, red);
         writeInt(GREEN_LED_FILE, green);
@@ -313,6 +297,7 @@ int Light::setLightNotifications(const LightState &state)
 }
 
 static const std::vector<Type> kSupportedTypes = {
+    Type::ATTENTION,
     Type::BACKLIGHT,
     Type::BATTERY,
     Type::NOTIFICATIONS,

--- a/hardware/liblights/Light.h
+++ b/hardware/liblights/Light.h
@@ -40,14 +40,17 @@
 static constexpr int RAMP_SIZE = 8;
 static constexpr int BRIGHTNESS_RAMP[RAMP_SIZE] = { 0, 14, 28, 42, 56, 70, 84, 100 };
 
+const static std::string LEDS_CLASS_BASE
+    = "/sys/class/leds/";
+
 static const std::string RED_LED_BASE
-    = "/sys/class/leds/led:rgb_red/";
+    = LEDS_CLASS_BASE + "red/";
 
 static const std::string GREEN_LED_BASE
-    = "/sys/class/leds/led:rgb_green/";
+    = LEDS_CLASS_BASE + "green/";
 
 static const std::string BLUE_LED_BASE
-    = "/sys/class/leds/led:rgb_blue/";
+    = LEDS_CLASS_BASE + "blue/";
 
 static const std::string RED_LED_FILE
     = RED_LED_BASE + "brightness";
@@ -58,14 +61,14 @@ static const std::string GREEN_LED_FILE
 static const std::string BLUE_LED_FILE
     = BLUE_LED_BASE + "brightness";
 
-static const std::string RED_LED_DUTY_PCTS_FILE
-    = RED_LED_BASE + "duty_pcts";
+const static std::string RED_LED_BREATH_FILE
+    = RED_LED_BASE + "breath";
 
-static const std::string GREEN_LED_DUTY_PCTS_FILE
-    = GREEN_LED_BASE + "duty_pcts";
+const static std::string GREEN_LED_BREATH_FILE
+    = GREEN_LED_BASE + "breath";
 
-static const std::string BLUE_LED_DUTY_PCTS_FILE
-    = BLUE_LED_BASE + "duty_pcts";
+const static std::string BLUE_LED_BREATH_FILE
+    = BLUE_LED_BASE + "breath";
 
 static const std::string RED_BLINK_FILE
     = RED_LED_BASE + "blink";
@@ -75,9 +78,6 @@ static const std::string GREEN_BLINK_FILE
 
 static const std::string BLUE_BLINK_FILE
     = BLUE_LED_BASE + "blink";
-
-static const std::string RGB_BLINK_FILE
-    = "/sys/class/leds/rgb/rgb_blink";
 
 #ifdef DRMSDE_BACKLIGHT
 static const std::string LCD_FILE


### PR DESCRIPTION
The RGB tri-led now uses a different driver combo (pwm+led)
and it uses the Linux standard LED triggers... with different
paths.

Make a basic conversion of this HAL so that we get the very
basic functionality out of it.

Advanced functionality such as heartbeat and other triggers
can be implemented later.