### PR TITLE
treble/vintf: Bump graphics.composer to version 2.3.

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -4,8 +4,8 @@ PRODUCT_PACKAGES += \
 
 # Composer
 PRODUCT_PACKAGES += \
-    android.hardware.graphics.composer@2.1-impl:64 \
-    android.hardware.graphics.composer@2.1-service \
+    android.hardware.graphics.composer@2.3-impl:64 \
+    android.hardware.graphics.composer@2.3-service \
 
 # Graphics allocator/mapper
 ifeq ($(TARGET_HARDWARE_GRAPHICS_V3),true)

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -89,7 +89,7 @@
     <hal format="hidl">
         <name>android.hardware.graphics.composer</name>
         <transport>hwbinder</transport>
-        <version>2.1</version>
+        <version>2.3</version>
         <interface>
             <name>IComposer</name>
             <instance>default</instance>


### PR DESCRIPTION
DONOTMERGE: Composer 2.3 _depends on_ 8.1 display. It'll _crash_ with 7.1, likely due to missing/unimplemented/broken functionality.

After moving to CAF 8.1 display branches the new composer can and should
be used.