### PR TITLE
[COMMON] [R] Include vendor variant of libavservices_minijail

### DIFF
--- a/common-packages.mk
+++ b/common-packages.mk
@@ -117,7 +117,7 @@ PRODUCT_PACKAGES += \
 
 # Media
 PRODUCT_PACKAGES += \
-    libavservices_minijail
+    libavservices_minijail.vendor
 
 # OSS Time service
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
`libavservices_minijail` is `vendor_available`, meaning that a `PRODUCT_PACKAGES` dependency on it includes its system variant. This is _not_ part of the vndk and hence unavailable to odm blobs, leaving:

    F linker  : CANNOT LINK EXECUTABLE "/odm/bin/ims_rtp_daemon": library "libavservices_minijail.so" not found: needed by main executable

in place. Neither would that approach suffice for GSIs. Use a vendor
dependency to ensure the library is included in /vendor and available to
blobs.

(sidenote: Another 32-bit transitive dependency already includes this
library, this merely adds the 64-bit library for `ims_rtp_daemon`)

Fixes: 820955e5f6df3554ced911c17fbaebd2502c1ab1
