### PR TITLE
[COMMON] Additional configuration for new devices and new features

### DIFF
--- a/common-init.mk
+++ b/common-init.mk
@@ -41,6 +41,7 @@ PRODUCT_PACKAGES += \
     qseecom.rc \
     rmt_storage.rc \
     sct_service.rc \
+    sensorspd.rc \
     sensors.rc \
     sscrpcd.rc \
     tad.rc \

--- a/common.mk
+++ b/common.mk
@@ -78,6 +78,10 @@ PRODUCT_COPY_FILES += \
     $(COMMON_PATH)/rootdir/vendor/etc/data/netmgr_config.xml:$(TARGET_COPY_OUT_VENDOR)/etc/data/netmgr_config.xml \
     $(COMMON_PATH)/rootdir/vendor/etc/data/qmi_config.xml:$(TARGET_COPY_OUT_VENDOR)/etc/data/qmi_config.xml
 
+# QSEECOM TZ Storage
+PRODUCT_COPY_FILES += \
+    $(COMMON_PATH)/rootdir/vendor/etc/gpfspath_oem_config.xml:$(TARGET_COPY_OUT_VENDOR)/etc/gpfspath_oem_config.xml
+
 # Sec Configuration
 PRODUCT_COPY_FILES += \
     $(COMMON_PATH)/rootdir/vendor/etc/sec_config:$(TARGET_COPY_OUT_VENDOR)/etc/sec_config

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -97,19 +97,21 @@ LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 endif # TARGET_BOARD_PLATFORM in (sdm845 sm6125 sm8150)
 
+ifneq ($(filter sdm660 msm8998 sdm845 sm8150,$(TARGET_BOARD_PLATFORM)),)
+include $(CLEAR_VARS)
+LOCAL_MODULE := sscrpcd.rc
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES := vendor/etc/init/sscrpcd.rc
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
+include $(BUILD_PREBUILT)
+endif # TARGET_BOARD_PLATFORM in (sdm660 msm8998 sdm845 sm8150)
+
 ifneq ($(filter sdm660 msm8998 sdm845 sm6125 sm8150,$(TARGET_BOARD_PLATFORM)),)
 include $(CLEAR_VARS)
 LOCAL_MODULE := pd_mapper.rc
 LOCAL_MODULE_CLASS := ETC
 LOCAL_SRC_FILES := vendor/etc/init/pd_mapper.rc
-LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
-include $(BUILD_PREBUILT)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := sscrpcd.rc
-LOCAL_MODULE_CLASS := ETC
-LOCAL_SRC_FILES := vendor/etc/init/sscrpcd.rc
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -40,6 +40,16 @@ LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 endif
 
+ifeq ($(TARGET_NEEDS_SENSORS_PDR), true)
+include $(CLEAR_VARS)
+LOCAL_MODULE := sensorspd.rc
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES := vendor/etc/init/sensorspd.rc
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
+include $(BUILD_PREBUILT)
+endif
+
 ifneq ($(filter msm8952,$(TARGET_BOARD_PLATFORM)),)
 include $(CLEAR_VARS)
 LOCAL_MODULE := qmuxd.rc

--- a/rootdir/vendor/etc/data/dsi_config.xml
+++ b/rootdir/vendor/etc/data/dsi_config.xml
@@ -347,6 +347,99 @@
      </list>
    </listitem>
 
+   <!-- Configuration for SM6150(Talos) and SM6125 -->
+   <listitem name="msmsteppe">
+
+     <data name="qos_enabled" type="int"> 1 </data>
+     <data name="rmnet_data_enabled" type="int"> 1 </data>
+     <data name="phys_net_dev" type="string"> rmnet_ipa0 </data>
+
+     <data name="single_qmux_channel_enabled" type="int"> 1 </data>
+     <data name="single_qmux_channel_name" type="string"> rmnet0 </data>
+
+     <data name="num_dsi_handles" type="int"> 11 </data>
+     <list name="device_names">
+       <data type="string"> rmnet_data0 </data>
+       <data type="string"> rmnet_data1 </data>
+       <data type="string"> rmnet_data2 </data>
+       <data type="string"> rmnet_data3 </data>
+       <data type="string"> rmnet_data4 </data>
+       <data type="string"> rmnet_data5 </data>
+       <data type="string"> rmnet_data6 </data>
+       <data type="string"> rmnet_data7 </data>
+       <data type="string"> rmnet_data8 </data>
+       <data type="string"> rmnet_data9 </data>
+       <data type="string"> rmnet_data10 </data>
+     </list>
+     <list name="control_port_names">
+       <data type="string"> rmnet_data0 </data>
+       <data type="string"> rmnet_data1 </data>
+       <data type="string"> rmnet_data2 </data>
+       <data type="string"> rmnet_data3 </data>
+       <data type="string"> rmnet_data4 </data>
+       <data type="string"> rmnet_data5 </data>
+       <data type="string"> rmnet_data6 </data>
+       <data type="string"> rmnet_data7 </data>
+       <data type="string"> rmnet_data8 </data>
+       <data type="string"> rmnet_data9 </data>
+       <data type="string"> rmnet_data10 </data>
+     </list>
+   </listitem>
+
+         <data type="string"> rmnet_data3 </data>
+         <data type="string"> rmnet_data4 </data>
+         <data type="string"> rmnet_data5 </data>
+         <data type="string"> rmnet_data6 </data>
+         <data type="string"> rmnet_data7 </data>
+         <data type="string"> rmnet_data8 </data>
+         <data type="string"> rmnet_data9 </data>
+         <data type="string"> rmnet_data10 </data>
+      </list>
+
+      <data name="data_ports_len" type="int"> 11 </data>
+      <list name="data_ports">
+         <data type="string"> rmnet_data0 </data>
+         <data type="string"> rmnet_data1 </data>
+         <data type="string"> rmnet_data2 </data>
+         <data type="string"> rmnet_data3 </data>
+         <data type="string"> rmnet_data4 </data>
+         <data type="string"> rmnet_data5 </data>
+         <data type="string"> rmnet_data6 </data>
+         <data type="string"> rmnet_data7 </data>
+         <data type="string"> rmnet_data8 </data>
+         <data type="string"> rmnet_data9 </data>
+         <data type="string"> rmnet_data10 </data>
+      </list>
+
+      <!-- iWLAN ports -->
+      <data name="iwlan_enable" type="int"> 1 </data>
+      <data name="rev_control_ports_len" type="int"> 9 </data>
+      <list name="rev_control_ports">
+         <data type="string"> r_rmnet_data0 </data>
+         <data type="string"> r_rmnet_data1 </data>
+         <data type="string"> r_rmnet_data2 </data>
+         <data type="string"> r_rmnet_data3 </data>
+         <data type="string"> r_rmnet_data4 </data>
+         <data type="string"> r_rmnet_data5 </data>
+         <data type="string"> r_rmnet_data6 </data>
+         <data type="string"> r_rmnet_data7 </data>
+         <data type="string"> r_rmnet_data8 </data>
+      </list>
+
+      <data name="rev_data_ports_len" type="int"> 9 </data>
+      <list name="rev_data_ports">
+        <data type="string"> r_rmnet_data0 </data>
+        <data type="string"> r_rmnet_data1 </data>
+        <data type="string"> r_rmnet_data2 </data>
+        <data type="string"> r_rmnet_data3 </data>
+        <data type="string"> r_rmnet_data4 </data>
+        <data type="string"> r_rmnet_data5 </data>
+        <data type="string"> r_rmnet_data6 </data>
+        <data type="string"> r_rmnet_data7 </data>
+        <data type="string"> r_rmnet_data8 </data>
+      </list>
+   </listitem>
+
    <!-- Configuration for SM8150  -->
    <listitem name="msmnile">
 

--- a/rootdir/vendor/etc/data/netmgr_config.xml
+++ b/rootdir/vendor/etc/data/netmgr_config.xml
@@ -910,6 +910,111 @@
       </list>
    </listitem>
 
+   <!-- SM6150(Talos) and SM6125 parameters -->
+   <listitem name = "msmsteppe">
+
+      <data name="qmi_dpm_enabled" type="int"> 1 </data>
+      <data name="use_qmuxd" type="int"> 0 </data>
+      <data name="dpm_retry_timeout" type="int"> 10000 </data>
+      <data name="wda_data_format_enabled" type="int"> 1 </data>
+
+      <data name="single_qmux_ch_enabled" type="int"> 1 </data>
+      <data name="single_qmux_ch_conn_id_str" type="string"> rmnet0 </data>
+      <data name="single_qmux_ch_name" type="string"> DATA5_CNTL </data>
+
+      <data name="tc_ul_baserate" type="int"> 155000000 </data>
+      <data name="dynamic_tc_ul_baserate" type="int"> 1 </data>
+      <data name="tc_ul_burst" type="int"> 25000 </data>
+
+      <data name="rmnet_data_enabled" type="int"> 1 </data>
+      <data name="dataformat_agg_dl_pkt" type="int"> 10 </data>
+      <data name="dataformat_agg_dl_size" type="int"> 8192 </data>
+      <data name="dataformat_agg_ul_pkt" type="int"> 0 </data>
+      <data name="dataformat_agg_ul_size" type="int"> 0 </data>
+      <data name="dataformat_dl_data_aggregation_protocol" type="int"> 8 </data>
+      <data name="dataformat_ul_data_aggregation_protocol" type="int"> 8 </data>
+      <data name="dataformat_dl_gro_enabled" type="int"> 1 </data>
+      <data name="dataformat_ul_gso_enabled" type="int"> 1 </data>
+      <data name="phys_net_dev" type="string"> rmnet_ipa0 </data>
+      <data name="rtm_rmnet_data_enabled" type="int"> 1 </data>
+      <data name="rtnetlink_tc_enabled" type="int"> 1 </data>
+      <data name="netdev_max_backlog" type="int"> 10000 </data>
+
+      <data name="disable_tcp_hystart_detect" type="int"> 1 </data>
+      <data name="disable_hystart" type="int"> 1 </data>
+      <data name="initial_ssthresh" type="int"> 1400 </data>
+      <data name="pnd_rps_mask" type="int"> 2 </data>
+      <data name="vnd_rps_mask" type="int"> 12 </data>
+      <data name="netdev_budget" type="int"> 0 </data>
+      <data name="low_latency_filters" type="int"> 0 </data>
+      <data name="qos_via_idl" type="int"> 1 </data>
+      <data name="skip_buffered_qos_modify" type="int"> 1 </data>
+
+      <data name="num_modems" type="int"> 2 </data>
+      <list name="modems_enabled">
+         <data type="int"> 1 </data> <!-- MODEM_MSM -->
+         <data type="int"> 0 </data> <!-- MODEM_MDM -->
+      </list>
+
+      <data name="control_ports_len" type="int"> 11 </data>
+      <list name="control_ports">
+         <data type="string"> rmnet_data0 </data>
+         <data type="string"> rmnet_data1 </data>
+         <data type="string"> rmnet_data2 </data>
+         <data type="string"> rmnet_data3 </data>
+         <data type="string"> rmnet_data4 </data>
+         <data type="string"> rmnet_data5 </data>
+         <data type="string"> rmnet_data6 </data>
+         <data type="string"> rmnet_data7 </data>
+         <data type="string"> rmnet_data8 </data>
+         <data type="string"> rmnet_data9 </data>
+         <data type="string"> rmnet_data10 </data>
+      </list>
+
+      <data name="data_ports_len" type="int"> 11 </data>
+      <list name="data_ports">
+         <data type="string"> rmnet_data0 </data>
+         <data type="string"> rmnet_data1 </data>
+         <data type="string"> rmnet_data2 </data>
+         <data type="string"> rmnet_data3 </data>
+         <data type="string"> rmnet_data4 </data>
+         <data type="string"> rmnet_data5 </data>
+         <data type="string"> rmnet_data6 </data>
+         <data type="string"> rmnet_data7 </data>
+         <data type="string"> rmnet_data8 </data>
+         <data type="string"> rmnet_data9 </data>
+         <data type="string"> rmnet_data10 </data>
+      </list>
+
+      <!-- iWLAN ports -->
+      <data name="iwlan_enable" type="int"> 1 </data>
+      <data name="rev_control_ports_len" type="int"> 9 </data>
+      <list name="rev_control_ports">
+         <data type="string"> r_rmnet_data0 </data>
+         <data type="string"> r_rmnet_data1 </data>
+         <data type="string"> r_rmnet_data2 </data>
+         <data type="string"> r_rmnet_data3 </data>
+         <data type="string"> r_rmnet_data4 </data>
+         <data type="string"> r_rmnet_data5 </data>
+         <data type="string"> r_rmnet_data6 </data>
+         <data type="string"> r_rmnet_data7 </data>
+         <data type="string"> r_rmnet_data8 </data>
+      </list>
+
+      <data name="rev_data_ports_len" type="int"> 9 </data>
+      <list name="rev_data_ports">
+        <data type="string"> r_rmnet_data0 </data>
+        <data type="string"> r_rmnet_data1 </data>
+        <data type="string"> r_rmnet_data2 </data>
+        <data type="string"> r_rmnet_data3 </data>
+        <data type="string"> r_rmnet_data4 </data>
+        <data type="string"> r_rmnet_data5 </data>
+        <data type="string"> r_rmnet_data6 </data>
+        <data type="string"> r_rmnet_data7 </data>
+        <data type="string"> r_rmnet_data8 </data>
+      </list>
+   </listitem>
+
   <!-- SM8150 parameters -->
    <listitem name = "msmnile">
 

--- a/rootdir/vendor/etc/gpfspath_oem_config.xml
+++ b/rootdir/vendor/etc/gpfspath_oem_config.xml
@@ -1,0 +1,61 @@
+<!--
+Copyright (c) 2017 Qualcomm Technologies, Inc.
+All Rights Reserved.
+Confidential and Proprietary - Qualcomm Technologies, Inc.
+-->
+
+<!--
+
+This file is configured by OEM to customize the path used by GP FS listener
+service to save files, and will be located in /vendor/etc on device
+
+"gp_data_path" and "gp_persist_path" are the /data and /persist partition
+path to save files, respectively.
+By default, "gp_data_path" is "/data/vendor/tzstorage/", and
+"gp_persist_path" is "/mnt/vendor/persist/data/".
+
+To replace with different paths, please also create folder in init.qcom.rc
+file and update SEAndroid policy.
+
+Take "/data/vendor/tzstorage/" as an example below,
+
+A) rootdir/etc/init.qcom.rc:
+# Create /data/vendor/tzstorage directory for SFS listener
+mkdir /data/vendor/tzstorage 0770 system system
+
+B) common/file.te:
+# SFS listener data file
+type data_tzstorage_file, file_type, data_file_type;
+
+C) common/file_contexts:
+/data/vendor/tzstorage(/.*)?       u:object_r:data_tzstorage_file:s0
+
+D) common/qseecomd.te:
+# Allow SFS to write to data partition
+allow tee data_tzstorage_file:dir create_dir_perms;
+allow tee data_tzstorage_file:file create_file_perms;
+
+"gp_whitelist_count" and "gp_whitelist_path"
+
+Some paths needs "/data/vendor/tzstorage" appended to it at the beginning
+as they do not have access/permissions on their own.
+Use gp_whitelist_count and gp_whitelist_paths entries to add more such paths.
+By default, we add "/data/system/users" and "/data/misc/qsee" for current use
+cases.
+
+To add an extra path, increment the count in gp_whitelist_count and add a new
+gp_whitelist_path entry. It is very critical that the count matches with the
+number of path entries.
+
+-->
+
+<sfs_path>
+    <gp_data_path> /data/vendor/tzstorage/ </gp_data_path>
+    <gp_persist_path> /mnt/vendor/persist/data/ </gp_persist_path>
+    <gp_whitelist_count> 4 </gp_whitelist_count>
+    <gp_whitelist_path> /data/system/users/ </gp_whitelist_path>
+    <gp_whitelist_path> /data/misc/qsee/ </gp_whitelist_path>
+    <gp_whitelist_path> /qwes </gp_whitelist_path>
+    <gp_whitelist_path> /qwes/licenses </gp_whitelist_path>
+</sfs_path>
+

--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -142,6 +142,9 @@ on post-fs-data
     mkdir /data/misc/qsee 0770 system system
     mkdir /data/fpc 0700 system system
 
+    # Create directory for QSEE Secure FS listener
+    mkdir /data/vendor/tzstorage 0770 system system
+
     mkdir /data/misc/dts 0770 media audio
     mkdir /data/persist 0770 system system
 

--- a/rootdir/vendor/etc/init/sensorspd.rc
+++ b/rootdir/vendor/etc/init/sensorspd.rc
@@ -1,0 +1,4 @@
+service vendor.sensorspd /odm/bin/adsprpcd sensorspd
+   class main
+   user system
+   group system


### PR DESCRIPTION
The ADSP on some targets have a Sensors PDR Service: add the
init script in order to enable the transport endpoint to the
tms/servreg service, located on sensors_pdr_adsprpc.

This init script gets copied when the target device declares
TARGET_NEEDS_SENSORS_PDR := true

EDIT:
Also, push netmgr/dsi config for SM6125 and add the QSEE
TZ Storage configuration and paths, required by new devices
and new BSPs. 

Required by new SoCs.