### PR TITLE
vintf: Align NFC

### DIFF
--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -156,7 +156,7 @@
     <hal format="hidl">
         <name>android.hardware.nfc</name>
         <transport>hwbinder</transport>
-        <version>1.1</version>
+        <version>1.2</version>
         <interface>
             <name>INfc</name>
             <instance>default</instance>

--- a/vintf/vendor.nxp.nfc.interfaces.xml
+++ b/vintf/vendor.nxp.nfc.interfaces.xml
@@ -2,7 +2,7 @@
     <hal format="hidl">
         <name>vendor.nxp.nxpnfc</name>
         <transport>hwbinder</transport>
-        <version>1.1</version>
+        <version>1.0</version>
         <interface>
             <name>INxpNfc</name>
             <instance>default</instance>


### PR DESCRIPTION
### Align INfc version, fix INxpNfc version

We are shiping the 1.2 nxp nfc service now.
The vendor.nxp version was wrong, there is no @1.1 interface as of now.