### PR TITLE
vendor: GP FS: Drop /data/system/users/ from whitelist

### DIFF
--- a/rootdir/vendor/etc/gpfspath_oem_config.xml
+++ b/rootdir/vendor/etc/gpfspath_oem_config.xml
@@ -52,8 +52,7 @@ number of path entries.
 <sfs_path>
     <gp_data_path> /data/vendor/tzstorage/ </gp_data_path>
     <gp_persist_path> /mnt/vendor/persist/data/ </gp_persist_path>
-    <gp_whitelist_count> 4 </gp_whitelist_count>
-    <gp_whitelist_path> /data/system/users/ </gp_whitelist_path>
+    <gp_whitelist_count> 3 </gp_whitelist_count>
     <gp_whitelist_path> /data/misc/qsee/ </gp_whitelist_path>
     <gp_whitelist_path> /qwes </gp_whitelist_path>
     <gp_whitelist_path> /qwes/licenses </gp_whitelist_path>


### PR DESCRIPTION
This whitelist (though it does not exclude but rather INCLUDE) moves all
paths starting with one of the entries into gp_data_path to solve system
boundary issues such as files in /data/{system,misc}, see our BUGS in
sepolicy for tee [1].

Unfortunately this breaks FPC (which is one such violation) in the
process:

    [pid  8105] openat(AT_FDCWD, 0x77e677a004, O_RDONLY|O_CLOEXEC|O_DIRECTORY) = -1 ENOENT (No such file or directory)
    [pid  8105] openat(AT_FDCWD, "/data/vendor/tzstorage//data/system/users/0/fpdata/user.db.tmp", O_RDONLY|O_CLOEXEC|O_DIRECTORY) = -1 ENOENT (No such file or directory)
    [pid  8105] openat(AT_FDCWD, "/data/vendor/tzstorage//data/system/users/0/fpdata/", O_RDONLY|O_CLOEXEC|O_DIRECTORY) = -1 ENOENT (No such file or directory)
    [pid  8105] openat(AT_FDCWD, "/data/vendor/tzstorage", O_RDONLY|O_CLOEXEC|O_DIRECTORY) = 36
    [pid  8105] close(36)                   = 0
    [pid  8105] openat(AT_FDCWD, "/data/vendor/tzstorage//data/system/users/0/fpdata/user.db.tmp", O_RDWR|O_CREAT|O_SYNC, 010700) = -1 ENOENT (No such file or directory)

No subdirectories are created beyond /data/vendor/tzstorage making the
feature "useless", at least on Tama. Solve that and we likely run into
different issues because the FPC HAL still uses the normal path.
Besides, AOSP deliberately provides this path [2] for the HAL to store
such files in. Unfortunately the bug referenced in our sepolicy is
inaccessible to the public [3].

Final note: Whoever invented gp_whitelist_count, I have no words. Either
parse all the nodes or ask the XML parser to count it for you, this is
far from the idiomatic...

[1]: https://github.com/sonyxperiadev/device-sony-sepolicy/blob/af8240afe01e4e57aab2d30d02d6c43303b8121a/vendor/tee.te#L22-L30
[2]: https://android.googlesource.com/platform/hardware/interfaces/+/android-10.0.0_r37/biometrics/fingerprint/2.1/IBiometricsFingerprint.hal#145
[3]: https://issuetracker.google.com/issues/36644492
