### PR TITLE
[DONOTMERGE] [COMMON] [master] common-treble: Migrate to sensors@2.1 multihal

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -82,9 +82,14 @@ PRODUCT_PACKAGES += \
     android.hardware.health@2.0-service.sony
 
 # Sensors
+# PRODUCT_PACKAGES += \
+#     android.hardware.sensors@1.0-impl:64 \
+#     android.hardware.sensors@1.0-service
+
 PRODUCT_PACKAGES += \
-    android.hardware.sensors@1.0-impl:64 \
-    android.hardware.sensors@1.0-service
+    android.hardware.sensors@2.1-service.multihal \
+    vendor.qti.hardware.display.mapper@1.1.vendor
+# Yes, some transitive library needs mapper otherwise sensors.ssc.so can't load...
 
 ifeq ($(TARGET_VIBRATOR_V1_2),true)
 # QTI Haptics Vibrator


### PR DESCRIPTION
The new sensor module on Edo needs/takes advantage of the extended API in sensors v2.

As far as I'm aware the libhardware interface hasn't changed, or at least not in such a way that we couldn't use 2.X on other platforms.  This change should be safe to merge if that works as normal, and otherwise all supported devices are expected to get recompiled with newer code that should support all this so that we can stick with one consistent, shared software stack (ie. no hacks to keep Edo at 9.x branches while the rest lives on at 7.x or 8.x).

Notes:
- This requires sensors.ssc.so (the libhw module) to reside under hw/ again, finally;
- Remove android.hardware.sensors@1.0 from vintf (2.X includes its own vintf fragment);
- One of the libs tries to open display mapper 1.1... Otherwise sensors.ssc.so silently fails to `dlopen`.
