### PR TITLE
[R] rootdir: usb.rc: Drop load_system_props

### DIFF
--- a/rootdir/vendor/etc/init/init.usb.rc
+++ b/rootdir/vendor/etc/init/init.usb.rc
@@ -13,8 +13,6 @@
 # limitations under the License.
 #
 on charger
-    load_system_props
-
     mount configfs none /config
     mkdir /config/usb_gadget/g1 0770 shell shell
     mkdir /config/usb_gadget/g1/strings/0x409 0770 shell shell


### PR DESCRIPTION
This has been a no-op for a long time and will throw an error in Android R.

See https://android.googlesource.com/platform/system/core/+/refs/tags/android-10.0.0_r33/init/builtins.cpp#1056