### PR TITLE
[COMMON] vintf: Add com.qualcomm.qti.dpm.api::IdpmQmi@1.0

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -149,6 +149,9 @@ DEVICE_MATRIX_FILE   += $(COMMON_PATH)/vintf/compatibility_matrix.xml
 # Custom NXP vendor interfaces
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.nxp.nfc.interfaces.xml
 
+# Dynamic Power Management
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.qualcomm.qti.dpm.xml
+
 ifeq ($(PRODUCT_DEVICE_DS),true)
 ifeq ($(TARGET_USE_QCRILD),true)
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hw.qcradio_ds.xml

--- a/vintf/vendor.qualcomm.qti.dpm.xml
+++ b/vintf/vendor.qualcomm.qti.dpm.xml
@@ -1,0 +1,7 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>com.qualcomm.qti.dpm.api</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::IdpmQmi/dpmQmiService</fqname>
+    </hal>
+</manifest>


### PR DESCRIPTION
This new interface is hosted by dpmQmiMgr and used by dpmd.

See also https://github.com/sonyxperiadev/device-sony-sepolicy/pull/567 for the backing policy.

TODO: Is there a more sensible file to move this into?