### PR TITLE
[COMMON] [PART1] VoLTE/VT/WFC + DPM/TCM/CnE enablement

### DIFF
--- a/common-packages.mk
+++ b/common-packages.mk
@@ -67,6 +67,16 @@ PRODUCT_PACKAGES += \
     libloc_ds_api \
     libgnsspps
 
+# IMS (OSS)
+PRODUCT_PACKAGES += \
+    qti-telephony-hidl-wrapper \
+    qti_telephony_hidl_wrapper.xml \
+    qti-telephony-utils \
+    qti_telephony_utils.xml \
+    telephony-ext \
+    ims-ext-common \
+    ims_ext_common.xml
+
 # IPA
 PRODUCT_PACKAGES += \
     libqti_vndfwk_detect.vendor \

--- a/common-prop.mk
+++ b/common-prop.mk
@@ -62,7 +62,8 @@ PRODUCT_PROPERTY_OVERRIDES +=
     persist.vendor.radio.mt_sms_ack=19 \
     persist.vendor.radio.enableadvancedscan=true \
     persist.vendor.radio.unicode_op_names=true \
-    persist.vendor.radio.sib16_support=1
+    persist.vendor.radio.sib16_support=1 \
+    persist.vendor.radio.oem_socket=true
 
 # Ringer
 PRODUCT_PROPERTY_OVERRIDES += \

--- a/common-prop.mk
+++ b/common-prop.mk
@@ -60,7 +60,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.vendor.radio.report_codec=1
 
 # Modem properties
-PRODUCT_PROPERTY_OVERRIDES +=
+PRODUCT_PROPERTY_OVERRIDES += \
     persist.vendor.radio.wait_for_pbm=1 \
     persist.vendor.radio.mt_sms_ack=19 \
     persist.vendor.radio.enableadvancedscan=true \

--- a/common-prop.mk
+++ b/common-prop.mk
@@ -51,6 +51,14 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.vendor.radio.add_power_save=1 \
     persist.vendor.radio.apm_sim_not_pwdn=1
 
+# Enable advanced power saving for data connectivity
+# DPM: Data Port Mapper, with TCM (TCP Connection Manager)
+# CnE: Connectivity Engine
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.vendor.dpm.feature=1 \
+    persist.vendor.dpm.tcm=1 \
+    persist.vendor.cne.feature=1
+
 # IMS
 # P.S.: va_{aosp,odm} is necessary to load imscmservice
 PRODUCT_PROPERTY_OVERRIDES += \

--- a/common-prop.mk
+++ b/common-prop.mk
@@ -43,6 +43,7 @@ endif
 # System props for the data modules
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.vendor.use_data_netmgrd=true \
+    persist.vendor.data.mode=concurrent \
     persist.data.netmgrd.qos.enable=true \
     ro.data.large_tcp_window_size=true
 

--- a/common-prop.mk
+++ b/common-prop.mk
@@ -68,6 +68,15 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.vendor.radio.vdp_on_ims_cap=1 \
     persist.vendor.radio.report_codec=1
 
+# VoLTE / VT / WFC
+# These properties will force availability of the VoLTE,
+# VideoTelephony and Wi-Fi Call, without needing carrier
+# services provisioning sites hooked up: simplifies it.
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.dbg.volte_avail_ovr=1 \
+    persist.dbg.vt_avail_ovr=1  \
+    persist.dbg.wfc_avail_ovr=1
+
 # Modem properties
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.vendor.radio.wait_for_pbm=1 \

--- a/common-prop.mk
+++ b/common-prop.mk
@@ -52,7 +52,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.vendor.radio.apm_sim_not_pwdn=1
 
 # IMS
+# P.S.: va_{aosp,odm} is necessary to load imscmservice
 PRODUCT_PROPERTY_OVERRIDES += \
+    ro.vendor.qti.va_aosp.support=1 \
+    ro.vendor.qti.va_odm.support=1 \
     persist.vendor.radio.vdp_on_ims_cap=1 \
     persist.vendor.radio.report_codec=1
 


### PR DESCRIPTION
This is the first big part to enable IMS functionalities, including VoLTE,
VideoTelephony and Wi-Fi Calling, and other important power saving
and enhancements for mobile data connectivity, including:

- Connectivity Engine (CnE)
- DPM (Data Path Manager) with:
--- Fast Dormancy (FD)
--- TCP Connection Manager (TCM)

Note that there would be too many comments to do on this patchset,
so, if you want more informations about what's in the works, PLEASE,
refer to the commit messages of this patchset.

WARNING: This is PART 1. This is SAFE TO MERGE right now, but obviously
the functionalities will not work without the proper binaries.

Enjoy!  