### PR TITLE
[COMMON] Configure modem properly on qcrild and for IMS

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -62,7 +62,8 @@ PRODUCT_PROPERTY_OVERRIDES +=
     persist.vendor.radio.wait_for_pbm=1 \
     persist.vendor.radio.mt_sms_ack=19 \
     persist.vendor.radio.enableadvancedscan=true \
-    persist.vendor.radio.unicode_op_names=true
+    persist.vendor.radio.unicode_op_names=true \
+    persist.vendor.radio.sib16_support=1
 
 # Ringer
 PRODUCT_PROPERTY_OVERRIDES += \

--- a/common-prop.mk
+++ b/common-prop.mk
@@ -57,6 +57,13 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.vendor.radio.vdp_on_ims_cap=1 \
     persist.vendor.radio.report_codec=1
 
+# Modem properties
+PRODUCT_PROPERTY_OVERRIDES +=
+    persist.vendor.radio.wait_for_pbm=1 \
+    persist.vendor.radio.mt_sms_ack=19 \
+    persist.vendor.radio.enableadvancedscan=true \
+    persist.vendor.radio.unicode_op_names=true
+
 # Ringer
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.telephony.call_ring.multiple=false

--- a/common-prop.mk
+++ b/common-prop.mk
@@ -52,6 +52,11 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.vendor.radio.apm_sim_not_pwdn=1 \
     persist.vendor.radio.oem_socket=false
 
+# IMS
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.vendor.radio.vdp_on_ims_cap=1 \
+    persist.vendor.radio.report_codec=1
+
 # Ringer
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.telephony.call_ring.multiple=false


### PR DESCRIPTION
IMS needs some other properties to be set.... also, qcrild supports some nice
features, which are definitely supported on all platforms.

For more informations on what, how, when and why, refer to the
descriptions for each commit in this patchset.


Tested on SoMC Kumano Griffin DSDS