### PR TITLE
hw: qcom: do not explictly include hals

### DIFF
--- a/hardware/qcom/Android.mk
+++ b/hardware/qcom/Android.mk
@@ -5,6 +5,9 @@ else
 # TARGET_BOARD_PLATFORM specific featurization
 QCOM_BOARD_PLATFORMS += msm8952 msm8996 msm8998 sdm660 sdm845 sm8150
 
+# Some supported platforms need a different media hal
+# This list selects platforms that should use the latest media hal
+# All other platforms automatically fallback to the legacy hal
 QCOM_NEW_MEDIA_PLATFORM := sdm845 sm8150
 
 #List of targets that use video hw
@@ -15,14 +18,14 @@ MASTER_SIDE_CP_TARGET_LIST := msm8996 msm8998 sdm660 sdm845 sm8150
 
 audio-hal := hardware/qcom/audio
 gps-hal := hardware/qcom/gps/sdm845
-ipa-hal := hardware/qcom/data/ipacfg-mgr/sdm845
+ipa-hal := vendor/qcom/opensource/data/ipacfg-mgr/sdm845
 
-display-hal := hardware/qcom/display/sde
+display-hal := vendor/qcom/opensource/display
 
 ifneq ($(filter $(QCOM_NEW_MEDIA_PLATFORM), $(TARGET_BOARD_PLATFORM)),)
-QCOM_MEDIA_ROOT := hardware/qcom/media/sm8150
+QCOM_MEDIA_ROOT := vendor/qcom/opensource/media/sm8150
 else
-QCOM_MEDIA_ROOT := hardware/qcom/media/sdm660-libion
+QCOM_MEDIA_ROOT := vendor/qcom/opensource/media/sdm660-libion
 endif
 
 OMX_VIDEO_PATH := mm-video-v4l2
@@ -35,9 +38,6 @@ TARGET_KERNEL_VERSION := $(SOMC_KERNEL_VERSION)
 
 include device/sony/common/hardware/qcom/utils.mk
 
-include $(display-hal)/Android.mk
 include $(call all-makefiles-under,$(audio-hal))
-include $(call first-makefiles-under,$(ipa-hal))
 include $(call all-makefiles-under,$(gps-hal))
-include $(call all-makefiles-under,$(media-hal))
 endif


### PR DESCRIPTION
Display, media and ipa hals are now automatically included by the build system.
Explictly including them leads to double module definitions.
Additionally, add a brief documentationfor QCOM_NEW_MEDIA_PLATFORM.