### PR TITLE
[COMMON] init.recovery: Remove paranoid ADB configuration

### DIFF
--- a/rootdir/init.recovery.common.rc
+++ b/rootdir/init.recovery.common.rc
@@ -21,20 +21,6 @@ on fs
     wait /dev/block/platform/soc/${ro.boot.bootdevice}
     symlink /dev/block/platform/soc/${ro.boot.bootdevice} /dev/block/bootdevice
 
-# Keep a paranoid ADB configuration
-on property:sys.usb.ffs.ready=1 && property:sys.usb.config=adb
-    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "adb"
-    rm /config/usb_gadget/g1/configs/b.1/f1
-    rm /config/usb_gadget/g1/configs/b.1/f2
-    rm /config/usb_gadget/g1/configs/b.1/f3
-    rm /config/usb_gadget/g1/configs/b.1/f4
-    rm /config/usb_gadget/g1/configs/b.1/f5
-    write /config/usb_gadget/g1/idVendor 0x0fce
-    write /config/usb_gadget/g1/idProduct 0x7${ro.usb.pid_suffix}
-    symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f1
-    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
-    setprop sys.usb.state ${sys.usb.config}
-
 on property:sys.usb.config=adb
     start adbd
 


### PR DESCRIPTION
This gives issues with Kumano: removing it brings it to
functional adb shell in recovery.

Tested on SoMC SM8150 Kumano Bahamut DSDS