### PR TITLE
[COMMON] vendor: Add startup modem operator configuration scripts

### DIFF
--- a/common-init.mk
+++ b/common-init.mk
@@ -56,6 +56,7 @@ endif
 
 # Common init scripts
 PRODUCT_PACKAGES += \
+    init.qcom.modem.sh \
     init.qcom.adspstart.sh \
     init.qcom.cdspstart.sh \
     init.qcom.ipastart.sh \

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -24,6 +24,15 @@ include $(BUILD_PREBUILT)
 endif # $(TARGET_KEYMASTER_V4) == true
 
 include $(CLEAR_VARS)
+LOCAL_MODULE := init.qcom.modem.sh
+LOCAL_MODULE_CLASS := EXECUTABLES
+LOCAL_SRC_FILES_arm64 := vendor/bin/init.qcom.modem.sh
+LOCAL_INIT_RC_64  := vendor/etc/init/init.modem.rc
+LOCAL_MODULE_TARGET_ARCH := arm64
+LOCAL_VENDOR_MODULE := true
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE := init.qcom.slpistart.sh
 LOCAL_MODULE_CLASS := EXECUTABLES
 LOCAL_SRC_FILES_arm64 := vendor/bin/init.qcom.slpistart.sh

--- a/rootdir/vendor/bin/init.qcom.modem.sh
+++ b/rootdir/vendor/bin/init.qcom.modem.sh
@@ -1,0 +1,44 @@
+#!/vendor/bin/sh
+
+#
+# Make modem config folder and copy firmware config to that folder for RIL
+#
+
+# Fill the current and previous version temporary env variables
+cur_version_info=`cat /vendor/firmware_mnt/verinfo/ver_info.txt`
+
+if [ -f /data/vendor/modem_config/ver_info.txt ]; then
+    prev_version_info=`cat /data/vendor/modem_config/ver_info.txt`
+else
+    # Userdata is blank or modem_config is bad: this will trigger a
+    # cur-prev ver mismatch and will copy modem configuration in data
+    prev_version_info=""
+fi
+
+if [ ! -f /vendor/firmware_mnt/verinfo/ver_info.txt -o "$prev_version_info" != "$cur_version_info" ]; then
+    # Version is different: delete everything and copy the new stuff over.
+    rm -rf /data/vendor/modem_config
+
+    mkdir /data/vendor/modem_config
+    chmod 770 /data/vendor/modem_config
+
+    # Copy the modem operator configurations: mbn_sw
+    cp -r /vendor/firmware_mnt/image/modem_pr/mcfg/configs/* /data/vendor/modem_config/
+    chown -hR radio.root /data/vendor/modem_config
+
+    # For checking the current vs new version of the modem operator configurations
+    cp /vendor/firmware_mnt/verinfo/ver_info.txt /data/vendor/modem_config/
+    chown radio.root /data/vendor/modem_config/ver_info.txt
+
+    # This file exists only on some versions of the modem_pr. Try copying it anyway.
+    cp /vendor/firmware_mnt/image/modem_pr/mbn_ota.txt /data/vendor/modem_config
+    chown radio.root /data/vendor/modem_config/mbn_ota.txt
+
+    # To support both libril-qc-hal-qmi and libril-qc-qmi-1 paths
+    rm /data/vendor/radio/modem_config
+    ln -s /data/vendor/modem_config /data/vendor/radio/modem_config
+fi
+
+# This file is recreated at every boot (for reasons) by init.rc: set it right.
+echo 1 > /data/vendor/radio/copy_complete
+

--- a/rootdir/vendor/etc/init/init.modem.rc
+++ b/rootdir/vendor/etc/init/init.modem.rc
@@ -1,0 +1,5 @@
+service vendor.init-modem /vendor/bin/init.qcom.modem.sh
+    class late_start
+    user radio
+    group root system radio
+    oneshot


### PR DESCRIPTION
This script will copy the modem operator configurations to the
right folders for consumption by the RIL.

This ensures correct modem operation on all of the (supported)
carriers requiring special mcfg_sw configurations.