### PR TITLE
[COMMON] [WIP] [Q-MR1] Drop legacy/unstable /firmware symlink

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -51,7 +51,6 @@ TARGET_USERIMAGES_USE_EXT4 := true
 
 BOARD_ROOT_EXTRA_FOLDERS := odm
 BOARD_ROOT_EXTRA_SYMLINKS += /odm/dsp:/dsp
-BOARD_ROOT_EXTRA_SYMLINKS += /$(TARGET_COPY_OUT_VENDOR)/firmware_mnt:/firmware
 BOARD_ROOT_EXTRA_SYMLINKS += /$(TARGET_COPY_OUT_VENDOR)/bt_firmware:/bt_firmware
 BOARD_ROOT_EXTRA_SYMLINKS += /mnt/vendor/persist:/persist
 


### PR DESCRIPTION
See the PR to master for more details: https://github.com/sonyxperiadev/device-sony-common/pull/743

After fixing local projects using TZapps (fingerprint) and enabling
ueventd to read firmware directly from /vendor/firmware_mnt/image/ it is
now time to drop this unstable symlink and watch our devices... work
just as fine as before.
The problem with /firmware is that it resides in the root partition;
and may be missing entirely on system-as-root GSIs. Even if it exists
sepolicy may be conflicting, disallowing files from being loaded.
Instead all our firmware should be directly referenced in /odm or
/vendor.