### PR TITLE
[COMMON] [URGENT] CommonConfig: Remove kernel cross compile prefixes for Q

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -43,8 +43,6 @@ BOARD_MKBOOTIMG_ARGS := --ramdisk_offset $(BOARD_RAMDISK_OFFSET) --tags_offset $
 
 TARGET_KERNEL_ARCH := arm64
 TARGET_KERNEL_HEADER_ARCH := arm64
-TARGET_KERNEL_CROSS_COMPILE_PREFIX := aarch64-linux-android-
-TARGET_KERNEL_CROSS_COMPILE_32BITS_PREFIX := arm-linux-androideabi-
 BOARD_KERNEL_IMAGE_NAME := Image.gz-dtb
 
 # Use mke2fs to create ext4 images


### PR DESCRIPTION
Android 10's build system will fail to build the kernel if we use these
prefixes due to "unallowed paths".