### PR TITLE
[1/2] common-treble: Build vibrator 1.0 or 1.2 based on TARGET_VIBRATOR_V1_2.

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -84,10 +84,16 @@ PRODUCT_PACKAGES += \
     android.hardware.sensors@1.0-impl:64 \
     android.hardware.sensors@1.0-service
 
+ifeq ($(TARGET_VIBRATOR_V1_2),true)
+# QTI Haptics Vibrator
+PRODUCT_PACKAGES += \
+    vendor.qti.hardware.vibrator@1.2-service
+else
 # Vibrator
 PRODUCT_PACKAGES += \
     android.hardware.vibrator@1.0-impl \
     android.hardware.vibrator@1.0-service
+endif
 
 # Fingerprint
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Kumano uses a different vibrator HAL, and leaving the default
implementation at V1.0 in the build results in a mess.
Make sure only one of the two services is built and included in the
image.

To simplify and prepare for future platforms most likely using the same
or a similar HAL, move the inclusion of vendor.qti.hardware.vibrator
here as well, instead of leaving it in kumano/platform.mk.