### PR TITLE
[DONOTMERGE] [1/2] Tracking PR for secure element feature

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -165,11 +165,26 @@ endif
 # SELinux
 include device/sony/sepolicy/sepolicy.mk
 
+# Device manifest: What HALs the device provides
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/manifest.xml
+# Framework compatibility matrix: What the device(=vendor) expects of the framework(=system)
 DEVICE_MATRIX_FILE   += $(COMMON_PATH)/vintf/compatibility_matrix.xml
 
-# Custom NXP vendor interfaces
-DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.nxp.nfc.interfaces.xml
+# Custom NXP NFC vendor interface
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.nxp.nxpnfc.xml
+
+# Secure Element
+ifeq ($(TARGET_HAS_SECURE_ELEMENT),true)
+# NFC secure element, eSE1
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.nxp.nxpese.xml
+
+# SIM secure element, SIM1/SIM2
+ifeq ($(PRODUCT_DEVICE_DS),true)
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.secure_element_ds.xml
+else
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.secure_element_ss.xml
+endif
+endif
 
 # Dynamic Power Management
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.qualcomm.qti.dpm.xml

--- a/vintf/android.hardware.secure_element_ds.xml
+++ b/vintf/android.hardware.secure_element_ds.xml
@@ -1,0 +1,8 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.secure_element</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::ISecureElement/SIM1</fqname>
+        <fqname>@1.0::ISecureElement/SIM2</fqname>
+    </hal>
+</manifest>

--- a/vintf/android.hardware.secure_element_ss.xml
+++ b/vintf/android.hardware.secure_element_ss.xml
@@ -1,0 +1,7 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.secure_element</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::ISecureElement/SIM1</fqname>
+    </hal>
+</manifest>

--- a/vintf/vendor.nxp.nxpese.xml
+++ b/vintf/vendor.nxp.nxpese.xml
@@ -1,0 +1,12 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>vendor.nxp.nxpese</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::INxpEse/default</fqname>
+    </hal>
+    <hal format="hidl">
+        <name>android.hardware.secure_element</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.1::ISecureElement/eSE1</fqname>
+    </hal>
+</manifest>

--- a/vintf/vendor.nxp.nxpnfc.xml
+++ b/vintf/vendor.nxp.nxpnfc.xml
@@ -2,10 +2,6 @@
     <hal format="hidl">
         <name>vendor.nxp.nxpnfc</name>
         <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>INxpNfc</name>
-            <instance>default</instance>
-        </interface>
+        <fqname>@1.0::INxpNfc/default</fqname>
     </hal>
 </manifest>


### PR DESCRIPTION
This is a fixup of #720. As it turns out the PR might be slightly more complex to enable access to the SE in the NFC chip. Access to the SE in a UICC should be fine.

TODO:
- [ ] Seine and Kumano are the only devices with a PN557 from NXP which seems to have an "NFC secure element" but lack a config file (on stock and SODP); the HAL will crash without this. A variant of the file is easily available in the repo: https://cs.android.com/android/_/android/platform/hardware/nxp/secure_element/+/master:libese-spi/p73/libese-nxp-P73.conf but lack of this on stock makes me curious: how's that working?
- [ ] `SIM1` and `SIM2` are hosted by `qcrild`; do all our devices have access to the SE in the UICC, or is that limited for Seine and Kumano?
- [ ] @ix5 What's your feeling towards file naming? `vendor.nxp.nxpese.xml` should IMO get a name that represents the service from `hardware/nxp/secure_element` that hosts both `INxpEse` as well as `ISecureElement/eSE1`. Likewise `ISecureElement/SIM[12]` should be moved to an existing (renamed) SS/DS file representing `qcrild`, which hosts those.
     In other words, I think we should name vintf files (logically) after the services hosting them rather than the name of the service itself; that can be read from the contents. Unless you disagree, then it's best to move `eSE1` into `android.hardware.secure_element.xml` (wihout ss/ds postfix, of course).
- [ ] #720 was initially filed for Q, this should be backwards compatible and merged there.