### PR TITLE
common: Inherit GSI AVB pubkeys for Google GSIs

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -32,6 +32,15 @@ PRODUCT_ENFORCE_RRO_TARGETS := *
 
 PRODUCT_DEXPREOPT_SPEED_APPS += SystemUI
 
+# Google GSI public keys for /avb
+# Needed for official GSIs while maintaining AVB and vbmeta.
+$(call inherit-product, $(SRC_TARGET_DIR)/product/gsi_keys.mk)
+ifneq (,$(filter userdebug eng,$(TARGET_BUILD_VARIANT)))
+# Developer GSI images
+# https://developer.android.com/topic/generic-system-image/releases
+$(call inherit-product, $(SRC_TARGET_DIR)/product/developer_gsi_keys.mk)
+endif
+
 # Force using the following regardless of shipping API level:
 #   PRODUCT_TREBLE_LINKER_NAMESPACES
 #   PRODUCT_SEPOLICY_SPLIT

--- a/common.mk
+++ b/common.mk
@@ -114,12 +114,9 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     $(COMMON_PATH)/rootdir/vendor/etc/public.libraries.txt:$(TARGET_COPY_OUT_VENDOR)/etc/public.libraries.txt
 
-# PRODUCT_PLATFORM isn't set yet, thus we check the available path
-ifneq (,$(filter userdebug eng,$(TARGET_BUILD_VARIANT)))
 # ramdump cleaner
-PRODUCT_PACKAGES += \
+PRODUCT_PACKAGES_DEBUG += \
     rdclean.sh
-endif
 
 # Depend on symlink creation in /vendor:
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Makes testing things possible with enforcing AVB and verity.

Also clean up rdclean.sh guards, we can use PRODUCT_PACKAGES_DEBUG for userdebug+eng builds in Q.