### PR TITLE
[COMMON] [Q/R] vintf: Add Secure Element interface for SIM cards (UICC)

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -161,11 +161,20 @@ endif
 # SELinux
 include device/sony/sepolicy/sepolicy.mk
 
+# Device manifest: What HALs the device provides
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/manifest.xml
+# Framework compatibility matrix: What the device(=vendor) expects of the framework(=system)
 DEVICE_MATRIX_FILE   += $(COMMON_PATH)/vintf/compatibility_matrix.xml
 
-# Custom NXP vendor interfaces
-DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.nxp.nfc.interfaces.xml
+# Custom NXP NFC vendor interface
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.nxp.nxpnfc.xml
+
+# SIM secure element, SIM1/SIM2
+ifeq ($(PRODUCT_DEVICE_DS),true)
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.secure_element_ds.xml
+else
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.secure_element_ss.xml
+endif
 
 # Dynamic Power Management
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.qualcomm.qti.dpm.xml

--- a/vintf/android.hardware.secure_element_ds.xml
+++ b/vintf/android.hardware.secure_element_ds.xml
@@ -1,0 +1,8 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.secure_element</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::ISecureElement/SIM1</fqname>
+        <fqname>@1.0::ISecureElement/SIM2</fqname>
+    </hal>
+</manifest>

--- a/vintf/android.hardware.secure_element_ss.xml
+++ b/vintf/android.hardware.secure_element_ss.xml
@@ -1,0 +1,7 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.secure_element</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::ISecureElement/SIM1</fqname>
+    </hal>
+</manifest>

--- a/vintf/vendor.nxp.nxpnfc.xml
+++ b/vintf/vendor.nxp.nxpnfc.xml
@@ -2,10 +2,6 @@
     <hal format="hidl">
         <name>vendor.nxp.nxpnfc</name>
         <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>INxpNfc</name>
-            <instance>default</instance>
-        </interface>
+        <fqname>@1.0::INxpNfc/default</fqname>
     </hal>
 </manifest>


### PR DESCRIPTION
Continuation of #720 and #792 

Qcrild provides access to the UICC through a Secure Element interface. Add a SS and DS vintf manifest to allow this interface to be hosted and retrieved.

Also clean up the vintf for NXP NFC, which was part of the original PR that covered SE for NFC (eSE1) as well.

@jerpelea Can you rebase master as soon as this lands on Q?