### PR TITLE
[WIP] Guard IMS and kumano init files

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -157,4 +157,6 @@ endif
 # Used by newer keymaster binaries
 VENDOR_SECURITY_PATCH=$(PLATFORM_SECURITY_PATCH)
 
+ifneq ($(filter sdm660 msm8998 sdm845 sm8150,$(TARGET_BOARD_PLATFORM)),)
 TARGET_USES_IMS:= true
+endif

--- a/common-init.mk
+++ b/common-init.mk
@@ -21,10 +21,6 @@ PRODUCT_PACKAGES += \
     cdsprpcd.rc \
     cnss-daemon.rc \
     ipacm.rc \
-    imsdatadaemon.rc \
-    imsqmidaemon.rc \
-    imsrcsd.rc \
-    ims_rtp_daemon.rc \
     irsc_util.rc \
     mlog_qmi.rc \
     msm_irq.rc \
@@ -45,6 +41,14 @@ PRODUCT_PACKAGES += \
     ta_qmi.rc \
     tftp_server.rc \
     wpa_supplicant.rc
+
+ifeq ($(TARGET_USES_IMS),true)
+PRODUCT_PACKAGES += \
+    ims_rtp_daemon.rc \
+    imsdatadaemon.rc \
+    imsqmidaemon.rc \
+    imsrcsd.rc
+endif
 
 # Common init scripts
 PRODUCT_PACKAGES += \

--- a/common-init.mk
+++ b/common-init.mk
@@ -17,7 +17,6 @@ PRODUCT_PACKAGES += \
     init.usb.rc \
     adb_tcp.rc \
     adsprpcd.rc \
-    adpl.rc \
     cdsprpcd.rc \
     cnss-daemon.rc \
     ipacm.rc \
@@ -31,7 +30,6 @@ PRODUCT_PACKAGES += \
     qmuxd.rc \
     qrtr.rc \
     qseecom.rc \
-    qti.rc \
     rild2.rc \
     rmt_storage.rc \
     sct_service.rc \
@@ -48,6 +46,12 @@ PRODUCT_PACKAGES += \
     imsdatadaemon.rc \
     imsqmidaemon.rc \
     imsrcsd.rc
+endif
+
+ifneq ($(filter sm8150,$(TARGET_BOARD_PLATFORM)),)
+PRODUCT_PACKAGES += \
+    adpl.rc \
+    qti.rc
 endif
 
 # Common init scripts


### PR DESCRIPTION
Guard IMS init pkgs by `TARGET_USES_IMS`. Prevents inclusion for legacy devices.

Only copy `qti.rc` and `adpl.rc` for sm8150. These services would never start on other platforms.