### PR TITLE
common-prop: Disable PartyCrasher - don't reboot to recovery for wipe

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -215,3 +215,8 @@ endif
 # Reduce cost of scrypt for FBE CE decryption
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.crypto.scrypt_params=15:3:1
+
+# Disable PartyCrasher: No need to reboot to recovery
+# and request a wipe when something is broken.
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.sys.disable_rescue=1


### PR DESCRIPTION
Seriously. A boot-to-recovery instead of an _at least partially working_
device? /shrug.

The intention is to clean the device and at last resort request the user
to wipe their phone in an attempt to recover the device.

In our case this is hardly ever a solution: rather we want to get to the
bottom of an issue/crash and resolve it, as we have the ability to do so
on an open platform.

I have personally not seen these "recovery attempts" yet, rather an
immediate reboot to recovery, hiding actual issues at hand (90% of the
time sensors missing -> transpower crashing -> taking the core phone
process with it).

See the docs for more info:
https://source.android.com/devices/tech/debug/rescue-party

---

Partycrasher is a [common](https://github.com/sonyxperiadev/bug_tracker/issues/471#issuecomment-535959689) [way](https://github.com/sonyxperiadev/bug_tracker/issues/580) [to](https://github.com/sonyxperiadev/bug_tracker/issues/351#issuecomment-531491110) [hide](https://github.com/sonyxperiadev/bug_tracker/issues/572#issuecomment-622357146) issues from us. Let's disable it and save ourselves the hassle sorting through logs and figure out the device isn't actually rebooting due to hardware errors.

One reason to not merge this: Issues might be harder to spot. While crashing `com.android.phone` _should_ show on the screen, I don't recall seeing it nor did any of the report indicate such. That means the device drains a ton of energy, and when you're finally outside and need to make an emergency call...