### PR TITLE
rootdir: vendor: move audiopd to own file

### DIFF
--- a/common-init.mk
+++ b/common-init.mk
@@ -17,6 +17,7 @@ PRODUCT_PACKAGES += \
     init.usb.rc \
     adb_tcp.rc \
     adsprpcd.rc \
+    audiopd.rc \
     cdsprpcd.rc \
     cnss-daemon.rc \
     ipacm.rc \

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -94,6 +94,15 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 
+ifeq ($(TARGET_NEEDS_AUDIOPD), true)
+include $(CLEAR_VARS)
+LOCAL_MODULE := audiopd.rc
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES := vendor/etc/init/audiopd.rc
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
+include $(BUILD_PREBUILT)
+endif
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := ipacm.rc

--- a/rootdir/vendor/etc/init/adsprpcd.rc
+++ b/rootdir/vendor/etc/init/adsprpcd.rc
@@ -5,14 +5,5 @@ service vendor.adsprpcd /odm/bin/adsprpcd
    group media
    disabled
 
-service vendor.audiopd /odm/bin/adsprpcd audiopd
-   class main
-   user media
-   group media
-   disabled
-
-on property:ro.board.platform=sdm660
-    enable vendor.audiopd
-
 on property:vendor.qcom.adspup=1
     enable vendor.adsprpcd

--- a/rootdir/vendor/etc/init/audiopd.rc
+++ b/rootdir/vendor/etc/init/audiopd.rc
@@ -1,0 +1,4 @@
+service vendor.audiopd /odm/bin/adsprpcd audiopd
+   class main
+   user media
+   group media


### PR DESCRIPTION
Guard the separated service with a flag instead of enabling at boot time via prop.