### PR TITLE
[q-mr1-legacy] Move kernel path to common config

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -113,6 +113,12 @@ ifeq ($(HOST_OS),linux)
 endif
 WITH_DEXPREOPT_BOOT_IMG_AND_SYSTEM_SERVER_ONLY ?= true
 
+# Build kernel using kernel's Android.mk file.
+# May be overriden by KernelConfig.mk if prebuilt kernel present.
+# Can also be turned off in Customization.mk in case it is desired to use a
+# custom ROM's kernel build system, e.g. LineageOS' or PE's.
+BUILD_KERNEL ?= true
+
 -include $(KERNEL_PATH)/common-kernel/KernelConfig.mk
 
 # Include build helpers for QCOM proprietary

--- a/common.mk
+++ b/common.mk
@@ -50,7 +50,7 @@ PRODUCT_PACKAGES += \
 # Force building a recovery image: Needed for OTA packaging to work since Q
 PRODUCT_BUILD_RECOVERY_IMAGE := true
 
-BUILD_KERNEL := true
+# Sanitized prebuilt kernel headers
 -include $(KERNEL_PATH)/common-headers/KernelHeaders.mk
 
 # Codecs Configuration

--- a/common.mk
+++ b/common.mk
@@ -50,6 +50,7 @@ PRODUCT_PACKAGES += \
 # Force building a recovery image: Needed for OTA packaging to work since Q
 PRODUCT_BUILD_RECOVERY_IMAGE := true
 
+KERNEL_PATH := kernel/sony/msm-$(SOMC_KERNEL_VERSION)
 # Sanitized prebuilt kernel headers
 -include $(KERNEL_PATH)/common-headers/KernelHeaders.mk
 


### PR DESCRIPTION
Following changes of @ix5 to fix build in legacy devices.

Platform will need change in platform.mk. See [Loire for example](https://github.com/sonyxperiadev/device-sony-loire/commit/678af16ec3d2283e0a88da9130d623d60cffa6b2)

Should be merged together with [kernel/PR2216](https://github.com/sonyxperiadev/kernel/pull/2216)

I am currently testing this for Kugo/Loire. Other device/platform tests would be nice.