### PR TITLE
[DONOTMERGE][Q-MR1] TEMP: Kernel 4.9 backward compat

### DIFF
--- a/common-init.mk
+++ b/common-init.mk
@@ -23,13 +23,6 @@ PRODUCT_PACKAGES += \
     cnd.rc \
     cnss-daemon.rc \
     ipacm.rc \
-    dataqti.rc \
-    dpmQmiMgr.rc \
-    dpmd.rc \
-    imsdatadaemon.rc \
-    imsqmidaemon.rc \
-    imsrcsd.rc \
-    ims_rtp_daemon.rc \
     irsc_util.rc \
     mlog_qmi.rc \
     msm_irq.rc \
@@ -38,7 +31,6 @@ PRODUCT_PACKAGES += \
     per-proxy.rc \
     per-service.rc \
     qmuxd.rc \
-    qrtr.rc \
     qseecom.rc \
     rmt_storage.rc \
     sct_service.rc \
@@ -55,6 +47,24 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     qcrild.rc \
     qcrild2.rc
+
+# Legacy RIL
+ifeq ($(SOMC_KERNEL_VERSION),4.9)
+PRODUCT_PACKAGES += \
+    rild2.rc
+endif
+
+ifeq ($(SOMC_KERNEL_VERSION),4.14)
+PRODUCT_PACKAGES += \
+    dataqti.rc \
+    dpmQmiMgr.rc \
+    dpmd.rc \
+    ims_rtp_daemon.rc \
+    imsdatadaemon.rc \
+    imsqmidaemon.rc \
+    imsrcsd.rc \
+    qrtr.rc
+endif
 
 # Common init scripts
 PRODUCT_PACKAGES += \

--- a/common-prop.mk
+++ b/common-prop.mk
@@ -52,6 +52,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.vendor.radio.add_power_save=1 \
     persist.vendor.radio.apm_sim_not_pwdn=1
 
+ifeq ($(SOMC_KERNEL_VERSION),4.14)
 # Enable advanced power saving for data connectivity
 # DPM: Data Port Mapper, with TCM (TCP Connection Manager)
 # CnE: Connectivity Engine
@@ -85,6 +86,12 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.vendor.radio.unicode_op_names=true \
     persist.vendor.radio.sib16_support=1 \
     persist.vendor.radio.oem_socket=true
+
+else # SOMC_KERNEL_VERSION != 4.14
+# Keep legacy IOemHook interface
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.vendor.radio.oem_socket=false
+endif
 
 # Ringer
 PRODUCT_PROPERTY_OVERRIDES += \
@@ -239,6 +246,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.sys.wfd.virtual=0
 
+ifeq ($(SOMC_KERNEL_VERSION),4.14)
 # Display properties
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.demo.hdmirotationlock=false \
@@ -250,6 +258,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
     vendor.display.enable_default_color_mode=1 \
     vendor.display.enable_optimize_refresh=1 \
     vendor.display.disable_ui_3d_tonemap=1
+endif
 
 # Wi-Fi interface name
 PRODUCT_PROPERTY_OVERRIDES += \
@@ -265,8 +274,14 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # RILD
 PRODUCT_PROPERTY_OVERRIDES += \
-    vendor.rild.libpath=/odm/lib64/libril-qc-hal-qmi.so \
     ril.subscription.types=NV,RUIM
+ifeq ($(SOMC_KERNEL_VERSION),4.14)
+PRODUCT_PROPERTY_OVERRIDES += \
+    vendor.rild.libpath=/odm/lib64/libril-qc-hal-qmi.so
+else
+PRODUCT_PROPERTY_OVERRIDES += \
+    vendor.rild.libpath=/odm/lib64/libril-qc-qmi-1.so
+endif
 
 # OpenGLES version
 PRODUCT_PROPERTY_OVERRIDES += \

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -2,16 +2,16 @@
 PRODUCT_PACKAGES += \
     android.hardware.renderscript@1.0-impl
 
-# Composer
-PRODUCT_PACKAGES += \
-    android.hardware.graphics.composer@2.3-impl:64 \
-    android.hardware.graphics.composer@2.3-service \
-
 # Graphics allocator/mapper
 ifeq ($(TARGET_HARDWARE_GRAPHICS_V3),true)
 
 PRODUCT_PACKAGES += \
     android.hardware.graphics.mapper@3.0-impl-qti-display
+
+# Composer
+PRODUCT_PACKAGES += \
+    android.hardware.graphics.composer@2.3-impl:64 \
+    android.hardware.graphics.composer@2.3-service
 
 # android.hardware.graphics.allocator@3.0::IAllocator:
 PRODUCT_PACKAGES += \
@@ -23,6 +23,11 @@ PRODUCT_PACKAGES += \
     android.hardware.graphics.allocator@2.0-impl:64 \
     android.hardware.graphics.allocator@2.0-service \
     android.hardware.graphics.mapper@2.0-impl
+
+# Composer
+PRODUCT_PACKAGES += \
+    android.hardware.graphics.composer@2.1-impl:64 \
+    android.hardware.graphics.composer@2.1-service
 
 endif
 
@@ -74,8 +79,13 @@ PRODUCT_PACKAGES += \
     android.hardware.gnss@2.0-service-qti
 
 # Light
+ifeq ($(SOMC_KERNEL_VERSION),4.14)
 PRODUCT_PACKAGES += \
     android.hardware.light@2.0-service.sony
+else
+PRODUCT_PACKAGES += \
+    android.hardware.light@2.0-service.sony.legacy
+endif
 
 # Health
 PRODUCT_PACKAGES += \

--- a/common.mk
+++ b/common.mk
@@ -143,4 +143,6 @@ $(call inherit-product, device/sony/common/common-packages.mk)
 $(call inherit-product, device/sony/common/common-perm.mk)
 $(call inherit-product, device/sony/common/common-prop.mk)
 $(call inherit-product, device/sony/common/common-treble.mk)
+ifeq ($(SOMC_KERNEL_VERSION),4.14)
 $(call inherit-product, device/sony/common/common-binds.mk)
+endif

--- a/rootdir/Android.bp
+++ b/rootdir/Android.bp
@@ -215,6 +215,13 @@ prebuilt_etc {
 }
 
 prebuilt_etc {
+    name: "rild2.rc",
+    src: "vendor/etc/init/rild2.rc",
+    sub_dir: "init",
+    vendor: true,
+}
+
+prebuilt_etc {
     name: "rmt_storage.rc",
     src: "vendor/etc/init/rmt_storage.rc",
     sub_dir: "init",

--- a/rootdir/vendor/etc/init/rild2.rc
+++ b/rootdir/vendor/etc/init/rild2.rc
@@ -1,0 +1,11 @@
+# DSDS second ril
+service vendor.ril-daemon2 /vendor/bin/hw/rild -c 2
+    class main
+    user radio
+    disabled
+    group radio cache inet misc audio log readproc wakelock
+    capabilities BLOCK_SUSPEND NET_ADMIN NET_RAW
+
+on property:persist.vendor.radio.multisim.config=dsds
+    setprop persist.radio.multisim.config dsds
+    enable vendor.ril-daemon2

--- a/vintf/android.hardware.graphics_v2.xml
+++ b/vintf/android.hardware.graphics_v2.xml
@@ -19,4 +19,13 @@
             <instance>default</instance>
         </interface>
     </hal>
+    <hal format="hidl">
+        <name>android.hardware.graphics.composer</name>
+        <transport>hwbinder</transport>
+        <version>2.1</version>
+        <interface>
+            <name>IComposer</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
 </manifest>

--- a/vintf/android.hardware.graphics_v3.xml
+++ b/vintf/android.hardware.graphics_v3.xml
@@ -20,6 +20,15 @@
         </interface>
     </hal>
     <hal format="hidl">
+        <name>android.hardware.graphics.composer</name>
+        <transport>hwbinder</transport>
+        <version>2.3</version>
+        <interface>
+            <name>IComposer</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
         <name>vendor.qti.hardware.display.allocator</name>
         <transport>hwbinder</transport>
         <version>3.0</version>

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -96,15 +96,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.graphics.composer</name>
-        <transport>hwbinder</transport>
-        <version>2.3</version>
-        <interface>
-            <name>IComposer</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>vendor.display.config</name>
         <transport>hwbinder</transport>
         <version>1.2</version>

--- a/vintf/vendor.hw.radio_ds.xml
+++ b/vintf/vendor.hw.radio_ds.xml
@@ -1,11 +1,5 @@
 <manifest version="1.0" type="device">
     <hal format="hidl">
-        <name>vendor.qti.hardware.radio.am</name>
-        <transport>hwbinder</transport>
-        <fqname>@1.0::IQcRilAudio/slot1</fqname>
-        <fqname>@1.0::IQcRilAudio/slot2</fqname>
-    </hal>
-    <hal format="hidl">
         <name>vendor.qti.hardware.radio.ims</name>
         <transport>hwbinder</transport>
         <fqname>@1.5::IImsRadio/imsradio0</fqname>

--- a/vintf/vendor.hw.radio_ss.xml
+++ b/vintf/vendor.hw.radio_ss.xml
@@ -1,10 +1,5 @@
 <manifest version="1.0" type="device">
     <hal format="hidl">
-        <name>vendor.qti.hardware.radio.am</name>
-        <transport>hwbinder</transport>
-        <fqname>@1.0::IQcRilAudio/slot1</fqname>
-    </hal>
-    <hal format="hidl">
         <name>vendor.qti.hardware.radio.ims</name>
         <transport>hwbinder</transport>
         <fqname>@1.5::IImsRadio/imsradio0</fqname>

--- a/vintf/vendor.qti.hw.radio.am_ds.xml
+++ b/vintf/vendor.qti.hw.radio.am_ds.xml
@@ -1,0 +1,8 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>vendor.qti.hardware.radio.am</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::IQcRilAudio/slot1</fqname>
+        <fqname>@1.0::IQcRilAudio/slot2</fqname>
+    </hal>
+</manifest>

--- a/vintf/vendor.qti.hw.radio.am_ss.xml
+++ b/vintf/vendor.qti.hw.radio.am_ss.xml
@@ -1,0 +1,7 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>vendor.qti.hardware.radio.am</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::IQcRilAudio/slot1</fqname>
+    </hal>
+</manifest>


### PR DESCRIPTION
**DO NOT MERGE:**
Only for those wanting to keep 4.9 alive without being forced to use the `android-10_legacy` branch.

**NOTE:** This PR is now for the `q-mr1` branch.

---

Differentiate based on `SOMC_KERNEL_VERSION`:
- Use the new sm8150 media HAL on all devices only
  if on kernel 4.14
- Use the (new-ish) `sdm660-libion` media HAL on all devices only
  if on kernel 4.14
- For kernel 4.9, use msm8998 media HAL
- Restore `OVERRIDE_RS_DRIVER` if on k4.9
- Use the `/dsp` -> `/odm/dsp` and `/firmware` symlinks if on k4.9
- Guard kernel cmdline args by kernel version
- Only ship qrtr, qti, ims init files on 4.14
- Guard new display props by k4.14
- Guard new IMS/modem props by k4.14
- Keep legacy `IOemHook` for k4.9 via prop
- Use legacy liblights if on k4.9
- Use `composer@2.1` instead of 2.3 for k4.9
- Restore old rild, props for k4.9, only use qcrild on k4.14
- Use qti-qcrild-specific vintf interfaces only on k4.14,
  retrofit qti.radio.am for k4.9 in SS/DS separate files
- Use `/odm` bindmounts only on k4.14
