### PR TITLE
[COMMON] CommonConfig: Allow adding manifest/matrix from customization

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -140,8 +140,8 @@ endif
 # SELinux
 include device/sony/sepolicy/sepolicy.mk
 
-DEVICE_MANIFEST_FILE := $(COMMON_PATH)/vintf/manifest.xml
-DEVICE_MATRIX_FILE   := $(COMMON_PATH)/vintf/compatibility_matrix.xml
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/manifest.xml
+DEVICE_MATRIX_FILE   += $(COMMON_PATH)/vintf/compatibility_matrix.xml
 
 # Custom NXP vendor interfaces
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.nxp.nfc.interfaces.xml


### PR DESCRIPTION
Change := to += for DEVICE_MANIFEST_FILE and DEVICE_MATRIX_FILE
so that we are allowed to add manifest/matrix files from the external
customization repository, if present.