### PR TITLE
[COMMON] init: netmgrd: Start netmgr daemon for external modem

### DIFF
--- a/rootdir/vendor/etc/init/netmgrd.rc
+++ b/rootdir/vendor/etc/init/netmgrd.rc
@@ -19,3 +19,6 @@ on property:ro.boot.baseband=msm
 
 on property:ro.boot.baseband=sdm
     enable vendor.netmgrd
+
+on property:ro.boot.baseband=mdm
+    enable vendor.netmgrd


### PR DESCRIPTION
External modem network is managed by netmgrd.
This is the case with SDX55 on SM8250/SDA865.