### PR TITLE
[COMMON] Remove forced disablement of compr_voip audio feature

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -178,7 +178,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     vendor.audio.feature.battery_listener.enable=false \
     vendor.audio.feature.compr_cap.enable=false \
     vendor.audio.feature.compress_meta_data.enable=true \
-    vendor.audio.feature.compr_voip.enable=false \
     vendor.audio.feature.dsm_feedback.enable=false \
     vendor.audio.feature.ext_hw_plugin.enable=false \
     vendor.audio.feature.external_dsp.enable=false \


### PR DESCRIPTION
Three of our platforms - Yoshino, Nile and Ganges - use this feature.
This is not only evident from the fact that CAF audio enables it on
sdm660 and msm8998, but the lack of `echo-reference-voip` mixer paths.
Only echo-reference is available, where `-voip` is appened if compr_voip
is disabled.

Explicitly enabling this feature (which defaults to false) in platform
repos fixes issues with calls that utilize echo-reference.
