### PR TITLE
[COMMON] [MASTER] [RESUBMIT] common-treble,vintf: Migrate to sensors@2.1 multihal

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -82,9 +82,12 @@ PRODUCT_PACKAGES += \
     android.hardware.health@2.0-service.sony
 
 # Sensors
+# hardware.ssc.so links against display mappers, of which
+# the interface libraries are explicitly included here:
 PRODUCT_PACKAGES += \
-    android.hardware.sensors@1.0-impl:64 \
-    android.hardware.sensors@1.0-service
+    android.hardware.sensors@2.1-service.multihal \
+    vendor.qti.hardware.display.mapper@1.1.vendor \
+    vendor.qti.hardware.display.mapper@3.0.vendor
 
 ifeq ($(TARGET_VIBRATOR_V1_2),true)
 # QTI Haptics Vibrator

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -179,15 +179,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.sensors</name>
-        <transport>hwbinder</transport>
-        <version>1.0</version>
-        <interface>
-            <name>ISensors</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.soundtrigger</name>
         <transport>hwbinder</transport>
         <version>2.2</version>


### PR DESCRIPTION
Cleaned up resubmission from #/820, this time iwithout donotmerge, notes and old commented-out bits :)

---

The new sensor module on edo needs/takes advantage of the extended API
in sensors v2. In due time all other platforms will receive the same
upgraded libhardware module and friends.

Notable changes:
- `sensors.ssc.so` (which is a libhardware module) finally resides under
  `hw/` again;
- The multihal includes its own vintf fragment, no need to declare this
  in our own file anymore;
- The new module strangely depends on diplay mapper 1.1 and 3.0, which
  have been explicitly included on the vendor partition (`.vendor`
  postfix):

      Type                 Name/Value
      ...
      (NEEDED)             Shared library: [android.hardware.graphics.mapper@3.0.so]
      (NEEDED)             Shared library: [android.hardware.graphics.mapper@2.0.so]
      (NEEDED)             Shared library: [vendor.qti.hardware.display.mapper@3.0.so]
      (NEEDED)             Shared library: [vendor.qti.hardware.display.mapper@1.1.so]
      ...
      (SONAME)             Library soname: [sensors.ssc.so]