### PR TITLE
[COMMON] Enable WiFi concurrent STA/AP for all platforms

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -101,6 +101,9 @@ BOARD_CHARGER_ENABLE_SUSPEND := true
 # DRM
 TARGET_ENABLE_MEDIADRM_64 := true
 
+# Wi-Fi Concurrent STA/AP
+WIFI_HIDL_FEATURE_DUAL_INTERFACE := true
+
 # Enable dex-preoptimization to speed up first boot sequence
 ifeq ($(HOST_OS),linux)
   ifneq ($(TARGET_BUILD_VARIANT),eng)

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -57,6 +57,14 @@
         <item>"wlan0"</item>
     </string-array>
 
+    <!-- Enable ACS (auto channel selection) for Wifi hotspot (SAP) -->
+    <bool translatable="false" name="config_wifi_softap_acs_supported">true</bool>
+
+    <!-- Channel list restriction to Automatic channel selection (ACS) for softap. If the device
+         doesn't want to restrict channels this should be empty. Value is a comma separated channel
+         string and/or channel range string like '1-6,11' -->
+    <string translatable="false" name="config_wifi_softap_acs_supported_channel_list"></string>
+
     <!-- Enable 802.11ac for Wifi hotspot (SAP) -->
     <bool translatable="false" name="config_wifi_softap_ieee80211ac_supported">true</bool>
 

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -57,6 +57,9 @@
         <item>"wlan0"</item>
     </string-array>
 
+    <!-- Enable 802.11ac for Wifi hotspot (SAP) -->
+    <bool translatable="false" name="config_wifi_softap_ieee80211ac_supported">true</bool>
+
     <!-- Boolean indicating whether the wifi chipset has dual frequency band support -->
     <bool translatable="false" name="config_wifi_dual_band_support">true</bool>
 


### PR DESCRIPTION
https://source.android.com/devices/tech/connect/wifi-sta-ap-concurrency

All our platforms support concurrent STA/AP (see output of `iw info`), including Loire and Tone on brcmfmac (which have recently been dropped from these master branches).
Platforms on QCACLD require an extra flag `gEnableConcurrentSTA=wlan1` in `WCNSS_qcom_cfg.ini` which will be PR'ed separately to platform repositories: this flag creates an `__ap` interface named `wlan1`. Loire and Tone require a manual command to create this interface which can be provided and backported to the appropriate tags if desired.

There is one configuration option that does not make a lot of sense, but is enabled on crosshatch and coral: https://android.googlesource.com/device/google/crosshatch/+/9e44fc78629b66c93d6dc6d78f98245853a0c1f8%5E%21/#F0
`config_wifi_convert_apband_5ghz_to_any` seems to be a special fallback for hardware limitations. See the implementation here: https://android.googlesource.com/platform/frameworks/opt/net/wifi/+/refs/tags/android-10.0.0_r25/service/java/com/android/server/wifi/WifiApConfigStore.java#232
Enabling or disabling this feature does not seem to have any effect; the `Log.w`s are never triggered. I don't have time to dig any further in the code, feel free to do so if you are interested.
(Before you ask, I was able to successfully host a 5GHz and 2.4GHz AP while remaining connected to a 2.4GHz AP).