### PR TITLE
[COMMON] init: Introduce support for Sensors PDR on SDSP

### DIFF
--- a/common-init.mk
+++ b/common-init.mk
@@ -41,7 +41,8 @@ PRODUCT_PACKAGES += \
     qseecom.rc \
     rmt_storage.rc \
     sct_service.rc \
-    sensorspd.rc \
+    adsp-sensorspdr.rc \
+    sdsp-sensorspdr.rc \
     sensors.rc \
     sscrpcd.rc \
     tad.rc \

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -40,11 +40,26 @@ LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 endif
 
-ifeq ($(TARGET_NEEDS_SENSORS_PDR), true)
+# Note: Sensors PDR can be on ADSP **or** on SDSP
+ifeq ($(TARGET_NEEDS_ADSP_SENSORS_PDR), true)
+ # Let's error out if the developer makes an impossible choice
+ ifeq ($(TARGET_NEEDS_SDSP_SENSORS_PDR), true)
+  $(error Activating both ADSP and SDSP Sensors PDR is wrong!!!)
+ endif
+
 include $(CLEAR_VARS)
-LOCAL_MODULE := sensorspd.rc
+LOCAL_MODULE := adsp-sensorspdr.rc
 LOCAL_MODULE_CLASS := ETC
-LOCAL_SRC_FILES := vendor/etc/init/sensorspd.rc
+LOCAL_SRC_FILES := vendor/etc/init/adsp-sensorspdr.rc
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
+include $(BUILD_PREBUILT)
+
+else ifeq ($(TARGET_NEEDS_SDSP_SENSORS_PDR), true)
+include $(CLEAR_VARS)
+LOCAL_MODULE := sdsp-sensorspdr.rc
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES := vendor/etc/init/sdsp-sensorspdr.rc
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)

--- a/rootdir/vendor/etc/init/adsp-sensorspdr.rc
+++ b/rootdir/vendor/etc/init/adsp-sensorspdr.rc
@@ -2,3 +2,4 @@ service vendor.sensorspd /odm/bin/adsprpcd sensorspd
    class main
    user system
    group system
+   disabled

--- a/rootdir/vendor/etc/init/sdsp-sensorspdr.rc
+++ b/rootdir/vendor/etc/init/sdsp-sensorspdr.rc
@@ -1,0 +1,7 @@
+# Sensors PDR service
+service vendor.sensorspd /odm/bin/sscrpcd sensorspd
+    class core
+    user system
+    group system wakelock
+    capabilities BLOCK_SUSPEND
+    disabled

--- a/rootdir/vendor/etc/init/sensors.rc
+++ b/rootdir/vendor/etc/init/sensors.rc
@@ -24,5 +24,8 @@ service vendor.sensors /odm/bin/sensors.qcom
     disabled
 
 # Enable the service after ADSP and SLPI are up
+# Note: sensorspd exists only on some devices either in
+#       form of adsp-sensorspdr or ssc-sensorspdr.
 on property:vendor.qcom.slpiup=1
+    enable vendor.sensorspd
     enable vendor.sensors


### PR DESCRIPTION
The higher tier SoCs have got a dedicated Sensors Low Power Island
(SLPI) with its own RTOS: in this case the Sensors PDR is not
located on the ADSP, but on the SDSP (SSC).

For this reason, introduce a new init definition for the latter,
change it for the former, and activate it on these conditions:
1. TARGET_NEEDS_ADSP_SENSORS_PDR is *false*
2. TARGET_NEEDS_SDSP_SENSORS_PDR is *true*.

For obvious reasons, *no* target can have a Sensors PDR on both
A- and S- DSP... That's why one force-excludes the other.
Also, to avoid issues with having two of them together, trigger
a build error in case both env vars are true, so that the
developer is warned about the impossible *stupid*  choice.

--------

The PDR init is verified working on Sony SM8150 Kumano Griffin DSDS,
but I want some feedback from @MarijnS95 @ix5 about the way I have
done the SDSP-ADSP exclusion and the enable on the sensors.rc before
merging it.

Specifically, I want to remind you that not all devices have got either one
or the other: some legacy ones have got no Sensors PDR at all.