### PR TITLE
[q-mr1] odm: Only leave ro.odm.expect in build.prop

### DIFF
--- a/hardware/odm/Android.mk
+++ b/hardware/odm/Android.mk
@@ -6,6 +6,6 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := odm_prop_cleaner
 LOCAL_MODULE_PATH := $(TARGET_OUT_ODM)
 
-LOCAL_POST_INSTALL_CMD := sed -i '/ro.product.odm/d' $(TARGET_OUT_ODM)/etc/build.prop
+LOCAL_POST_INSTALL_CMD := sed -i '/^ro.odm.version/!d' $(TARGET_OUT_ODM)/etc/build.prop
 
 include $(BUILD_PHONY_PACKAGE)


### PR DESCRIPTION
We need to be a bit more thorough since `ro.odm.product.*` etc. can also be generated.

Explanation:
`sed -i '/ro.product.odm/d` only cleans every line containing `ro.product.odm`.
`sed -i '/^ro.odm.version/!d` removes every line _not_ starting with `ro.odm.version`.