### PR TITLE
[COMMON] CommonConfig/vintf: Add QTI IUceService 2.1 for IMS

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -149,6 +149,7 @@ endif
 
 ifeq ($(TARGET_USE_QCRILD),true)
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.radio.config.xml
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.hw.radio.uceservice.xml
 endif
 
 ifeq ($(TARGET_KEYMASTER_V4),true)

--- a/vintf/vendor.hw.radio.uceservice.xml
+++ b/vintf/vendor.hw.radio.uceservice.xml
@@ -1,0 +1,11 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>com.qualcomm.qti.uceservice</name>
+        <transport>hwbinder</transport>
+        <version>2.1</version>
+        <interface>
+            <name>IUceService</name>
+            <instance>com.qualcomm.qti.uceservice</instance>
+        </interface>
+    </hal>
+</manifest>


### PR DESCRIPTION
This interface is necessary in order to successfully register IMS
services.