### PR TITLE
[COMMON] init: Add pd_mapper service to SM8250 platforms

### DIFF
--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -148,7 +148,7 @@ LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 endif # TARGET_BOARD_PLATFORM in (sm6125)
 
-ifneq ($(filter sdm660 msm8998 sdm845 sm6125 sm8150,$(TARGET_BOARD_PLATFORM)),)
+ifneq ($(filter sdm660 msm8998 sdm845 sm6125 sm8150 sm8250,$(TARGET_BOARD_PLATFORM)),)
 include $(CLEAR_VARS)
 LOCAL_MODULE := pd_mapper.rc
 LOCAL_MODULE_CLASS := ETC


### PR DESCRIPTION
The SM8250 platforms have PDRs discoverable with pd_mapper.