### PR TITLE
[COMMON] [R/ODM] vintf: imsservices: Add IImsFactory and clean up fqname dupes

### DIFF
--- a/vintf/vendor.hw.imsservices.xml
+++ b/vintf/vendor.hw.imsservices.xml
@@ -10,6 +10,11 @@
         <fqname>@1.0::IService/default</fqname>
     </hal>
     <hal format="hidl">
+        <name>vendor.qti.ims.factory</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::IImsFactory/default</fqname>
+    </hal>
+    <hal format="hidl">
         <name>vendor.qti.imsrtpservice</name>
         <transport>hwbinder</transport>
         <version>2.1</version>
@@ -22,11 +27,6 @@
     <hal format="hidl">
         <name>com.qualcomm.qti.imscmservice</name>
         <transport>hwbinder</transport>
-        <version>2.2</version>
-        <interface>
-            <name>IImsCmService</name>
-            <instance>qti.ims.connectionmanagerservice</instance>
-        </interface>
         <fqname>@2.2::IImsCmService/qti.ims.connectionmanagerservice</fqname>
     </hal>
 </manifest>


### PR DESCRIPTION
Vendor blobs for Android 11 host this new service:

    E HidlServiceManagement: Service vendor.qti.ims.factory@1.0::IImsFactory/default must be in VINTF manifest in order to register/get.
    F imsrcsd : ImsRcsBaseImpl.cpp:101] Check failed: ((ImsFactory*) m_pImsFactory)->registerAsService() == android::NO_ERROR (((ImsFactory*) m_pImsFactory)->registerAsService()=-2147483648, android::NO_ERROR=0) Failed to register ImsFactory HAL
