### PR TITLE
[COMMON] [Q-MR1] vendor: data: netmgr: Update MSM8998, SDM845 config for new RMNET

### DIFF
--- a/rootdir/vendor/etc/data/netmgr_config.xml
+++ b/rootdir/vendor/etc/data/netmgr_config.xml
@@ -829,12 +829,15 @@
       <data name="use_qmuxd" type="int"> 0 </data>
       <data name="dpm_retry_timeout" type="int"> 10000 </data>
       <data name="wda_data_format_enabled" type="int"> 1 </data>
-
+      <data name="kfc_mode" type="int"> 2 </data>
+      <data name="qmi_pc" type="int"> 1 </data>
+      <data name="tcp_ack_prio" type="int"> 1 </data>
+	  
       <data name="single_qmux_ch_enabled" type="int"> 1 </data>
       <data name="single_qmux_ch_conn_id_str" type="string"> rmnet0 </data>
       <data name="single_qmux_ch_name" type="string"> DATA5_CNTL </data>
       <data name="tc_ul_baserate" type="int"> 155000000 </data>
-      <data name="dynamic_tc_ul_baserate" type="int"> 1 </data>
+      <data name="dynamic_tc_ul_baserate" type="int"> 0 </data>
       <data name="tc_ul_burst" type="int"> 25000 </data>
       <data name="rmnet_data_enabled" type="int"> 1 </data>
       <data name="dataformat_agg_dl_pkt" type="int"> 10 </data>
@@ -852,11 +855,21 @@
       <data name="disable_hystart" type="int"> 1 </data>
       <data name="initial_ssthresh" type="int"> 1400 </data>
 
+      <data name="rtm_rmnet_data_enabled" type="int"> 1 </data>
+      <data name="rtnetlink_tc_enabled" type="int"> 1 </data>
+      <data name="rmnet_shs" type="int"> 0 </data>
+      <data name="rmnet_perf" type="int"> 0 </data>
+
       <data name="pnd_rps_mask" type="int"> 2 </data>
       <data name="vnd_rps_mask" type="int"> 13 </data>
       <data name="netdev_budget" type="int"> 0 </data>
       <data name="low_latency_filters" type="int"> 0 </data>
       <data name="qos_via_idl" type="int"> 1 </data>
+
+      <data name="dl_marker_enabled" type="int"> 1 </data>
+      <data name="xlat_txcsum_disabled" type="int"> 0 </data>
+      <data name="tcp_mtu_probing" type="int"> 2 </data>
+      <data name="max_mtu" type="int"> 0 </data>
 
       <data name="num_modems" type="int"> 2 </data>
       <list name="modems_enabled">

--- a/rootdir/vendor/etc/data/netmgr_config.xml
+++ b/rootdir/vendor/etc/data/netmgr_config.xml
@@ -721,24 +721,32 @@
       <data name="use_qmuxd" type="int"> 0 </data>
       <data name="dpm_retry_timeout" type="int"> 10000 </data>
       <data name="wda_data_format_enabled" type="int"> 1 </data>
+      <data name="kfc_mode" type="int"> 2 </data>
+      <data name="qmi_pc" type="int"> 1 </data>
+      <data name="tcp_ack_prio" type="int"> 1 </data>
 
       <data name="single_qmux_ch_enabled" type="int"> 1 </data>
       <data name="single_qmux_ch_conn_id_str" type="string"> rmnet0 </data>
       <data name="single_qmux_ch_name" type="string"> DATA5_CNTL </data>
       <data name="tc_ul_baserate" type="int"> 155000000 </data>
-      <data name="dynamic_tc_ul_baserate" type="int"> 1 </data>
+      <data name="dynamic_tc_ul_baserate" type="int"> 0 </data>
       <data name="tc_ul_burst" type="int"> 25000 </data>
       <data name="rmnet_data_enabled" type="int"> 1 </data>
-      <data name="dataformat_agg_dl_pkt" type="int"> 10 </data>
-      <data name="dataformat_agg_dl_size" type="int"> 8192 </data>
-      <data name="dataformat_agg_ul_pkt" type="int"> 0 </data>
-      <data name="dataformat_agg_ul_size" type="int"> 0 </data>
+      <data name="dataformat_agg_dl_pkt" type="int"> 31 </data>
+      <data name="dataformat_agg_dl_size" type="int"> 16384 </data>
+      <data name="dataformat_agg_ul_pkt" type="int"> 32 </data>
+      <data name="dataformat_agg_ul_size" type="int"> 16384 </data>
       <data name="dataformat_dl_data_aggregation_protocol" type="int"> 8 </data>
       <data name="dataformat_ul_data_aggregation_protocol" type="int"> 8 </data>
       <data name="dataformat_dl_gro_enabled" type="int"> 1 </data>
       <data name="dataformat_ul_gso_enabled" type="int"> 1 </data>
       <data name="phys_net_dev" type="string"> rmnet_ipa0 </data>
       <data name="netdev_max_backlog" type="int"> 10000 </data>
+
+      <data name="rtm_rmnet_data_enabled" type="int"> 1 </data>
+      <data name="rtnetlink_tc_enabled" type="int"> 1 </data>
+      <data name="rmnet_shs" type="int"> 0 </data>
+      <data name="rmnet_perf" type="int"> 0 </data>
 
       <data name="disable_tcp_hystart_detect" type="int"> 1 </data>
       <data name="disable_hystart" type="int"> 1 </data>
@@ -749,6 +757,11 @@
       <data name="netdev_budget" type="int"> 0 </data>
       <data name="low_latency_filters" type="int"> 0 </data>
       <data name="qos_via_idl" type="int"> 1 </data>
+
+      <data name="dl_marker_enabled" type="int"> 1 </data>
+      <data name="xlat_txcsum_disabled" type="int"> 0 </data>
+      <data name="tcp_mtu_probing" type="int"> 2 </data>
+      <data name="max_mtu" type="int"> 0 </data>
 
       <data name="num_modems" type="int"> 2 </data>
       <list name="modems_enabled">


### PR DESCRIPTION
Enable the new data-kernel RMNET driver in kernel 4.14 by updating
the configuration for MSM8998 and SDM845.
Now this platform has to use the same driver as newer platforms.

Depends on:
https://github.com/sonyxperiadev/kernel-defconfig/pull/85
https://github.com/sonyxperiadev/kernel/pull/2321

Tested on TIM IT LTE network:
MSM8998 Yoshino Maple RoW - DL: 94Mbps UL: 28Mbps
SDM845 Tama Akatsuki RoW - DL: 118Mbps UL:27Mbps

P.S.: Tests on stock are showing basically the same numbers, between
margin of error, so my tests are being limited by the network.
In any case, it's a big improvement from the old tests, without this
changes, showing around 10MBits in both DL and UL at best!