### PR TITLE
[R] vintf: Remove usb, already defined

### DIFF
--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -218,15 +218,6 @@
         <fqname>@1.0::IOffloadControl/default</fqname>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.usb</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>IUsb</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.vibrator</name>
         <transport>hwbinder</transport>
         <version>1.0</version>


### PR DESCRIPTION
In Android R, the android.hardware.usb@1.0-service module already ships its own `vintf_fragment` for `IUsb`.

Needs a change to the legacy "basic" USB HAL for users of `BOARD_USE_LEGACY_USB`.