### PR TITLE
[q-mr1] odm: Add build.prop cleaner

### DIFF
--- a/common-odm.mk
+++ b/common-odm.mk
@@ -11,6 +11,10 @@ BOARD_ODMIMAGE_FILE_SYSTEM_TYPE := ext4
 PRODUCT_ODM_PROPERTIES += \
     ro.odm.version=$(PLATFORM_VERSION)_$(SOMC_KERNEL_VERSION)_$(SOMC_PLATFORM)_$(TARGET_VENDOR_VERSION)
 
+# Clear device-specific info from platform-level odm image
+PRODUCT_PACKAGES += \
+    odm_prop_cleaner
+
 # SDE DRM
 PRODUCT_PACKAGES += \
     libsdedrm

--- a/hardware/odm/Android.mk
+++ b/hardware/odm/Android.mk
@@ -1,0 +1,11 @@
+# Remove device-specific props from odm
+
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := odm_prop_cleaner
+LOCAL_MODULE_PATH := $(TARGET_OUT_ODM)
+
+LOCAL_POST_INSTALL_CMD := sed -i '/ro.product.odm/d' $(TARGET_OUT_ODM)/etc/build.prop
+
+include $(BUILD_PHONY_PACKAGE)


### PR DESCRIPTION
Certain props need to be filtered out from the proprietary `odm` image ("Software Binaries") because they are device-specific, while the `odm` image is released per platform.