### PR TITLE
[COMMON] Enable IQtiOemHook

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -49,8 +49,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Enable Power save functionality for modem
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.vendor.radio.add_power_save=1 \
-    persist.vendor.radio.apm_sim_not_pwdn=1 \
-    persist.vendor.radio.oem_socket=false
+    persist.vendor.radio.apm_sim_not_pwdn=1
 
 # Ringer
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
This enables legacy `libril` from legacy `rild` and `qcrild` to host the IQtiOemHook, required to implement TransPower for SAR compliance and some more features in the near future.