### PR TITLE
[COMMON] [R] Switch clearkey to version 1.3; all drm services to lazy

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -127,8 +127,8 @@ endif
 # DRM
 PRODUCT_PACKAGES += \
     android.hardware.drm@1.0-impl \
-    android.hardware.drm@1.0-service \
-    android.hardware.drm@1.2-service.clearkey
+    android.hardware.drm@1.0-service-lazy \
+    android.hardware.drm@1.3-service-lazy.clearkey
 
 ifneq ($(BOARD_USE_LEGACY_USB),true)
 # Usb HAL

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -74,8 +74,6 @@
             <name>IDrmFactory</name>
             <instance>default</instance>
         </interface>
-        <fqname>@1.2::ICryptoFactory/clearkey</fqname>
-        <fqname>@1.2::IDrmFactory/clearkey</fqname>
     </hal>
     <hal format="hidl">
         <name>android.hardware.gatekeeper</name>


### PR DESCRIPTION
Android now includes vintf fragments for clearkey so the unnecessary and
wrongly versioned redeclaration is removed from our manifest.

Furthermore the service that is hosted with 1.2 or 1.3 is the same
except for vintf and the lazy interface version that is exposed.
Enforcing vintf expects us to declare exactly what is hosted, even if
1.2 should technically allow 1.3 to run:

    I init    : starting service 'vendor.drm-clearkey-hal-1-2'...
    I hwservicemanager: getTransport: Cannot find entry android.hardware.drm@1.3::IDrmFactory/clearkey in either framework or device manifest.
    E HidlServiceManagement: Service android.hardware.drm@1.3::IDrmFactory/clearkey must be in VINTF manifest in order to register/get.
    F android.hardware.drm@1.2-service.clearkey: Check failed: drmFactory->registerAsService("clearkey") == android::NO_ERROR (drmFactory->registerAsService("clearkey")=-2147483648, android::NO_ERROR=0) Failed to register Clearkey Factory HAL
    F libc    : Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 8748 (android.hardwar), pid 8748 (android.hardwar)

Switching both clearkey and the encapsulating drm service to lazy allows
them to run only when necessary and shut down after.
