### PR TITLE
[COMMON] [Q-LEGACY] Bump audio to 5.0, provide policy config

### DIFF
--- a/common-packages.mk
+++ b/common-packages.mk
@@ -15,6 +15,8 @@
 # Audio
 PRODUCT_PACKAGES += \
     audio.a2dp.default \
+    audio.bluetooth.default \
+    audio.hearing_aid.default \
     audio.r_submix.default \
     audio.usb.default \
     libaudio-resampler

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -46,7 +46,7 @@ PRODUCT_PACKAGES += \
     android.hardware.audio@5.0-impl:32 \
     android.hardware.audio@2.0-service \
     android.hardware.audio.effect@5.0-impl:32 \
-    android.hardware.soundtrigger@2.1-impl:32
+    android.hardware.soundtrigger@2.2-impl
 
 # Camera
 ifeq ($(TARGET_USES_64BIT_CAMERA),true)

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -46,6 +46,7 @@ PRODUCT_PACKAGES += \
     android.hardware.audio@5.0-impl:32 \
     android.hardware.audio@2.0-service \
     android.hardware.audio.effect@5.0-impl:32 \
+    android.hardware.bluetooth.audio@2.0-impl \
     android.hardware.soundtrigger@2.2-impl
 
 # Camera

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -43,9 +43,9 @@ PRODUCT_PACKAGES += \
 
 # Audio
 PRODUCT_PACKAGES += \
-    android.hardware.audio@4.0-impl:32 \
+    android.hardware.audio@5.0-impl:32 \
     android.hardware.audio@2.0-service \
-    android.hardware.audio.effect@4.0-impl:32 \
+    android.hardware.audio.effect@5.0-impl:32 \
     android.hardware.soundtrigger@2.1-impl:32
 
 # Camera

--- a/common.mk
+++ b/common.mk
@@ -87,7 +87,9 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     $(COMMON_PATH)/rootdir/vendor/etc/audio_effects.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_effects.xml \
     frameworks/av/services/audiopolicy/config/a2dp_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/a2dp_audio_policy_configuration.xml \
+    frameworks/av/services/audiopolicy/config/a2dp_in_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/a2dp_in_audio_policy_configuration.xml \
     frameworks/av/services/audiopolicy/config/audio_policy_volumes.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_volumes.xml \
+    frameworks/av/services/audiopolicy/config/bluetooth_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/bluetooth_audio_policy_configuration.xml \
     frameworks/av/services/audiopolicy/config/default_volume_tables.xml:$(TARGET_COPY_OUT_VENDOR)/etc/default_volume_tables.xml \
     frameworks/av/services/audiopolicy/config/r_submix_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/r_submix_audio_policy_configuration.xml \
     frameworks/av/services/audiopolicy/config/usb_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/usb_audio_policy_configuration.xml

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -2,7 +2,7 @@
     <hal format="hidl">
         <name>android.hardware.audio</name>
         <transport>hwbinder</transport>
-        <version>4.0</version>
+        <version>5.0</version>
         <interface>
             <name>IDevicesFactory</name>
             <instance>default</instance>
@@ -11,7 +11,7 @@
     <hal format="hidl">
         <name>android.hardware.audio.effect</name>
         <transport>hwbinder</transport>
-        <version>4.0</version>
+        <version>5.0</version>
         <interface>
             <name>IEffectsFactory</name>
             <instance>default</instance>

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -36,6 +36,15 @@
         </interface>
     </hal>
     <hal format="hidl">
+        <name>android.hardware.bluetooth.audio</name>
+        <transport>hwbinder</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IBluetoothAudioProvidersFactory</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
         <name>android.hardware.camera.provider</name>
         <transport>hwbinder</transport>
         <version>2.4</version>

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -183,7 +183,7 @@
     <hal format="hidl">
         <name>android.hardware.soundtrigger</name>
         <transport>hwbinder</transport>
-        <version>2.1</version>
+        <version>2.2</version>
         <interface>
             <name>ISoundTriggerHw</name>
             <instance>default</instance>


### PR DESCRIPTION
@stefanhh0 I woke up realising that the new 5.0 policy was PR'd by me to legacy platforms:

https://github.com/sonyxperiadev/device-sony-loire/pull/266
https://github.com/sonyxperiadev/device-sony-tone/pull/193

... without updating the legacy common branch too.

Can you and the other Loire/Tone @ Android10 users validate that there is audio, both from speakers, wired and bluetooth headphones, as well as in calls and such?