### PR TITLE
common: Include vendor/qcom/opensource/core-utils Soong namespace.

### DIFF
--- a/common-packages.mk
+++ b/common-packages.mk
@@ -67,7 +67,7 @@ PRODUCT_PACKAGES += \
 
 # IPA
 PRODUCT_PACKAGES += \
-    libqti_vndfwk_detect \
+    libqti_vndfwk_detect.vendor \
     IPACM_cfg.xml \
     ipacm
 

--- a/common.mk
+++ b/common.mk
@@ -16,7 +16,8 @@
 # Might be temporary! See:
 # https://android.googlesource.com/platform/build/soong/+/master/README.md#name-resolution
 PRODUCT_SOONG_NAMESPACES += \
-    $(PLATFORM_COMMON_PATH)
+    $(PLATFORM_COMMON_PATH) \
+    vendor/qcom/opensource/core-utils
 
 $(call inherit-product-if-exists, device/sony/customization/customization.mk)
 


### PR DESCRIPTION
For https://github.com/sonyxperiadev/vendor-qcom-opensource-core-utils/pull/2

This namespace contains the necessary libqti_vndfwk_detect.