### PR TITLE
[COMMON] common-treble: Update audio to 5.0

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -43,9 +43,9 @@ PRODUCT_PACKAGES += \
 
 # Audio
 PRODUCT_PACKAGES += \
-    android.hardware.audio@4.0-impl:32 \
+    android.hardware.audio@5.0-impl:32 \
     android.hardware.audio@2.0-service \
-    android.hardware.audio.effect@4.0-impl:32 \
+    android.hardware.audio.effect@5.0-impl:32 \
     android.hardware.soundtrigger@2.1-impl:32
 
 # Camera


### PR DESCRIPTION
This is required on new platforms, such as SM8150.