### PR TITLE
[R]rootdir: init: Remove useless verity_load_state

### DIFF
--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -65,9 +65,6 @@ on init
     write /sys/block/zram0/comp_algorithm lz4
     write /proc/sys/vm/page-cluster 0
 
-    # Load persistent dm-verity state
-    verity_load_state
-
     # cpuquiet rqbalance permissions
     chown system system /sys/devices/system/cpu/cpuquiet/nr_min_cpus
     chown system system /sys/devices/system/cpu/cpuquiet/nr_power_max_cpus


### PR DESCRIPTION
On R, verity state is better to be checked by bootloader instead of init in userspace.
`do_verity_load_state` is not be supported on R.

https://android-review.googlesource.com/c/platform/system/core/+/946923/3/init/builtins.cpp#b710

Error:
`host_init_verifier: device/sony/common/rootdir/vendor/etc/init/hw/init.common.rc: 69: Invalid keyword 'verity_load_state'`
