### PR TITLE
rootdir: Fix dpmd module name

### DIFF
--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -244,7 +244,7 @@ LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 
 include $(CLEAR_VARS)
-LOCAL_MODULE := dpm.rc
+LOCAL_MODULE := dpmd.rc
 LOCAL_MODULE_CLASS := ETC
 LOCAL_SRC_FILES := vendor/etc/init/dpmd.rc
 LOCAL_MODULE_TAGS := optional


### PR DESCRIPTION
The file is named dpmd.rc, as is the dependency on it in common-init.mk.

Fixes: fa14c9db6b4a6fd837eb771728e51cb7bc8eaa14

---
Another joker, just like https://github.com/sonyxperiadev/device-sony-common/pull/734 :)