### PR TITLE
[master] Disable TARGET_BOARD_AUTO

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -20,8 +20,6 @@ COMMON_PATH := device/sony/common
 # Do not build proprietary capability
 TARGET_USES_AOSP := true
 
-TARGET_BOARD_AUTO := true
-
 TARGET_NO_RADIOIMAGE := true
 TARGET_NO_BOOTLOADER := true
 TARGET_NO_RECOVERY ?= false


### PR DESCRIPTION
There is no need nowadays to rely on `AUTO` platform features.

Depends on https://github.com/sonyxperiadev/local_manifests/pull/115 to build successfully on `yoshino`.