### PR TITLE
TEMPORARY: liblights: Disable broken "breath" feature

### DIFF
--- a/hardware/liblights/Light.cpp
+++ b/hardware/liblights/Light.cpp
@@ -215,6 +215,19 @@ int Light::setLightBacklight(const LightState &state)
     return err;
 }
 
+void Light::blinkLed(const std::string &base_path, int brightness, int onMS, int offMS)
+{
+    LOG(VERBOSE) << "Writing blinking " << brightness << " to " << base_path;
+    writeInt(base_path + "brightness", brightness);
+
+    if (brightness) {
+        writeInt(base_path + "delay_on", onMS);
+        writeInt(base_path + "delay_off", offMS);
+        // Disable breath for now: this breaks the LED entirely
+        // writeInt(base_path + "breath", 1);
+    }
+}
+
 int Light::setSpeakerLightLocked(const LightState &state)
 {
     int red, green, blue;
@@ -251,17 +264,9 @@ int Light::setSpeakerLightLocked(const LightState &state)
     writeInt(BLUE_LED_BREATH_FILE, 0);
 
     if (blink) {
-        writeInt(RED_LED_BASE   + "delay_off", offMS);
-        writeInt(GREEN_LED_BASE + "delay_off", offMS);
-        writeInt(BLUE_LED_BASE  + "delay_off", offMS);
-
-        writeInt(RED_LED_BASE   + "delay_on", onMS);
-        writeInt(GREEN_LED_BASE + "delay_on", onMS);
-        writeInt(BLUE_LED_BASE  + "delay_on", onMS);
-
-        writeInt(RED_LED_BREATH_FILE, 1);
-        writeInt(GREEN_LED_BREATH_FILE, 1);
-        writeInt(BLUE_LED_BREATH_FILE, 1);
+        blinkLed(RED_LED_BASE, red, onMS, offMS);
+        blinkLed(GREEN_LED_BASE, green, onMS, offMS);
+        blinkLed(BLUE_LED_BASE, blue, onMS, offMS);
     } else {
         writeInt(RED_LED_FILE, red);
         writeInt(GREEN_LED_FILE, green);

--- a/hardware/liblights/Light.h
+++ b/hardware/liblights/Light.h
@@ -70,15 +70,6 @@ const static std::string GREEN_LED_BREATH_FILE
 const static std::string BLUE_LED_BREATH_FILE
     = BLUE_LED_BASE + "breath";
 
-static const std::string RED_BLINK_FILE
-    = RED_LED_BASE + "blink";
-
-static const std::string GREEN_BLINK_FILE
-    = GREEN_LED_BASE + "blink";
-
-static const std::string BLUE_BLINK_FILE
-    = BLUE_LED_BASE + "blink";
-
 #ifdef DRMSDE_BACKLIGHT
 static const std::string LCD_FILE
     = "/sys/class/backlight/panel0-backlight/brightness";
@@ -132,8 +123,9 @@ private:
     int setLightBacklight(const LightState &state);
     int setLightBattery(const LightState &state);
     int setLightNotifications(const LightState &state);
-    void handleSpeakerBatteryLocked();
     int setSpeakerLightLocked(const LightState &state);
+    void blinkLed(const std::string &base_path, int brightness, int onMS, int offMS);
+    void handleSpeakerBatteryLocked();
 
     static std::string getScaledDutyPcts(int brightness);
     static int isLit(const LightState &state);


### PR DESCRIPTION
Writing 1 to the breath file makes the TRILED not work at all. Disable
it until we find time to check the kernel PWM pieces.

---

@Haxk20 As requested: please test it!

As for the desync issue, please seee if you can reproduce it, and if so apply the following patch on top and let me know whether that fixes it:
https://github.com/MarijnS95/device-sony-common/commit/might-address-desync
