### PR TITLE
[1/3] Kernel rework

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -113,6 +113,15 @@ BUILD_KERNEL ?= true
 
 -include $(KERNEL_PATH)/common-kernel/KernelConfig.mk
 
+ifeq ($(TARGET_NEEDS_DTBOIMAGE),true)
+ifeq ($(BUILD_KERNEL),true)
+BOARD_DTBO_IMAGE_NAME := dtbo-$(TARGET_DEVICE).img
+BOARD_PREBUILT_DTBOIMAGE ?= $(PRODUCT_OUT)/$(BOARD_DTBO_IMAGE_NAME)
+else
+BOARD_PREBUILT_DTBOIMAGE ?= kernel/sony/msm-$(SOMC_KERNEL_VERSION)/common-kernel/dtbo-$(TARGET_DEVICE).img
+endif
+endif
+
 # Include build helpers for QCOM proprietary
 -include vendor/qcom/proprietary/common/build/proprietary-build.mk
 

--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -105,6 +105,12 @@ ifeq ($(HOST_OS),linux)
 endif
 WITH_DEXPREOPT_BOOT_IMG_AND_SYSTEM_SERVER_ONLY ?= true
 
+# Build kernel using kernel's Android.mk file.
+# May be overriden by KernelConfig.mk if prebuilt kernel present.
+# Can also be turned off in Customization.mk in case it is desired to use a
+# custom ROM's kernel build system, e.g. LineageOS' or PE's.
+BUILD_KERNEL ?= true
+
 -include $(KERNEL_PATH)/common-kernel/KernelConfig.mk
 
 # Include build helpers for QCOM proprietary

--- a/common.mk
+++ b/common.mk
@@ -48,7 +48,7 @@ BOARD_PROPERTY_OVERRIDES_SPLIT_ENABLED := true
 # Force building a recovery image: Needed for OTA packaging to work since Q
 PRODUCT_BUILD_RECOVERY_IMAGE := true
 
-BUILD_KERNEL := true
+# Sanitized prebuilt kernel headers
 -include $(KERNEL_PATH)/common-headers/KernelHeaders.mk
 
 # Codecs Configuration

--- a/common.mk
+++ b/common.mk
@@ -48,6 +48,7 @@ BOARD_PROPERTY_OVERRIDES_SPLIT_ENABLED := true
 # Force building a recovery image: Needed for OTA packaging to work since Q
 PRODUCT_BUILD_RECOVERY_IMAGE := true
 
+KERNEL_PATH := kernel/sony/msm-$(SOMC_KERNEL_VERSION)
 # Sanitized prebuilt kernel headers
 -include $(KERNEL_PATH)/common-headers/KernelHeaders.mk
 


### PR DESCRIPTION
## CommonConfig: Unify DTBOIMAGE vars

Move the BOARD_PREBUILT_DTBOIMAGE var for the prebuilt kernel from the platform repos to common, declutters the platform repos.

For building the kernel in-tree:
Set BOARD_PREBUILT_DTBOIMAGE - guarded by BUILD_KERNEL - so that the `dtbo-$(DEVICE).img` file can have an AVB hash footer appended by the build system.

## Move setting KERNEL_PATH to common

This declutters the platform repos

## Move BUILD_KERNEL to CommonConfig

I borked that one in 7637020af0612d44493b78240d1a089c93b9be97 "[Android-10] Move kernel includes to common.mk".

Now the flag can be overriden in Customization.mk.

## Dependents
https://github.com/sonyxperiadev/device-sony-loire/pull/264
https://github.com/sonyxperiadev/device-sony-tone/pull/188
https://github.com/sonyxperiadev/device-sony-yoshino/pull/152
https://github.com/sonyxperiadev/device-sony-nile/pull/106
https://github.com/sonyxperiadev/device-sony-tama/pull/76
https://github.com/sonyxperiadev/device-sony-ganges/pull/27
https://github.com/sonyxperiadev/device-sony-kumano/pull/23