### PR TITLE
[COMMON] [R] Re-enable "required" Bluetooth SapService

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -139,6 +139,10 @@ MODEM_CONFIG := $(shell find $(COMMON_PATH)/rootdir/vendor/oem/modem-config -typ
 endif
 PRODUCT_COPY_FILES += $(MODEM_CONFIG)
 
+# Bluetooth
+PRODUCT_COPY_FILES += \
+    $(COMMON_PATH)/rootdir/vendor/etc/sysconfig/component-overrides.xml:$(TARGET_COPY_OUT_VENDOR)/etc/sysconfig/component-overrides.xml
+
 -include device/sony/customization/customization.mk
 
 $(call inherit-product, device/sony/common/common-init.mk)

--- a/overlay/packages/apps/Bluetooth/res/values/config.xml
+++ b/overlay/packages/apps/Bluetooth/res/values/config.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<resources>
-    <bool name="profile_supported_sap">true</bool>
-</resources>

--- a/rootdir/vendor/etc/sysconfig/component-overrides.xml
+++ b/rootdir/vendor/etc/sysconfig/component-overrides.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2019 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<config>
+    <component-override package="com.android.bluetooth" >
+        <component class=".sap.SapService" enabled="true" />
+    </component-override>
+</config>


### PR DESCRIPTION
Runtime Resource Overlays (RROs) can no longer change the value of
resources in manifest when read during PackagerParser.

This change uses component-override to enable the service by default
on all devices.

Remove usages of profile_supported_sap from overlays as they no
longer configure the enable state of .sap.SapService.

Bug: 135048762
Test: adb shell pm query-services \
      com.android.bluetooth/.sap.SapService

Change-Id: If41df9fdefbcd952f8387451dc137565343e3d75

---

@sjllls thanks for bringing this one to my attention! After looking closer at the logs it's pretty obvious why this happens:

```log
W ActivityManager: Unable to start service Intent { cmp=com.android.bluetooth/.sap.SapService (has extras) } U=0: not found
```

Fine, Sim Access Profile should be optional... Then later in the logs, where the adapter is supposed to start:

```log
E AdapterState: TURNING_ON : BREDR_START_TIMEOUT
```

As it turns out BR/EDR in this context [waits for all profiles](https://cs.android.com/android/platform/superproject/+/master:packages/apps/Bluetooth/src/com/android/bluetooth/btservice/AdapterService.java;l=342;drc=master;bpv=1;bpt=1) (services, such as the `SapService`) to show up :grimacing:

Sidenote: If we were to disable sap service from the overlay this wouldn't have occured either; it wouldn't be [marked](https://cs.android.com/android/platform/superproject/+/master:packages/apps/Bluetooth/src/com/android/bluetooth/btservice/Config.java;l=95;drc=master;bpv=1;bpt=1) as [supported](https://cs.android.com/android/platform/superproject/+/master:packages/apps/Bluetooth/src/com/android/bluetooth/btservice/Config.java;l=127;drc=master;bpv=1;bpt=1) and hence not block the adapter from starting.
