### PR TITLE
[R/Q] android.bp: Remove hidltransport and hwbinder from shared libs

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -27,6 +27,10 @@ TARGET_NO_BOOTLOADER := true
 TARGET_NO_RECOVERY ?= false
 TARGET_NO_KERNEL := false
 
+# Android R: Disable logic for new vendor_boot
+# Our devices do not support it
+TARGET_NO_VENDOR_BOOT := true
+
 # common cmdline parameters
 ifneq ($(BOARD_USE_ENFORCING_SELINUX),true)
 BOARD_KERNEL_CMDLINE += androidboot.selinux=permissive

--- a/common-packages.mk
+++ b/common-packages.mk
@@ -139,6 +139,11 @@ PRODUCT_PACKAGES += \
     libandroid_net \
     libprotobuf-cpp-full
 
+# FIXME: master: compat for libprotobuf
+# See https://android-review.googlesource.com/c/platform/prebuilts/vndk/v28/+/1109518
+PRODUCT_PACKAGES += \
+    libprotobuf-cpp-full-vendorcompat
+
 # RenderScript
 PRODUCT_PACKAGES += \
     librsjni

--- a/common.mk
+++ b/common.mk
@@ -49,6 +49,9 @@ PRODUCT_PACKAGES += \
 # Force building a recovery image: Needed for OTA packaging to work since Q
 PRODUCT_BUILD_RECOVERY_IMAGE := true
 
+# Force building a boot image. This needs to be set explicitly since Android R
+PRODUCT_BUILD_BOOT_IMAGE := true
+
 KERNEL_PATH := kernel/sony/msm-$(SOMC_KERNEL_VERSION)
 # Sanitized prebuilt kernel headers
 -include $(KERNEL_PATH)/common-headers/KernelHeaders.mk

--- a/common.mk
+++ b/common.mk
@@ -104,7 +104,8 @@ PRODUCT_COPY_FILES += \
     frameworks/av/services/audiopolicy/config/r_submix_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/r_submix_audio_policy_configuration.xml \
     frameworks/av/services/audiopolicy/config/usb_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/usb_audio_policy_configuration.xml
 
-# Public Libraries
+# Additional native libraries
+# See https://source.android.com/devices/tech/config/namespaces_libraries
 PRODUCT_COPY_FILES += \
     $(COMMON_PATH)/rootdir/vendor/etc/public.libraries.txt:$(TARGET_COPY_OUT_VENDOR)/etc/public.libraries.txt
 

--- a/hardware/health/Android.bp
+++ b/hardware/health/Android.bp
@@ -28,8 +28,6 @@ cc_binary {
         "libbase",
         "libcutils",
         "libhidlbase",
-        "libhidltransport",
-        "libhwbinder",
         "liblog",
         "libutils",
     ],

--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -112,14 +112,12 @@ on fs
 on late-fs
     mount none /vendor/oem /oem bind rec
 
-on post-fs
-    # Wait for qseecomd to be started
-    wait_for_prop vendor.sys.listeners.registered true
+    # Wait for hwservicemanager ready since fsck might be triggered in mount_all --late
+    # In such case, init won't responce the property_set from hwservicemanager and then
+    # cause services for bootanim not running.
+    wait_for_prop hwservicemanager.ready true
 
-on late-fs
-    # Start services for bootanim
-    start surfaceflinger
-    start bootanim
+    exec_start wait_for_keymaster
 
     # Try for @2.1, for legacy
     start vendor.hwcomposer-2-1
@@ -137,6 +135,10 @@ on late-fs
 
     # Mount RW partitions which need to run fsck
     mount_all /vendor/etc/fstab.${ro.hardware} --late
+
+on post-fs
+    # Wait for qseecomd to be started
+    wait_for_prop vendor.sys.listeners.registered true
 
 on post-fs-data
     # We can start netd here before in is launched in common init.rc on zygote-start

--- a/rootdir/vendor/etc/public.libraries.txt
+++ b/rootdir/vendor/etc/public.libraries.txt
@@ -4,3 +4,4 @@ libsdsprpc.so
 libOpenCL.so
 libaptX_encoder.so
 libaptXHD_encoder.so
+libprotobuf-cpp-full.so

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -218,15 +218,6 @@
         <fqname>@1.0::IOffloadControl/default</fqname>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.usb</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>IUsb</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.vibrator</name>
         <transport>hwbinder</transport>
         <version>1.0</version>


### PR DESCRIPTION
In Android R libhwbinder and libhidltransport are no longer available to use.
Thus let's remove the libraries.