### PR TITLE
[COMMON] Audio related battery and latency optimizations

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -151,7 +151,22 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.vendor.audio.fluence.voicecall=true \
     persist.vendor.audio.fluence.voicecomm=true \
     persist.vendor.audio.fluence.voicerec=true \
-    persist.vendor.audio.fluence.speaker=true
+    persist.vendor.audio.fluence.speaker=true \
+    vendor.audio.offload.track.enable=true \
+    vendor.voice.path.for.pcm.voip=true \
+    vendor.audio.offload.multiaac.enable=true \
+    vendor.audio.offload.multiple.enabled=false \
+    vendor.audio.offload.passthrough=false \
+    vendor.audio.offload.gapless.enabled=true \
+    vendor.audio.parser.ip.buffer.size=262144 \
+    vendor.audio.volume.headset.gain.depcal=true
+
+# Audio (CAF - Hardware enc/decoding)
+PRODUCT_PROPERTY_OVERRIDES += \
+    vendor.audio.flac.sw.decoder.24bit=true \
+    vendor.audio.use.sw.alac.decoder=true \
+    vendor.audio.use.sw.ape.decoder=true \
+    vendor.audio.hw.aac.encoder=true
 
 # Audio Features
 PRODUCT_PROPERTY_OVERRIDES += \
@@ -193,6 +208,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # AudioPolicy Manager
 PRODUCT_PROPERTY_OVERRIDES += \
     audio.offload.video=1
+
+# AudioFlinger
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.af.client_heap_size_kbyte=7168
 
 # Enable stats logging in LMKD
 TARGET_LMKD_STATS_LOG := true

--- a/common-prop.mk
+++ b/common-prop.mk
@@ -190,6 +190,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
     vendor.audio.feature.audiozoom.enable=false \
     vendor.audio.feature.snd_mon.enable=true
 
+# AudioPolicy Manager
+PRODUCT_PROPERTY_OVERRIDES += \
+    audio.offload.video=1
+
 # Enable stats logging in LMKD
 TARGET_LMKD_STATS_LOG := true
 PRODUCT_PROPERTY_OVERRIDES += \

--- a/common-prop.mk
+++ b/common-prop.mk
@@ -159,7 +159,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
     vendor.audio.offload.passthrough=false \
     vendor.audio.offload.gapless.enabled=true \
     vendor.audio.parser.ip.buffer.size=262144 \
-    vendor.audio.volume.headset.gain.depcal=true
+    vendor.audio.volume.headset.gain.depcal=true \
+    vendor.audio_hal.period_size=192 \
+    vendor.audio_hal.in_period_size=144 \
+    vendor.audio_hal.period_multiplier=3
 
 # Audio (CAF - Hardware enc/decoding)
 PRODUCT_PROPERTY_OVERRIDES += \

--- a/common-prop.mk
+++ b/common-prop.mk
@@ -132,7 +132,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Audio
 PRODUCT_PROPERTY_OVERRIDES += \
     media.aac_51_output_enabled=true \
-    audio.deep_buffer.media=1 \
+    audio.deep_buffer.media=true \
     fmas.hdph_sgain=0 \
     ro.config.vc_call_vol_steps=7 \
     ro.config.media_vol_steps=25


### PR DESCRIPTION
Correctly configure audio buffers, enc/decoders etc for optimizations
related to battery and latency.
Also solves a buffer underrun issue that happens rarely on legacy SoCs
but rather commonly on newer ones, like SM8150: this solution was
previously applied only on device-sony-kumano, but it's actually applying
to all of the platforms that we currently supports.

Of course, a PR on device-sony-kumano will remove the duplication that
happens by merging this.