### PR TITLE
[COMMON] common-prop: Temporarily disable audio@5.0 bluetooth HAL

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -124,6 +124,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.lmk.kill_timeout_ms=100 \
     ro.lmk.use_minfree_levels=true
 
+# Bluetooth Audio
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.bluetooth.bluetooth_audio_hal.disabled=true
+
 # Property to enable user to access Google WFD settings.
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.debug.wfd.enable=0


### PR DESCRIPTION
Audio v5 includes a new HAL and way to register bluetooth endpoints
(bluetooth.audio@2.0) and their transmission, which is used by newer
bluetooth audio libs. This obviously requires different audio policy to
route BT streams to said libs, which has not been included in the V5
bump.
Instead of switching that around, allow me to finalize A2DP offloading
(finally) and PR the entire, proper switch at once. Meanwhile, disable
this new way of registering endpoints.