### PR TITLE
[COMMON] Remove /firmware and /dsp remnants, also drop /bt_firmware entirely

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -51,7 +51,6 @@ TARGET_USES_MKE2FS := true
 TARGET_USERIMAGES_USE_EXT4 := true
 
 BOARD_ROOT_EXTRA_FOLDERS := odm
-BOARD_ROOT_EXTRA_SYMLINKS += /$(TARGET_COPY_OUT_VENDOR)/bt_firmware:/bt_firmware
 BOARD_ROOT_EXTRA_SYMLINKS += /mnt/vendor/persist:/persist
 
 # Filesystem

--- a/config.fs
+++ b/config.fs
@@ -40,12 +40,6 @@ user: AID_SYSTEM
 group: AID_RADIO
 caps: NET_BIND_SERVICE
 
-[bt_firmware/]
-mode: 0771
-user: AID_SYSTEM
-group: AID_SYSTEM
-caps: 0
-
 [persist/]
 mode: 0771
 user: AID_SYSTEM

--- a/config.fs
+++ b/config.fs
@@ -40,12 +40,6 @@ user: AID_SYSTEM
 group: AID_RADIO
 caps: NET_BIND_SERVICE
 
-[firmware/]
-mode: 0771
-user: AID_SYSTEM
-group: AID_SYSTEM
-caps: 0
-
 [bt_firmware/]
 mode: 0771
 user: AID_SYSTEM

--- a/config.fs
+++ b/config.fs
@@ -52,12 +52,6 @@ user: AID_SYSTEM
 group: AID_SYSTEM
 caps: 0
 
-[dsp/]
-mode: 0771
-user: AID_MEDIA
-group: AID_MEDIA
-caps: 0
-
 [odm/]
 mode: 0755
 user: AID_ROOT


### PR DESCRIPTION
Delete `config.fs` mappings for `/dsp` and `/firmware` which are not necessary/used anymore.

Also drop `/bt_firwmware` which is not stable (SAR GSIs...) and not necessary either, as the HAL falls back to `/vendor/bt_firmware` properly. Unfortunately not gracefully though; this has to happen with big red error lines for some reason.

    E vendor.qti.bluetooth@1.0-patch_dl_manager: /bt_firmware/image/crbtfw21.tlv File Open Fail No such file or directory (2)
    I vendor.qti.bluetooth@1.0-patch_dl_manager: File open /vendor/bt_firmware/image/crbtfw21.tlv succeeded
    E vendor.qti.bluetooth@1.0-patch_dl_manager: /bt_firmware/image/crnv21.b00 File Open Fail No such file or directory (2)
    E vendor.qti.bluetooth@1.0-patch_dl_manager: /vendor/bt_firmware/image/crnv21.b00 File Opening from alternate path: Fail No such file or directory (2)
    I vendor.qti.bluetooth@1.0-patch_dl_manager: DownloadTlvFile: /bt_firmware/image/crnv21.b00: file doesn't exist, falling back to default file
    E vendor.qti.bluetooth@1.0-patch_dl_manager: /bt_firmware/image/crnv21.bin File Open Fail No such file or directory (2)
    I vendor.qti.bluetooth@1.0-patch_dl_manager: File open /vendor/bt_firmware/image/crnv21.bin succeeded
    D vendor.qti.bluetooth@1.0-data_handler: Firmware download succeded.

Let's see if that can be removed from the next vendor release.
