### PR TITLE
[COMMON] common: MDM helper and new directory

### DIFF
--- a/common-init.mk
+++ b/common-init.mk
@@ -18,6 +18,7 @@ PRODUCT_PACKAGES += \
     adb_tcp.rc \
     adpl.rc \
     adsprpcd.rc \
+    atfwd.rc \
     audiopd.rc \
     cdsprpcd.rc \
     cnd.rc \

--- a/common-init.mk
+++ b/common-init.mk
@@ -33,6 +33,7 @@ PRODUCT_PACKAGES += \
     ims_rtp_daemon.rc \
     irsc_util.rc \
     mlog_qmi.rc \
+    mdm_helper.rc \
     msm_irq.rc \
     netmgrd.rc \
     pd_mapper.rc \

--- a/rootdir/Android.bp
+++ b/rootdir/Android.bp
@@ -65,6 +65,13 @@ prebuilt_etc {
 }
 
 prebuilt_etc {
+    name: "atfwd.rc",
+    src: "vendor/etc/init/atfwd.rc",
+    sub_dir: "init",
+    vendor: true,
+}
+
+prebuilt_etc {
     name: "cnd.rc",
     src: "vendor/etc/init/cnd.rc",
     sub_dir: "init",

--- a/rootdir/Android.bp
+++ b/rootdir/Android.bp
@@ -121,6 +121,13 @@ prebuilt_etc {
 }
 
 prebuilt_etc {
+    name: "mdm_helper.rc",
+    src: "vendor/etc/init/mdm_helper.rc",
+    sub_dir: "init",
+    vendor: true,
+}
+
+prebuilt_etc {
     name: "msm_irq.rc",
     src: "vendor/etc/init/msm_irq.rc",
     sub_dir: "init",

--- a/rootdir/vendor/etc/init/atfwd.rc
+++ b/rootdir/vendor/etc/init/atfwd.rc
@@ -1,0 +1,9 @@
+# AT forwarding Daemon
+service vendor.atfwd /odm/bin/ATFWD-daemon
+    class late_start
+    user system
+    group system radio
+    disabled
+
+on property:ro.boot.baseband=mdm
+    enable vendor.atfwd

--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -205,6 +205,9 @@ on post-fs-data
     # RIL directoy for services
     mkdir /data/vendor/radio 0771 system radio
 
+    # Create directory for modem_config
+    mkdir /data/vendor/modem_config 0570 radio root
+
     chown system /dev/block/bootdevice/by-name
 
     setprop vold.post_fs_data_done 1

--- a/rootdir/vendor/etc/init/mdm_helper.rc
+++ b/rootdir/vendor/etc/init/mdm_helper.rc
@@ -1,0 +1,8 @@
+# External modem services
+service vendor.mdm_helper /odm/bin/mdm_helper
+    class core
+    group system wakelock
+    disabled
+
+on property:ro.baseband=mdm
+    start vendor.mdm_helper


### PR DESCRIPTION
The Edo platform has an external SDX55 PCIe modem: add the
mdm helper to initialize it.