### PR TITLE
[COMMON] Add tetheroffload HIDL interfaces

### DIFF
--- a/rootdir/vendor/etc/init/ipacm.rc
+++ b/rootdir/vendor/etc/init/ipacm.rc
@@ -3,6 +3,8 @@ on post-fs-data
     mkdir /data/vendor/ipa 0770 radio radio
 
 service vendor.ipacm /vendor/bin/ipacm
+    interface android.hardware.tetheroffload.config@1.0::IOffloadConfig default
+    interface android.hardware.tetheroffload.control@1.0::IOffloadControl default
     class main
     user radio
     group radio inet

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -199,6 +199,16 @@
         </interface>
     </hal>
     <hal format="hidl">
+        <name>android.hardware.tetheroffload.config</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::IOffloadConfig/default</fqname>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.tetheroffload.control</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::IOffloadControl/default</fqname>
+    </hal>
+    <hal format="hidl">
         <name>android.hardware.usb</name>
         <transport>hwbinder</transport>
         <version>1.0</version>


### PR DESCRIPTION
These interfaces are hosted by `ipacm`. Add the interfaces to the vintf (which is enforcing in our builds) and list them in the initrc.

This PR has originally been merged and accidentally force-pushed off for another feature:
https://github.com/sonyxperiadev/device-sony-common/pull/556