### PR TITLE
common: Add rfsa_symlinks package

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -105,6 +105,7 @@ PRODUCT_PACKAGES += \
     adreno_symlinks \
     camera_symlinks \
     qca_cld3_symlinks \
+    rfsa_symlinks \
     tftp_symlinks
 
 # Create firmware mount point folders in /vendor:


### PR DESCRIPTION
ffcd156e7997de9917cab0284f20ea357bafb5a0 added the module, now actually include it.

The symlink `/vendor/lib/rfsa` -> `/odm/lib/rfsa` is needed for the new k4.14 blobs.