### PR TITLE
common-init: add dpmQmiMgr service file.

### DIFF
--- a/common-init.mk
+++ b/common-init.mk
@@ -21,6 +21,7 @@ PRODUCT_PACKAGES += \
     cdsprpcd.rc \
     cnss-daemon.rc \
     ipacm.rc \
+    dpmQmiMgr.rc \
     imsdatadaemon.rc \
     imsqmidaemon.rc \
     imsrcsd.rc \

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -218,6 +218,14 @@ LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 
 include $(CLEAR_VARS)
+LOCAL_MODULE := dpmQmiMgr.rc
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES := vendor/etc/init/dpmQmiMgr.rc
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE := qseecom.rc
 LOCAL_MODULE_CLASS := ETC
 LOCAL_SRC_FILES := vendor/etc/init/qseecom.rc

--- a/rootdir/vendor/etc/init/dpmQmiMgr.rc
+++ b/rootdir/vendor/etc/init/dpmQmiMgr.rc
@@ -1,0 +1,4 @@
+service vendor.dpmQmiMgr /odm/bin/dpmQmiMgr
+    class main
+    user system
+    group system


### PR DESCRIPTION
This service is required on Kumano.