### PR TITLE
[COMMON][ vendor: sec_config: Add missing allowances for 4.14

### DIFF
--- a/rootdir/vendor/etc/sec_config
+++ b/rootdir/vendor/etc/sec_config
@@ -15,6 +15,12 @@
 55:4294967295:1021
 /* Allow RCS service to aquire net_raw permission */
 18:4294967295:1001:3004
+/* Allow RCS service to communicate to IMS QMI Priv Svc*/
+77:4294967295:1001:3003
+/* Allow SSGQMIGD to communicate to SSGCCS service*/
+76:4294967295:1001
+/* Allow cnd to accquire netbind */
+18:4294967295:1000:3003
 /* Allow QMID service to aquire net_raw permission */
 3:4294967295:1001:3004
 2:4294967295:1000:1001:3004
@@ -55,6 +61,7 @@
 /*SERVREG_NOTIF*/
 64:4294967295:1001
 66:4294967295:1001
+73:4294967295:1001
 /*LTE*/
 70:4294967295:1001
 /* Allow Data dpmd to access QMI DFS */


### PR DESCRIPTION
On k4.14 BSPs we have new allowances required for new QMI
services present in there.