### PR TITLE
[COMMON] [MASTER] rootdir: Unconditionally provide pd_mapper and tftp_server rcs

### DIFF
--- a/rootdir/Android.bp
+++ b/rootdir/Android.bp
@@ -259,3 +259,17 @@ prebuilt_etc {
     sub_dir: "init",
     vendor: true,
 }
+
+prebuilt_etc {
+    name: "pd_mapper.rc",
+    src: "vendor/etc/init/pd_mapper.rc",
+    sub_dir: "init",
+    vendor: true,
+}
+
+prebuilt_etc {
+    name: "tftp_server.rc",
+    src: "vendor/etc/init/tftp_server.rc",
+    sub_dir: "init",
+    vendor: true,
+}

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -148,24 +148,6 @@ LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 endif # TARGET_BOARD_PLATFORM in (sm6125)
 
-ifneq ($(filter sdm660 msm8998 sdm845 sm6125 sm8150,$(TARGET_BOARD_PLATFORM)),)
-include $(CLEAR_VARS)
-LOCAL_MODULE := pd_mapper.rc
-LOCAL_MODULE_CLASS := ETC
-LOCAL_SRC_FILES := vendor/etc/init/pd_mapper.rc
-LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
-include $(BUILD_PREBUILT)
-
-include $(CLEAR_VARS)
-LOCAL_MODULE := tftp_server.rc
-LOCAL_MODULE_CLASS := ETC
-LOCAL_SRC_FILES := vendor/etc/init/tftp_server.rc
-LOCAL_MODULE_TAGS := optional
-LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
-include $(BUILD_PREBUILT)
-endif # TARGET_BOARD_PLATFORM in (sdm660 msm8998 sdm845 sm6125 sm8150)
-
 ifeq ($(WIFI_DRIVER_BUILT),qca_cld3)
 include $(CLEAR_VARS)
 LOCAL_MODULE := cnss-daemon.rc


### PR DESCRIPTION
All boards listed here and new (unlisted!) SM8250 are the only ones supported by SODP R. Remove the guard entirely.
