### PR TITLE
[master] common: Update vendor boot variable

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -27,10 +27,6 @@ TARGET_NO_BOOTLOADER := true
 TARGET_NO_RECOVERY ?= false
 TARGET_NO_KERNEL := false
 
-# Android R: Disable logic for new vendor_boot
-# Our devices do not support it
-TARGET_NO_VENDOR_BOOT := true
-
 # common cmdline parameters
 ifneq ($(BOARD_USE_ENFORCING_SELINUX),true)
 BOARD_KERNEL_CMDLINE += androidboot.selinux=permissive

--- a/common.mk
+++ b/common.mk
@@ -52,6 +52,10 @@ PRODUCT_BUILD_RECOVERY_IMAGE := true
 # Force building a boot image. This needs to be set explicitly since Android R
 PRODUCT_BUILD_BOOT_IMAGE := true
 
+# Android R: Disable logic for new vendor_boot
+# Our devices do not support it
+PRODUCT_BUILD_VENDOR_BOOT_IMAGE := false
+
 KERNEL_PATH := kernel/sony/msm-$(SOMC_KERNEL_VERSION)
 # Sanitized prebuilt kernel headers
 -include $(KERNEL_PATH)/common-headers/KernelHeaders.mk


### PR DESCRIPTION
See https://r.android.com/1457443

The variable also needs to be set earlier now since it's read-only by the time `CommonConfig.mk` is read.

Groundhog day, yada yada. The CADT is strong with El Goog.