### PR TITLE
hardware/qcom/Android.mk: Add sm8250 (KONA) to media platform lists.

### DIFF
--- a/hardware/qcom/Android.mk
+++ b/hardware/qcom/Android.mk
@@ -3,18 +3,18 @@ ifneq ($(wildcard device/sony/common/hardware/qcom/custom.mk),)
 else
 # Board platforms lists to be used for
 # TARGET_BOARD_PLATFORM specific featurization
-QCOM_BOARD_PLATFORMS += msm8952 msm8996 msm8998 sdm660 sdm845 sm6125 sm8150
+QCOM_BOARD_PLATFORMS += msm8952 msm8996 msm8998 sdm660 sdm845 sm6125 sm8150 sm8250
 
 # Some supported platforms need a different media hal
 # This list selects platforms that should use the latest media hal
 # All other platforms automatically fallback to the legacy hal
-QCOM_NEW_MEDIA_PLATFORM := sdm845 sm6125 sm8150
+QCOM_NEW_MEDIA_PLATFORM := sdm845 sm6125 sm8150 sm8250
 
 #List of targets that use video hw
-MSM_VIDC_TARGET_LIST := msm8952 msm8996 msm8998 sdm660 sdm845 sm6125 sm8150
+MSM_VIDC_TARGET_LIST := msm8952 msm8996 msm8998 sdm660 sdm845 sm6125 sm8150 sm8250
 
 #List of targets that use master side content protection
-MASTER_SIDE_CP_TARGET_LIST := msm8996 msm8998 sdm660 sdm845 sm6125 sm8150
+MASTER_SIDE_CP_TARGET_LIST := msm8996 msm8998 sdm660 sdm845 sm6125 sm8150 sm8250
 
 ifneq ($(filter $(QCOM_NEW_MEDIA_PLATFORM), $(TARGET_BOARD_PLATFORM)),)
 QCOM_MEDIA_ROOT := vendor/qcom/opensource/media/sm8150


### PR DESCRIPTION
Without this we would fallback to sdm660-libion media HAL which is wrong.
Add sm8250 to the lists so that the correct HALs are used.