### PR TITLE
[COMMON] CommonConfig: Add symlink for DSPs signed apps

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -58,6 +58,9 @@ BOARD_ROOT_EXTRA_SYMLINKS += /$(TARGET_COPY_OUT_VENDOR)/bt_firmware:/bt_firmware
 BOARD_ROOT_EXTRA_SYMLINKS += /$(TARGET_COPY_OUT_VENDOR)/odm:/odm
 BOARD_ROOT_EXTRA_SYMLINKS += /mnt/vendor/persist:/persist
 
+# DSP RPC daemons need this extra link to find the right dsp apps
+BOARD_ROOT_EXTRA_SYMLINKS += /$(TARGET_COPY_OUT_VENDOR)/lib/rfsa/adsp:/odm/dsp
+
 # Filesystem
 TARGET_FS_CONFIG_GEN := $(COMMON_PATH)/config.fs
 


### PR DESCRIPTION
The audio, compute and sensor DSP RPC daemons are looking
in various default places for DSP programs.
On all Sony devices, the signed DSP programs are not in the dsp
partition of the eMMC/UFS card, but are distributed in the ODM
image (or elsewhere on stock ROMs), so we need to plug them in.

To get the DSP daemons to find and load these DSP programs,
add a symlink to /vendor/lib/rfsa/adsp, which is one of the default
binary paths for the dsprpc.

Note: Even though the symlink is to *A*dsp, this will still be
okay for all instances of the DSP RPC daemon (for all of
the available DSPs).