### PR TITLE
[DONOTMERGE/PLEASEDISCUSS] sensors: Remove /data dependencies for earlier start

### DIFF
--- a/rootdir/vendor/etc/init/sensors.rc
+++ b/rootdir/vendor/etc/init/sensors.rc
@@ -1,10 +1,4 @@
 on post-fs-data
-    # Sensors
-    mkdir /data/vendor/sensors 0775 system system
-
-    # LEGACY: Sensors
-    mkdir /data/misc/sensors 0775 system system
-
     # Fix sensors permissions
     chown system system /persist/sensors
 
@@ -18,19 +12,10 @@ on post-fs-data
 
 # Sensor service
 service sensors /odm/bin/sensors.qcom
-    class late_start
+    class core
     user system
     group system
     disabled
 
-# Start the service for unecrypted devices
-on property:ro.crypto.state=unencrypted
+on property:sys.qcom.devup=1
     enable sensors
-
-# Enable the service for FBE devices
-on property:ro.crypto.type=file
-    enable sensors
-
-# Start the service for FDE devices
-on property:vold.decrypt=trigger_post_fs_data
-    start sensors


### PR DESCRIPTION
Fixes https://github.com/sonyxperiadev/bug_tracker/issues/515

> Sensors do not seem to depend on data files at all, only persist is
> (supposed to be) used. Aside from that starting the service this late
> (after the FDE decryption password has been entered) seems too late to
> get sensors working properly.
>
> This patch enables the service as soon as the dsp is up (devup=1) and
> moves the service to the core class to be started early and never
> restarted when /data is mounted. Furthermore enabling the service rather
> than explicitly starting it allows the service to be restarted in the
> event of a crash.
> 
> Aside from that folder creation is removed, which does not seem to be
> necessary.
> 