### PR TITLE
rootdir: init.common: Bindmount /oem earlier

### DIFF
--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -109,7 +109,8 @@ on fs
     # And force restoring of SELinux labels
     restorecon_recursive /mnt/vendor/persist/
 
-on late-fs
+    # We mount the oem partition at /odm, so the /oem mountpoint is free
+    # for modem-config configs
     mount none /vendor/oem /oem bind rec
 
 on post-fs


### PR DESCRIPTION
No need to wait until late-fs if `/vendor` is already available after `mount_all --early` has run.