### PR TITLE
[COMMON] [DNM] init: Move {a,c}dspstart_sh start commands into optional service file

### DIFF
--- a/rootdir/vendor/etc/init/adspstart.rc
+++ b/rootdir/vendor/etc/init/adspstart.rc
@@ -4,3 +4,7 @@ service vendor.adspstart_sh /vendor/bin/init.qcom.adspstart.sh
     group root system
     disabled
     oneshot
+
+# Start DSP services as soon as partitions are mounted
+on property:vendor.init.earlymount.ready=1
+    start vendor.adspstart_sh

--- a/rootdir/vendor/etc/init/cdspstart.rc
+++ b/rootdir/vendor/etc/init/cdspstart.rc
@@ -4,3 +4,7 @@ service vendor.cdspstart_sh /vendor/bin/init.qcom.cdspstart.sh
     group root system
     disabled
     oneshot
+
+# Start DSP services as soon as partitions are mounted
+on property:vendor.init.earlymount.ready=1
+    start vendor.cdspstart_sh

--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -96,11 +96,7 @@ on fs
 
     mount_all /vendor/etc/fstab.${ro.hardware} --early
 
-    # Start DSP services as soon as partitions are mounted
-    # ADSP devices
-    start vendor.adspstart_sh
-    # CDSP devices
-    start vendor.cdspstart_sh
+    setprop vendor.init.earlymount.ready 1
 
     # (Android <= 9): Remove "security.restorecon_last" xattr from /mnt/vendor/persist/
     exec u:r:vendor_toolbox:s0 root root -- /vendor/bin/toybox_vendor setfattr -x security.restorecon_last /mnt/vendor/persist/


### PR DESCRIPTION
Not all platforms need {a,c}dspstart, and their initrc files with the
service declarations are only included on those that do. The start
commands however, to run these oneshot scripts after the necessary
partitions are mounted, are in a common initrc file, resulting in a
harmless yet misleading error:

    init: Command 'start vendor.cdspstart_sh' action=fs (/vendor/etc/init/hw/init.pioneer.rc:96) took 0ms and failed: service vendor.cdspstart_sh not found

Note that a property is used to start the services right after
early-mounting, but before anything else (not guaranteed! This all runs
asynchronous). This may not be necessary, post-fs could be early enough
too.

---

@ix5 thoughts?

@chris42 This follows from our discussion last week :wink:
