### PR TITLE
[COMMON] CommonConfig: Raise maximum possible loopback partitions

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -37,6 +37,7 @@ BOARD_KERNEL_CMDLINE += msm_rtb.filter=0x3F ehci-hcd.park=3
 BOARD_KERNEL_CMDLINE += coherent_pool=8M
 BOARD_KERNEL_CMDLINE += sched_enable_power_aware=1 user_debug=31
 BOARD_KERNEL_CMDLINE += printk.devkmsg=on
+BOARD_KERNEL_CMDLINE += loop.max_part=16
 BOARD_KERNEL_CMDLINE += kpti=0
 
 BOARD_MKBOOTIMG_ARGS := --ramdisk_offset $(BOARD_RAMDISK_OFFSET) --tags_offset $(BOARD_KERNEL_TAGS_OFFSET)


### PR DESCRIPTION
On Android 10 we need more loopback partitions in order
to get APEX working as per design.