### PR TITLE
[r-mr1] health: Add to recovery, use vintf_fragments

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -79,7 +79,8 @@ PRODUCT_PACKAGES += \
 
 # Health
 PRODUCT_PACKAGES += \
-    android.hardware.health@2.0-service.sony
+    android.hardware.health@2.0-service.sony \
+    android.hardware.health@2.0-service.sony.recovery
 
 # Sensors
 PRODUCT_PACKAGES += \

--- a/hardware/health/Android.bp
+++ b/hardware/health/Android.bp
@@ -37,14 +37,7 @@ cc_binary {
         "libbatteryservice_headers",
     ],
 
-    // Only availbale in current Android Q master.
-    // Nead to remove health section from common/vintf/manifext.xml as well
-    // once we decide to use this instead.
-    //vintf_fragments: [
-    //    "manifest_android.hardware.health@2.0.xml",
-    //],
-
-    overrides: [
-        "healthd",
+    vintf_fragments: [
+        "manifest_android.hardware.health@2.0.xml",
     ],
 }

--- a/hardware/health/Android.bp
+++ b/hardware/health/Android.bp
@@ -2,6 +2,7 @@ cc_binary {
     name: "android.hardware.health@2.0-service.sony",
     init_rc: ["android.hardware.health@2.0-service.sony.rc"],
     vendor: true,
+    recovery_available: true,
     relative_install_path: "hw",
     cflags: [
         "-Wall",

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -121,15 +121,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.health</name>
-        <transport>hwbinder</transport>
-        <version>2.0</version>
-        <interface>
-            <name>IHealth</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.media.omx</name>
         <transport>hwbinder</transport>
         <version>1.0</version>


### PR DESCRIPTION
DNM: Hold off until R when `libhealthservice` is available to recovery.

For more info: https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-r-preview-4/health/2.1/

Also don't forget to assign an sepolicy label for the recovery exec.