### PR TITLE
[COMMON] [DO-NOT-MERGE-BREAKS-ALL] vendor: init: Early mounts on fs, late mounts on post-fs

### DIFF
--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -87,7 +87,7 @@ on fs
     # Start HW service manager early
     start hwservicemanager
 
-    mount_all /vendor/etc/fstab.${ro.hardware}
+    mount_all /vendor/etc/fstab.${ro.hardware} --early
 
     # Start DSP services as soon as partitions are mounted
     # ADSP devices
@@ -111,6 +111,8 @@ on late-fs
     # In such case, init won't responce the property_set from hwservicemanager and then
     # cause services for bootanim not running.
     wait_for_prop hwservicemanager.ready true
+    exec_start wait_for_keymaster
+    mount_all /vendor/etc/fstab.${ro.hardware} --late
 
     mount none /vendor/oem /oem bind rec
 


### PR DESCRIPTION
For Dynamic Partitions devices, we need to do early mounts on fs
and late mounts on post-fs, or havoc happens.

This also means that we have to wait_for_keymaster before late
mounting, as the late ones include the userdata partition, which
is encrypted.

Before merging this, we should update all the fstab of all platforms
to declare early mounts, or everything breaks.