### PR TITLE
common-prop: Sync SurfaceFlinger props

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -66,6 +66,15 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     debug.sf.latch_unsignaled=1
 
+# SurfaceFlinger
+# Keep uppercase makevars like TARGET_FORCE_HWC_FOR_VIRTUAL_DISPLAYS
+# in sync, use hardware/interfaces/configstore/1.1/default/surfaceflinger.mk
+# as a reference
+# ConfigStore is being deprecated and sf is moving to props, see
+# frameworks/native/services/surfaceflinger/sysprop/SurfaceFlingerProperties.sysprop
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.surface_flinger.force_hwc_copy_for_virtual_displays=true
+
 # Disable buffer age (b/74534157)
 PRODUCT_PROPERTY_OVERRIDES += \
     debug.hwui.use_buffer_age=false
@@ -122,7 +131,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Property to choose between virtual/external wfd display
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.sys.wfd.virtual=0
-    
+
 # Display properties
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.demo.hdmirotationlock=false \


### PR DESCRIPTION
Until Pie, the `ConfigStore` HAL was supposed to configure `SurfaceFlinger`.
Google, in their infinite wisdom, got bored of this approach and decided that sysprops (which
ConfigStore was supposed to supplant, because of their _obvious drawbacks) were once again all the rage.

The ConfigStore HAL is being deprecated and will apparently be removed in R, see [the deprecation notice](https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-10.0.0_r33/configstore/README.md).

Translate the uppercase makevars that [`surfaceflinger.mk`](https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-10.0.0_r33/configstore/1.1/default/surfaceflinger.mk) used to supply as cflags to configstore internals to sysprops.

```
force_hwc_copy_for_virtual_displays = TARGET_FORCE_HWC_FOR_VIRTUAL_DISPLAYS
max_frame_buffer_acquired_buffers = NUM_FRAMEBUFFER_SURFACE_BUFFERS
```

Note: The uppercase vars must be kept because `hardware/qcom/display` still relies on them at build time.

Further adjustments follow in the platform repos.
`max_frame_buffer_acquired_buffers` will be overriden there for most devices.

For reference:
[SurfaceFlingerProperties.sysprop](https://android.googlesource.com/platform/frameworks/native/+/refs/tags/android-10.0.0_r33/services/surfaceflinger/sysprop/SurfaceFlingerProperties.sysprop)