### PR TITLE
[COMMON] [R] Update vintf versions for strict matching

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -209,6 +209,12 @@ else
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.graphics_v2.xml
 endif
 
+ifeq ($(TARGET_VIBRATOR_V1_2),true)
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.vibrator_v1.2.xml
+else
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.vibrator_v1.0.xml
+endif
+
 # New vendor security patch level: https://r.android.com/660840/
 # Used by newer keymaster binaries
 VENDOR_SECURITY_PATCH=$(PLATFORM_SECURITY_PATCH)

--- a/vintf/android.hardware.vibrator_v1.0.xml
+++ b/vintf/android.hardware.vibrator_v1.0.xml
@@ -1,0 +1,7 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.vibrator</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::IVibrator/default</fqname>
+    </hal>
+</manifest>

--- a/vintf/android.hardware.vibrator_v1.2.xml
+++ b/vintf/android.hardware.vibrator_v1.2.xml
@@ -1,0 +1,7 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.vibrator</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.2::IVibrator/default</fqname>
+    </hal>
+</manifest>

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -215,13 +215,4 @@
         <transport>hwbinder</transport>
         <fqname>@1.0::IOffloadControl/default</fqname>
     </hal>
-    <hal format="hidl">
-        <name>android.hardware.vibrator</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>IVibrator</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
 </manifest>

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -105,7 +105,7 @@
     <hal format="hidl">
         <name>vendor.display.config</name>
         <transport>hwbinder</transport>
-        <version>1.2</version>
+        <version>1.10</version>
         <interface>
             <name>IDisplayConfig</name>
             <instance>default</instance>


### PR DESCRIPTION
Android R enforces strict matching of hosted service versions and the version declared in vintf; a mismatch, even if technically allowed by semver is denied and the service fails to register.
This is likely done in favour of strict consistency; declaring a lower version than what is hosted previously (Android Q) allowed interface consumers to use that higher version without being limited by vintf, making it partly useless to reflect exactly what it hosted unless mandated by a targeted FCM.
