### PR TITLE
[R] vintf: Remove android.hardware.wifi

### DIFF
--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -227,15 +227,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.wifi</name>
-        <transport>hwbinder</transport>
-        <version>1.3</version>
-        <interface>
-            <name>IWifi</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.wifi.hostapd</name>
         <transport>hwbinder</transport>
         <version>1.1</version>


### PR DESCRIPTION
This is already defined by interfaces.  [Google-git](https://android.googlesource.com/platform/hardware/interfaces/+/refs/tags/android-11.0.0_r3/wifi/1.4/default/android.hardware.wifi%401.0-service.xml)

Error:
`checkvintf E 09-15 21:15:46  1594  1594 VintfObject.cpp:66] getDeviceHalManifest: -2147483648 VINTF parse error: Cannot add manifest fragment /vendor/etc/vintf/manifest/android.hardware.wifi@1.0-service.xml:HAL "android.hardware.wifi" has a conflict.`