### PR TITLE
[COMMON] Add init and vintf declarations for the modem switcher stack

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -172,6 +172,7 @@ DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.radio.config.xml
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.hw.radio.uceservice.xml
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.hw.imsservices.xml
 DEVICE_MANIFEST_FILE += ${COMMON_PATH}/vintf/vendor.hw.dataservices.xml
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.somc.modem.xml
 endif
 
 ifeq ($(TARGET_KEYMASTER_V4),true)

--- a/common-init.mk
+++ b/common-init.mk
@@ -65,3 +65,9 @@ PRODUCT_PACKAGES += \
     init.qcom.cdspstart.sh \
     init.qcom.ipastart.sh \
     init.qcom.slpistart.sh
+
+# modemswitcher
+PRODUCT_PACKAGES += \
+    vendor.somc.hardware.miscta@1.0-service.rc \
+    vendor.somc.hardware.modemswitcher@1.0-service.rc \
+    init.sony-modem-switcher.rc

--- a/rootdir/Android.bp
+++ b/rootdir/Android.bp
@@ -233,3 +233,24 @@ prebuilt_etc {
     sub_dir: "init",
     vendor: true,
 }
+
+prebuilt_etc {
+    name: "vendor.somc.hardware.miscta@1.0-service.rc",
+    src: "vendor/etc/init/vendor.somc.hardware.miscta@1.0-service.rc",
+    sub_dir: "init",
+    vendor: true,
+}
+
+prebuilt_etc {
+    name: "vendor.somc.hardware.modemswitcher@1.0-service.rc",
+    src: "vendor/etc/init/vendor.somc.hardware.modemswitcher@1.0-service.rc",
+    sub_dir: "init",
+    vendor: true,
+}
+
+prebuilt_etc {
+    name: "init.sony-modem-switcher.rc",
+    src: "vendor/etc/init/init.sony-modem-switcher.rc",
+    sub_dir: "init",
+    vendor: true,
+}

--- a/rootdir/vendor/etc/init/init.sony-modem-switcher.rc
+++ b/rootdir/vendor/etc/init/init.sony-modem-switcher.rc
@@ -17,6 +17,13 @@ on property:persist.somc.cust.modem0=*
 on property:persist.somc.cust.modem1=*
    start modem_switcher
 
+# Map SDK-compliant vendor.* props to the binary
+on property:persist.vendor.somc.cust.modem0=*
+   setprop persist.somc.cust.modem0 ${persist.vendor.somc.cust.modem0}
+
+on property:persist.vendor.somc.cust.modem1=*
+   setprop persist.somc.cust.modem1 ${persist.vendor.somc.cust.modem1}
+
 on property:somc.cust.copy_mcfg_file=1
    mkdir /data/customization 0755 system system
    mkdir /data/customization/mcfg 0775 system system

--- a/rootdir/vendor/etc/init/init.sony-modem-switcher.rc
+++ b/rootdir/vendor/etc/init/init.sony-modem-switcher.rc
@@ -1,0 +1,31 @@
+# Copyright (C) 2018 Sony Mobile Communications Inc.
+# All rights, including trade secret rights, reserved.
+
+# SONY: Trigger modem-switcher to swap modem fs
+on boot
+    start modem_switcher
+
+on property:persist.somc.cust.modem0.debug=*
+   start modem_switcher
+
+on property:persist.somc.cust.modem1.debug=*
+   start modem_switcher
+
+on property:persist.somc.cust.modem0=*
+   start modem_switcher
+
+on property:persist.somc.cust.modem1=*
+   start modem_switcher
+
+on property:somc.cust.copy_mcfg_file=1
+   mkdir /data/customization 0755 system system
+   mkdir /data/customization/mcfg 0775 system system
+   restorecon /data/customization
+   start modem_switcher
+
+# Modem-switcher service
+service modem_switcher /odm/bin/sony-modem-switcher
+    user root
+    group root system radio
+    disabled
+    oneshot

--- a/rootdir/vendor/etc/init/vendor.somc.hardware.miscta@1.0-service.rc
+++ b/rootdir/vendor/etc/init/vendor.somc.hardware.miscta@1.0-service.rc
@@ -1,0 +1,4 @@
+service vendor.somc.hardware.miscta-1-0 /odm/bin/hw/vendor.somc.hardware.miscta@1.0-service
+   class hal trimarea
+   user system
+   group system

--- a/rootdir/vendor/etc/init/vendor.somc.hardware.modemswitcher@1.0-service.rc
+++ b/rootdir/vendor/etc/init/vendor.somc.hardware.modemswitcher@1.0-service.rc
@@ -1,0 +1,8 @@
+# Modem-switcher service
+service vendor.somc.hardware.modemswitcher-1-0 /odm/bin/hw/vendor.somc.hardware.modemswitcher@1.0-service
+    interface vendor.somc.hardware.modemswitcher@1.0::IModemSwitcher default
+    oneshot
+    disabled
+    class hal
+    user radio
+    group radio root system

--- a/vintf/vendor.somc.modem.xml
+++ b/vintf/vendor.somc.modem.xml
@@ -1,0 +1,12 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>vendor.somc.hardware.miscta</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::IMisctaGlobal/default</fqname>
+    </hal>
+    <hal format="hidl">
+        <name>vendor.somc.hardware.modemswitcher</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::IModemSwitcher/default</fqname>
+    </hal>
+</manifest>


### PR DESCRIPTION
These two services and a single binary make it possible to flash carrier-specific firmware, as found in `/vendor/firmware_mnt/image/modem_pr`. The configuration utility receives an `S###.#` value through `persist.somc.custom.modem#` which resolves to a firmware path by reading /oem/modem-config/S###.#/modem.config. If no mapping is found it defaults to the path stored in TA.
This property is set by our new `ModemConfig` application which takes care of listening for sim changes to compute the desired `S###.#` for the carrier.

Note that we should seek to get the services to look for `persist.vendor.` props in the near future, as well as a different folder containing modem files. Bind-mounting /oem isn't very convenient.

Sepolicy and the ModemConfig app will follow tomorrow.
