### PR TITLE
init.common: Fix service start order for FDE

### DIFF
--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -112,11 +112,12 @@ on fs
 on late-fs
     mount none /vendor/oem /oem bind rec
 
-on post-fs
-    # Wait for qseecomd to be started
-    wait_for_prop vendor.sys.listeners.registered true
+    # Keymaster is needed for /data decryption
+    exec_start wait_for_keymaster
 
-on late-fs
+    # Mount RW partitions which need to run fsck
+    mount_all /vendor/etc/fstab.${ro.hardware} --late
+
     # Start services for bootanim
     start surfaceflinger
     start bootanim
@@ -135,8 +136,9 @@ on late-fs
     # GRAPHICS_V3: Try for QTI HAL gralloc
     start vendor.qti.hardware.display.allocator
 
-    # Mount RW partitions which need to run fsck
-    mount_all /vendor/etc/fstab.${ro.hardware} --late
+on post-fs
+    # Wait for qseecomd to be started
+    wait_for_prop vendor.sys.listeners.registered true
 
 on post-fs-data
     # We can start netd here before in is launched in common init.rc on zygote-start


### PR DESCRIPTION
FDE devices experience race conditions because `/data` might not be available for the services started `on late-fs`.

Rather, delay until `/data` is mounted.

Tested on Kagura with `forceencrypt=footer` in fstab, and "Secure Startup"
requiring PIN entry enabled.
