### PR TITLE
[COMMON] packages: Add ModemConfig

### DIFF
--- a/common-packages.mk
+++ b/common-packages.mk
@@ -122,6 +122,7 @@ PRODUCT_PACKAGES += \
 
 # Telephony
 PRODUCT_PACKAGES += \
+    ModemConfig \
     QcRilAm \
     SimDetect
 


### PR DESCRIPTION
Our new modem configuration utility, that provokes sony-modem-switcher
to send carrier-specific firmware to the modem, is finally done :)
