### PR TITLE
[R] Explicitly enable traditional boot.img

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -27,6 +27,10 @@ TARGET_NO_BOOTLOADER := true
 TARGET_NO_RECOVERY ?= false
 TARGET_NO_KERNEL := false
 
+# Android R: Disable logic for new vendor_boot
+# Our devices do not support it
+TARGET_NO_VENDOR_BOOT := true
+
 # common cmdline parameters
 ifneq ($(BOARD_USE_ENFORCING_SELINUX),true)
 BOARD_KERNEL_CMDLINE += androidboot.selinux=permissive

--- a/common.mk
+++ b/common.mk
@@ -49,6 +49,9 @@ PRODUCT_PACKAGES += \
 # Force building a recovery image: Needed for OTA packaging to work since Q
 PRODUCT_BUILD_RECOVERY_IMAGE := true
 
+# Force building a boot image. This needs to be set explicitly since Android R
+PRODUCT_BUILD_BOOT_IMAGE := true
+
 KERNEL_PATH := kernel/sony/msm-$(SOMC_KERNEL_VERSION)
 # Sanitized prebuilt kernel headers
 -include $(KERNEL_PATH)/common-headers/KernelHeaders.mk


### PR DESCRIPTION
Yes, the new release is approaching and you know what that means: Groundhog Day!
Once again, Android is not respecting a make target in favour of some highfalutin new endeavour, this time "vendor_boot".

Set building `vendor_boot.img` to false and actually re-enable building of `boot.img` for non-`RECOVERY_AS_BOOT` devices when you `make bootimg`.