### PR TITLE
liblights: Remove deprecated library from Android.mk

### DIFF
--- a/hardware/liblights/Android.mk
+++ b/hardware/liblights/Android.mk
@@ -29,7 +29,6 @@ LOCAL_SHARED_LIBRARIES := \
     libutils \
     libhardware \
     libhidlbase \
-    libhidltransport \
     android.hardware.light@2.0
 
 # We want the full operator-precedence experience:

--- a/hardware/power/Android.mk
+++ b/hardware/power/Android.mk
@@ -47,7 +47,6 @@ LOCAL_SHARED_LIBRARIES := \
     libutils \
     libhardware \
     libhidlbase \
-    libhidltransport \
     android.hardware.power@1.3
 
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
In Android Q libhidltransport was deprecated and all the symbols of this library were moved to libhidlbase.
Thus lets remove this library as it serves no purpose.

Commits that made those changes upstream:
https://android.googlesource.com/platform/system/libhidl/+/8f65ba713e73b40dc58dd7a8a702a96d6c1c2181
https://android.googlesource.com/platform/system/libhidl/+/a46371d5b3ffd08808ae93ec420721345738ec65
https://android.googlesource.com/platform/system/libhwbinder/+/09a8725d56b168668a11530537c9738f4bc58a90