### PR TITLE
[COMMON] [R] [2/3] TESTME: Update to audio@6.0 (HAL 3.0)

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -131,80 +131,80 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Audio
 PRODUCT_PROPERTY_OVERRIDES += \
-    media.aac_51_output_enabled=true \
     audio.deep_buffer.media=true \
     fmas.hdph_sgain=0 \
-    ro.config.vc_call_vol_steps=7 \
-    ro.config.media_vol_steps=25
+    media.aac_51_output_enabled=true \
+    ro.config.media_vol_steps=25 \
+    ro.config.vc_call_vol_steps=7
 
 # Audio (AOSP HAL)
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.qc.sdk.audio.fluencetype=fluence \
+    persist.audio.fluence.speaker=true \
     persist.audio.fluence.voicecall=true \
     persist.audio.fluence.voicecomm=true \
     persist.audio.fluence.voicerec=true \
-    persist.audio.fluence.speaker=true
+    ro.qc.sdk.audio.fluencetype=fluence
 
 # Audio (newer CAF HALs)
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.vendor.audio.sdk.fluencetype=fluence \
+    persist.vendor.audio.fluence.speaker=true \
     persist.vendor.audio.fluence.voicecall=true \
     persist.vendor.audio.fluence.voicecomm=true \
     persist.vendor.audio.fluence.voicerec=true \
-    persist.vendor.audio.fluence.speaker=true \
-    vendor.audio.offload.track.enable=true \
-    vendor.voice.path.for.pcm.voip=true \
+    ro.vendor.audio.sdk.fluencetype=fluence \
+    vendor.audio_hal.in_period_size=144 \
+    vendor.audio_hal.period_multiplier=3 \
+    vendor.audio_hal.period_size=192 \
+    vendor.audio.offload.gapless.enabled=true \
     vendor.audio.offload.multiaac.enable=true \
     vendor.audio.offload.multiple.enabled=false \
     vendor.audio.offload.passthrough=false \
-    vendor.audio.offload.gapless.enabled=true \
+    vendor.audio.offload.track.enable=true \
     vendor.audio.parser.ip.buffer.size=262144 \
     vendor.audio.volume.headset.gain.depcal=true \
-    vendor.audio_hal.period_size=192 \
-    vendor.audio_hal.in_period_size=144 \
-    vendor.audio_hal.period_multiplier=3
+    vendor.voice.path.for.pcm.voip=true
 
 # Audio (CAF - Hardware enc/decoding)
 PRODUCT_PROPERTY_OVERRIDES += \
     vendor.audio.flac.sw.decoder.24bit=true \
+    vendor.audio.hw.aac.encoder=true \
     vendor.audio.use.sw.alac.decoder=true \
-    vendor.audio.use.sw.ape.decoder=true \
-    vendor.audio.hw.aac.encoder=true
+    vendor.audio.use.sw.ape.decoder=true
 
 # Audio Features
 PRODUCT_PROPERTY_OVERRIDES += \
     vendor.audio.feature.afe_proxy.enable=true \
     vendor.audio.feature.anc_headset.enable=true \
+    vendor.audio.feature.audiozoom.enable=false \
     vendor.audio.feature.battery_listener.enable=false \
     vendor.audio.feature.compr_cap.enable=false \
     vendor.audio.feature.compress_meta_data.enable=true \
+    vendor.audio.feature.deepbuffer_as_primary.enable=false \
     vendor.audio.feature.dsm_feedback.enable=false \
     vendor.audio.feature.ext_hw_plugin.enable=false \
     vendor.audio.feature.external_dsp.enable=false \
-    vendor.audio.feature.external_speaker.enable=false \
     vendor.audio.feature.external_speaker_tfa.enable=false \
+    vendor.audio.feature.external_speaker.enable=false \
     vendor.audio.feature.fluence.enable=true \
     vendor.audio.feature.fm.enable=true \
     vendor.audio.feature.hfp.enable=true \
     vendor.audio.feature.hifi_audio.enable=false \
     vendor.audio.feature.hwdep_cal.enable=false \
     vendor.audio.feature.incall_music.enable=false \
-    vendor.audio.feature.multi_voice_session.enable=true \
     vendor.audio.feature.keep_alive.enable=false \
     vendor.audio.feature.maxx_audio.enable=false \
+    vendor.audio.feature.multi_voice_session.enable=true \
     vendor.audio.feature.ras.enable=true \
     vendor.audio.feature.record_play_concurency.enable=false \
-    vendor.audio.feature.src_trkn.enable=true \
+    vendor.audio.feature.snd_mon.enable=true \
     vendor.audio.feature.spkr_prot.enable=true \
+    vendor.audio.feature.src_trkn.enable=true \
     vendor.audio.feature.ssrec.enable=true \
-    vendor.audio.feature.usb_offload.enable=true \
     vendor.audio.feature.usb_offload_burst_mode.enable=false \
     vendor.audio.feature.usb_offload_sidetone_volume.enable=false \
-    vendor.audio.feature.deepbuffer_as_primary.enable=false \
+    vendor.audio.feature.usb_offload.enable=true \
     vendor.audio.feature.vbat.enable=true \
-    vendor.audio.feature.wsa.enable=false \
-    vendor.audio.feature.audiozoom.enable=false \
-    vendor.audio.feature.snd_mon.enable=true
+    vendor.audio.feature.wsa.enable=false
 
 # AudioPolicy Manager
 PRODUCT_PROPERTY_OVERRIDES += \

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -43,9 +43,9 @@ PRODUCT_PACKAGES += \
 
 # Audio
 PRODUCT_PACKAGES += \
-    android.hardware.audio@5.0-impl:32 \
+    android.hardware.audio@6.0-impl:32 \
     android.hardware.audio.service \
-    android.hardware.audio.effect@5.0-impl:32 \
+    android.hardware.audio.effect@6.0-impl:32 \
     android.hardware.bluetooth.audio@2.0-impl \
     android.hardware.soundtrigger@2.2-impl
 

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -44,7 +44,7 @@ PRODUCT_PACKAGES += \
 # Audio
 PRODUCT_PACKAGES += \
     android.hardware.audio@5.0-impl:32 \
-    android.hardware.audio@2.0-service \
+    android.hardware.audio.service \
     android.hardware.audio.effect@5.0-impl:32 \
     android.hardware.bluetooth.audio@2.0-impl \
     android.hardware.soundtrigger@2.2-impl

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -2,7 +2,7 @@
     <hal format="hidl">
         <name>android.hardware.audio</name>
         <transport>hwbinder</transport>
-        <version>5.0</version>
+        <version>6.0</version>
         <interface>
             <name>IDevicesFactory</name>
             <instance>default</instance>
@@ -11,7 +11,7 @@
     <hal format="hidl">
         <name>android.hardware.audio.effect</name>
         <transport>hwbinder</transport>
-        <version>5.0</version>
+        <version>6.0</version>
         <interface>
             <name>IEffectsFactory</name>
             <instance>default</instance>


### PR DESCRIPTION
Depends on https://github.com/sonyxperiadev/vendor-qcom-opensource-audio-hal-primary-hal/pull/8

The new API interface contains, among which, a new audio patch updating function to support more quickly and efficiently rerouting an audio stream without disruption. Despite the new (NICOBAR 9.11) CAF audio HAL supporting this function, no improvement is noticed when switching between speakers and BT headphones (assuming A2DP offloading - a feature that has not yet made it to sonyxperiadev repos but is in testing locally - which routes audio through the HAL and DSP for BT instead of Androids software bluetooth playback "device").

See the above PR for more details about testing progress!
