### PR TITLE
CommonConfig: Set VENDOR_SECURITY_PATCH for new Keymasters.

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -138,3 +138,7 @@ endif
 ifeq ($(AB_OTA_UPDATER),true)
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.bootctrl.xml
 endif
+
+# New vendor security patch level: https://r.android.com/660840/
+# Used by newer keymaster binaries
+VENDOR_SECURITY_PATCH=$(PLATFORM_SECURITY_PATCH)


### PR DESCRIPTION
Google added a new property ro.vendor.build.security_patch that's not
set to any sensible value by default. Our kew keymaster implementations
(KM4 on kernel 4.14 for the time being) rely on this value for rollback
protection.

Set it to the same value as the system currently built.

@ix5 Do you have any comment on this? Seems the only sensible default to me, no idea why AOSP doesn't set it.