### PR TITLE
[COMMON] [PART2] Allow new data/radio VINTFs to load

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -168,6 +168,7 @@ ifeq ($(TARGET_USE_QCRILD),true)
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.radio.config.xml
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.hw.radio.uceservice.xml
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.hw.imsservices.xml
+DEVICE_MANIFEST_FILE += ${COMMON_PATH}/vintf/vendor.hw.dataservices.xml
 endif
 
 ifeq ($(TARGET_KEYMASTER_V4),true)

--- a/common-init.mk
+++ b/common-init.mk
@@ -16,11 +16,13 @@
 PRODUCT_PACKAGES += \
     init.usb.rc \
     adb_tcp.rc \
+    adpl.rc \
     adsprpcd.rc \
     audiopd.rc \
     cdsprpcd.rc \
     cnss-daemon.rc \
     ipacm.rc \
+    dataqti.rc \
     dpmQmiMgr.rc \
     imsdatadaemon.rc \
     imsqmidaemon.rc \

--- a/common-init.mk
+++ b/common-init.mk
@@ -24,6 +24,7 @@ PRODUCT_PACKAGES += \
     ipacm.rc \
     dataqti.rc \
     dpmQmiMgr.rc \
+    dpmd.rc \
     imsdatadaemon.rc \
     imsqmidaemon.rc \
     imsrcsd.rc \

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -228,6 +228,22 @@ LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 
 include $(CLEAR_VARS)
+LOCAL_MODULE := adpl.rc
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES := vendor/etc/init/adpl.rc
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := qti.rc
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES := vendor/etc/init/qti.rc
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE := qseecom.rc
 LOCAL_MODULE_CLASS := ETC
 LOCAL_SRC_FILES := vendor/etc/init/qseecom.rc

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -244,6 +244,14 @@ LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 
 include $(CLEAR_VARS)
+LOCAL_MODULE := dpm.rc
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES := vendor/etc/init/dpmd.rc
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE := qseecom.rc
 LOCAL_MODULE_CLASS := ETC
 LOCAL_SRC_FILES := vendor/etc/init/qseecom.rc

--- a/rootdir/vendor/etc/init/adpl.rc
+++ b/rootdir/vendor/etc/init/adpl.rc
@@ -1,0 +1,6 @@
+#start dataadpl service
+service vendor.dataadpl /odm/bin/adpl
+    class main
+    user radio
+    socket adpl_cmd_uds_file dgram 660 radio radio
+    group radio diag usb inet

--- a/rootdir/vendor/etc/init/dataqti.rc
+++ b/rootdir/vendor/etc/init/dataqti.rc
@@ -1,0 +1,12 @@
+# msm specific files that need to be created on /data
+on post-fs-data
+    #Create DATAQTI dir for logs
+    mkdir /data/vendor/dataqti 0770 radio radio
+    chmod 0770 /data/vendor/dataqti
+
+#start dataqti service
+service vendor.dataqti /odm/bin/qti
+    class main
+    user radio
+    socket qti_dpm_uds_file dgram 660 radio radio
+    group radio diag usb inet

--- a/rootdir/vendor/etc/init/dpmd.rc
+++ b/rootdir/vendor/etc/init/dpmd.rc
@@ -1,0 +1,12 @@
+# Create the directories used by DPM subsystem
+on post-fs-data
+    mkdir /data/dpm 0771 system system
+    chown system system /data/dpm
+
+#start dpmd service
+service dpmd /odm/bin/dpmd
+    class late_start
+    socket dpmd stream 660 root radio
+    socket tcm  stream 660 root inet
+    socket dpmwrapper stream 660 root inet
+    group system readproc inet radio wakelock

--- a/vintf/vendor.hw.dataservices.xml
+++ b/vintf/vendor.hw.dataservices.xml
@@ -1,0 +1,12 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>vendor.qti.dpm.api</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::IdpmQmi/dpmQmiService</fqname>
+    </hal>
+    <hal format="hidl">
+        <name>vendor.qti.data.factory</name>
+        <transport>hwbinder</transport>
+        <fqname>@2.0::IFactory/default</fqname>
+    </hal>
+</manifest>

--- a/vintf/vendor.hw.imsservices.xml
+++ b/vintf/vendor.hw.imsservices.xml
@@ -19,4 +19,14 @@
         </interface>
         <fqname>@2.1::IRTPService/imsrtpservice</fqname>
     </hal>
+    <hal format="hidl">
+        <name>com.qualcomm.qti.imscmservice</name>
+        <transport>hwbinder</transport>
+        <version>2.2</version>
+        <interface>
+            <name>IImsCmService</name>
+            <instance>qti.ims.connectionmanagerservice</instance>
+        </interface>
+        <fqname>@2.2::IImsCmService/qti.ims.connectionmanagerservice</fqname>
+    </hal>
 </manifest>

--- a/vintf/vendor.hw.radio_ds.xml
+++ b/vintf/vendor.hw.radio_ds.xml
@@ -28,6 +28,8 @@
         <transport>hwbinder</transport>
         <fqname>@1.0::IQtiRadio/slot1</fqname>
         <fqname>@1.0::IQtiRadio/slot2</fqname>
+        <fqname>@2.3::IQtiRadio/slot1</fqname>
+        <fqname>@2.3::IQtiRadio/slot2</fqname>
     </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.data.iwlan</name>

--- a/vintf/vendor.hw.radio_ds.xml
+++ b/vintf/vendor.hw.radio_ds.xml
@@ -30,6 +30,12 @@
         <fqname>@1.0::IQtiRadio/slot2</fqname>
     </hal>
     <hal format="hidl">
+        <name>vendor.qti.hardware.data.iwlan</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::IIWlan/slot1</fqname>
+        <fqname>@1.0::IIWlan/slot2</fqname>
+    </hal>
+    <hal format="hidl">
         <name>vendor.qti.hardware.radio.uim</name>
         <transport>hwbinder</transport>
         <fqname>@1.2::IUim/Uim0</fqname>

--- a/vintf/vendor.hw.radio_ds.xml
+++ b/vintf/vendor.hw.radio_ds.xml
@@ -32,6 +32,12 @@
         <fqname>@2.3::IQtiRadio/slot2</fqname>
     </hal>
     <hal format="hidl">
+        <name>vendor.qti.hardware.data.connection</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.1::IDataConnection/slot1</fqname>
+        <fqname>@1.1::IDataConnection/slot2</fqname>
+    </hal>
+    <hal format="hidl">
         <name>vendor.qti.hardware.data.iwlan</name>
         <transport>hwbinder</transport>
         <fqname>@1.0::IIWlan/slot1</fqname>

--- a/vintf/vendor.hw.radio_ss.xml
+++ b/vintf/vendor.hw.radio_ss.xml
@@ -23,6 +23,7 @@
         <name>vendor.qti.hardware.radio.qtiradio</name>
         <transport>hwbinder</transport>
         <fqname>@1.0::IQtiRadio/slot1</fqname>
+        <fqname>@2.3::IQtiRadio/slot1</fqname>
     </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.data.iwlan</name>

--- a/vintf/vendor.hw.radio_ss.xml
+++ b/vintf/vendor.hw.radio_ss.xml
@@ -26,6 +26,11 @@
         <fqname>@2.3::IQtiRadio/slot1</fqname>
     </hal>
     <hal format="hidl">
+        <name>vendor.qti.hardware.data.connection</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.1::IDataConnection/slot1</fqname>
+    </hal>
+    <hal format="hidl">
         <name>vendor.qti.hardware.data.iwlan</name>
         <transport>hwbinder</transport>
         <fqname>@1.0::IIWlan/slot1</fqname>

--- a/vintf/vendor.hw.radio_ss.xml
+++ b/vintf/vendor.hw.radio_ss.xml
@@ -25,6 +25,11 @@
         <fqname>@1.0::IQtiRadio/slot1</fqname>
     </hal>
     <hal format="hidl">
+        <name>vendor.qti.hardware.data.iwlan</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::IIWlan/slot1</fqname>
+    </hal>
+    <hal format="hidl">
         <name>vendor.qti.hardware.radio.uim</name>
         <transport>hwbinder</transport>
         <fqname>@1.2::IUim/Uim0</fqname>


### PR DESCRIPTION
This is the PART2 patchset to allow loading the new VINTFs for IMS and
data services directly or indirectly required by it.

This PR is safe to merge, as these services are present in all ODM versions.