### PR TITLE
rootdir: Drop mediaextractor seccomp policy

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -83,7 +83,6 @@ PRODUCT_COPY_FILES += \
 
 # Seccomp policy
 PRODUCT_COPY_FILES += \
-    $(COMMON_PATH)/rootdir/vendor/etc/seccomp_policy/mediaextractor.policy:$(TARGET_COPY_OUT_VENDOR)/etc/seccomp_policy/mediaextractor.policy \
     $(COMMON_PATH)/rootdir/vendor/etc/seccomp_policy/mediacodec.policy:$(TARGET_COPY_OUT_VENDOR)/etc/seccomp_policy/mediacodec.policy
 
 # Audio Configuration

--- a/rootdir/vendor/etc/seccomp_policy/mediacodec.policy
+++ b/rootdir/vendor/etc/seccomp_policy/mediacodec.policy
@@ -3,7 +3,5 @@ pselect6: 1
 eventfd2: 1
 sendto: 1
 recvfrom: 1
-_llseek: 1
 sysinfo: 1
 getcwd: 1
-getdents64: 1

--- a/rootdir/vendor/etc/seccomp_policy/mediaextractor.policy
+++ b/rootdir/vendor/etc/seccomp_policy/mediaextractor.policy
@@ -1,3 +1,0 @@
-# device specific syscalls.
-readlinkat: 1
-pread64: 1


### PR DESCRIPTION
These syscalls are now allowed by default.

[arco] Also clean mediacodec.policy

Change-Id: I405f609d030331e19031612cbd912a54a3c72339

---

Proof:
https://android.googlesource.com/platform/frameworks/av/+/refs/tags/android-10.0.0_r35/services/mediaextractor/seccomp_policy/mediaextractor-arm64.policy
`readlinkat`, `pread64` contained

https://android.googlesource.com/platform/frameworks/av/+/refs/tags/android-10.0.0_r35/services/mediacodec/seccomp_policy/mediacodec-arm.policy
`_llseek`, `getdents64` contained