### PR TITLE
common: Forcibly include customization.mk at the beginning of common.mk

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -18,8 +18,6 @@
 PRODUCT_SOONG_NAMESPACES += \
     $(PLATFORM_COMMON_PATH)
 
-$(call inherit-product-if-exists, device/sony/customization/customization.mk)
-
 # Common path
 COMMON_PATH := device/sony/common
 
@@ -126,6 +124,8 @@ PRODUCT_PACKAGES += \
 # Community APN list
 PRODUCT_COPY_FILES += \
     $(COMMON_PATH)/rootdir/vendor/etc/apns-conf.xml:system/etc/apns-conf.xml
+
+-include device/sony/customization/customization.mk
 
 $(call inherit-product, device/sony/common/common-init.mk)
 $(call inherit-product, device/sony/common/common-odm.mk)


### PR DESCRIPTION
This resolves two subtle issues with the inherit-product mechanism:
- Inherited files are evaluated later, at least after _common.mk_ has
  been fully read despite the call to inherit-product being at the top
  of the file;
- The ordering between other inherit-product calls is not guaranteed;
  the list is sorted to remove duplicates and provide consistency.

The observed problem at hand is overriding TARGET_USE_QCRILD in
customization.mk, as is happening in PE. Due to sorting common-init.mk
(which uses this variable) is evaluated _before_ customization.mk,
leading to the wrong rc files ending up on vendor.img.
CommonConfig.mk on the other hand is parsed after the entire product
inheritance tree is evaluated, hence the right vintf is selected
according to this variable.

This issue is fixed by forcefully including customization.mk at the
"right" (or at the very least expected) step in the build process.
Repository maintainers are aware that this file should only be included
once, which is safe enough to do away with the single-evaluation
guarantees inherit-product provides.

Source:
https://android.googlesource.com/platform/build/+/android-10.0.0_r26/core/product.mk#364
> To be called from product makefiles, and is later evaluated during
> the import-nodes call below. It does three things: