### PR TITLE
permissions: Re-enable deprecated Android Beam on Android 10.

### DIFF
--- a/common-perm.mk
+++ b/common-perm.mk
@@ -42,7 +42,8 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.software.verified_boot.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.software.verified_boot.xml \
     frameworks/native/data/etc/com.android.nfc_extras.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/com.android.nfc_extras.xml \
     frameworks/native/data/etc/com.nxp.mifare.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/com.nxp.mifare.xml \
-    frameworks/native/data/etc/android.software.midi.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.software.midi.xml
+    frameworks/native/data/etc/android.software.midi.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.software.midi.xml \
+    $(COMMON_PATH)/rootdir/vendor/etc/permissions/enable_deprecated_beam.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/enable_deprecated_beam.xml
 
 # Keymaster 4 and StrongBox Permissions
 ifeq ($(TARGET_KEYMASTER_V4),true)

--- a/rootdir/vendor/etc/permissions/enable_deprecated_beam.xml
+++ b/rootdir/vendor/etc/permissions/enable_deprecated_beam.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<permissions>
+    <feature name="android.sofware.nfc.beam" />
+</permissions>


### PR DESCRIPTION
This feature is not gone yet, but it's going. Enable it for our devices
instead of cutting ourselves off from a file tranfering and sharing
feature that pretty much 99% of the other Android smartphones still
have.

See https://r.android.com/848931 for more details.