### PR TITLE
[R] packages: Add protobuf vendorcompat lib

### DIFF
--- a/common-packages.mk
+++ b/common-packages.mk
@@ -121,6 +121,11 @@ PRODUCT_PACKAGES += \
     libandroid_net \
     libprotobuf-cpp-full
 
+# FIXME: master: compat for libprotobuf
+# See https://android-review.googlesource.com/c/platform/prebuilts/vndk/v28/+/1109518
+PRODUCT_PACKAGES += \
+    libprotobuf-cpp-full-vendorcompat
+
 # RenderScript
 PRODUCT_PACKAGES += \
     librsjni

--- a/common.mk
+++ b/common.mk
@@ -98,7 +98,8 @@ PRODUCT_COPY_FILES += \
     frameworks/av/services/audiopolicy/config/r_submix_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/r_submix_audio_policy_configuration.xml \
     frameworks/av/services/audiopolicy/config/usb_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/usb_audio_policy_configuration.xml
 
-# Public Libraries
+# Additional native libraries
+# See https://source.android.com/devices/tech/config/namespaces_libraries
 PRODUCT_COPY_FILES += \
     $(COMMON_PATH)/rootdir/vendor/etc/public.libraries.txt:$(TARGET_COPY_OUT_VENDOR)/etc/public.libraries.txt
 

--- a/rootdir/vendor/etc/public.libraries.txt
+++ b/rootdir/vendor/etc/public.libraries.txt
@@ -4,3 +4,4 @@ libsdsprpc.so
 libOpenCL.so
 libaptX_encoder.so
 libaptXHD_encoder.so
+libprotobuf-cpp-full.so


### PR DESCRIPTION
Our blobs are compiled against `libprotobuf-full-cpp.so`, but starting in R, Android is using a versioned naming approach, e.g. `libprotobuf-cpp-full-3.9.1.so`.

See https://r.android.com/1109518

The entry in `public.libraries.txt` is needed to allow the linker to find and use the lib outside the VNDK.

See https://source.android.com/devices/tech/config/namespaces_libraries