### PR TITLE
[COMMON] Switch to dual media HAL again for legacy SoC

### DIFF
--- a/hardware/qcom/Android.mk
+++ b/hardware/qcom/Android.mk
@@ -5,7 +5,7 @@ else
 # TARGET_BOARD_PLATFORM specific featurization
 QCOM_BOARD_PLATFORMS += msm8952 msm8996 msm8998 sdm660 sdm845 sm8150
 
-QCOM_NEW_MEDIA_PLATFORM := msm8952 msm8996 msm8998 sdm660 sdm845 sm8150
+QCOM_NEW_MEDIA_PLATFORM := sdm845 sm8150
 
 #List of targets that use video hw
 MSM_VIDC_TARGET_LIST := msm8952 msm8996 msm8998 sdm660 sdm845 sm8150

--- a/hardware/qcom/Android.mk
+++ b/hardware/qcom/Android.mk
@@ -22,7 +22,7 @@ display-hal := hardware/qcom/display/sde
 ifneq ($(filter $(QCOM_NEW_MEDIA_PLATFORM), $(TARGET_BOARD_PLATFORM)),)
 QCOM_MEDIA_ROOT := hardware/qcom/media/sm8150
 else
-QCOM_MEDIA_ROOT := hardware/qcom/media/msm8998
+QCOM_MEDIA_ROOT := hardware/qcom/media/sdm660-libion
 endif
 
 OMX_VIDEO_PATH := mm-video-v4l2


### PR DESCRIPTION
A wild vidc_3x port from kernel 4.9 to 4.14 has appeared and we want to
use it in place of a huge rework of both HAL and SM8150 vidc driver
for all the legacy SoCs.

Place the new libion ported HAL in hardware/qcom/media/sdm660-libion
and use it for SoC range msm8956-sdm660.

The SDM845 SoC is kept on the new SM8150 codebase, as it is
compatible with only minor changes.