### PR TITLE
[COMMON] vintf: Add IMS Services CallInfo and IMSRTPService HIDL

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -167,6 +167,7 @@ endif
 ifeq ($(TARGET_USE_QCRILD),true)
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.radio.config.xml
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.hw.radio.uceservice.xml
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.hw.imsservices.xml
 endif
 
 ifeq ($(TARGET_KEYMASTER_V4),true)

--- a/vintf/vendor.hw.imsservices.xml
+++ b/vintf/vendor.hw.imsservices.xml
@@ -1,0 +1,22 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>vendor.qti.ims.callinfo</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IService</name>
+            <instance>default</instance>
+        </interface>
+        <fqname>@1.0::IService/default</fqname>
+    </hal>
+    <hal format="hidl">
+        <name>vendor.qti.imsrtpservice</name>
+        <transport>hwbinder</transport>
+        <version>2.1</version>
+        <interface>
+            <name>IRTPService</name>
+            <instance>imsrtpservice</instance>
+        </interface>
+        <fqname>@2.1::IRTPService/imsrtpservice</fqname>
+    </hal>
+</manifest>


### PR DESCRIPTION
These HALs are required in order to get IMS services up and
running.