### PR TITLE
rootdir: Restore LOCAL_PATH call

### DIFF
--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -1,3 +1,5 @@
+LOCAL_PATH := $(call my-dir)
+
 ifeq ($(TARGET_KEYMASTER_V4), true)
 include $(CLEAR_VARS)
 LOCAL_MODULE := android.hardware.keymaster@4.0-service-qti.rc


### PR DESCRIPTION
Got lost in 35c3a0fea71f6c61ec81ea7989562ae8c1d8c954
"rootdir: Convert .mk to .bp"

Still needed because else Android's build system does not
automatically make paths relative to the file unless
LOCAL_PATH is called.