### PR TITLE
[COMMON] vendor: init: sscrpcd: Add wakelock group to sensor dsp daemon

### DIFF
--- a/common-odm.mk
+++ b/common-odm.mk
@@ -655,11 +655,14 @@ PRODUCT_PACKAGES += \
     com.qti.node.memcpy \
     com.qti.hvx.binning \
     com.qti.hvx.addconstant \
+    com.qti.node.fcv \
+    com.qti.node.stitch \
     com.qti.node.gpu \
     com.qti.node.remosaic \
     com.qti.node.stitch \
     com.qti.node.depth \
     com.qti.tuned.default \
+    com.qti.stats.afd \
     fdconfigpreview \
     fdconfigpreviewlite \
     fdconfigvideo \

--- a/rootdir/vendor/etc/init/sscrpcd.rc
+++ b/rootdir/vendor/etc/init/sscrpcd.rc
@@ -1,7 +1,7 @@
 service vendor.sscrpcd /odm/bin/sscrpcd
     class core
     user system
-    group system
+    group system wakelock
     disabled
 
 on property:vendor.qcom.cdspup=1


### PR DESCRIPTION
This daemon can set a wakelock and will fail to initialize if it
has no permission to.