### PR TITLE
[COMMON] Add and fix esoc links, add CamX postprocessing manifest

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -218,6 +218,11 @@ else
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.vibrator_v1.0.xml
 endif
 
+# CamX manifests
+ifneq ($(filter edo,$(SOMC_PLATFORM)),)
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.qti.hardware.camera.postproc.xml
+endif
+
 # New vendor security patch level: https://r.android.com/660840/
 # Used by newer keymaster binaries
 VENDOR_SECURITY_PATCH=$(PLATFORM_SECURITY_PATCH)

--- a/common-binds.mk
+++ b/common-binds.mk
@@ -28,6 +28,21 @@
 # This, then, is a temporary workaround that will be applied only to
 # Android 10 based builds.
 
+# QTI libraries for system_ext
+PRODUCT_COPY_FILES += \
+    $(COMMON_PATH)/misc/emptyfile.zip:$(TARGET_COPY_OUT_PRODUCT)/lib/libOpenCL_system.so \
+    $(COMMON_PATH)/misc/emptyfile.zip:$(TARGET_COPY_OUT_PRODUCT)/lib/libQSEEComAPI_system.so \
+    $(COMMON_PATH)/misc/emptyfile.zip:$(TARGET_COPY_OUT_PRODUCT)/lib/libadsprpc_system.so \
+    $(COMMON_PATH)/misc/emptyfile.zip:$(TARGET_COPY_OUT_PRODUCT)/lib/libcdsprpc_system.so \
+    $(COMMON_PATH)/misc/emptyfile.zip:$(TARGET_COPY_OUT_PRODUCT)/lib/libmdsprpc_system.so \
+    $(COMMON_PATH)/misc/emptyfile.zip:$(TARGET_COPY_OUT_PRODUCT)/lib/libsdsprpc_system.so \
+    $(COMMON_PATH)/misc/emptyfile.zip:$(TARGET_COPY_OUT_PRODUCT)/lib64/libOpenCL_system.so \
+    $(COMMON_PATH)/misc/emptyfile.zip:$(TARGET_COPY_OUT_PRODUCT)/lib64/libQSEEComAPI_system.so \
+    $(COMMON_PATH)/misc/emptyfile.zip:$(TARGET_COPY_OUT_PRODUCT)/lib64/libadsprpc_system.so \
+    $(COMMON_PATH)/misc/emptyfile.zip:$(TARGET_COPY_OUT_PRODUCT)/lib64/libcdsprpc_system.so \
+    $(COMMON_PATH)/misc/emptyfile.zip:$(TARGET_COPY_OUT_PRODUCT)/lib64/libmdsprpc_system.so \
+    $(COMMON_PATH)/misc/emptyfile.zip:$(TARGET_COPY_OUT_PRODUCT)/lib64/libsdsprpc_system.so
+
 # Empty framework jars to bindmount from ODM
 PRODUCT_COPY_FILES += \
     $(COMMON_PATH)/misc/emptyfile.zip:$(TARGET_COPY_OUT_PRODUCT)/framework/com.qti.dpmframework.jar \

--- a/common-odm.mk
+++ b/common-odm.mk
@@ -655,11 +655,14 @@ PRODUCT_PACKAGES += \
     com.qti.node.memcpy \
     com.qti.hvx.binning \
     com.qti.hvx.addconstant \
+    com.qti.node.fcv \
+    com.qti.node.stitch \
     com.qti.node.gpu \
     com.qti.node.remosaic \
     com.qti.node.stitch \
     com.qti.node.depth \
     com.qti.tuned.default \
+    com.qti.stats.afd \
     fdconfigpreview \
     fdconfigpreviewlite \
     fdconfigvideo \

--- a/hardware/tftp/Android.mk
+++ b/hardware/tftp/Android.mk
@@ -24,6 +24,9 @@ target_soc := \
 ifeq ($(TARGET_USES_ESOC),true)
 target_soc += \
     mdm
+
+target_prefixes += \
+    tn
 endif
 
 # Prepend vendor and prefix directory to all link names:
@@ -53,6 +56,13 @@ SONY_SYMLINKS += \
         /data/vendor/tombstones/rfs/cdsp:$(TARGET_COPY_OUT_VENDOR)/rfs/$(tgtsoc)/cdsp/ramdumps \
         /data/vendor/tombstones/rfs/slpi:$(TARGET_COPY_OUT_VENDOR)/rfs/$(tgtsoc)/slpi/ramdumps \
     )
+
+ifeq ($(TARGET_USES_ESOC),true)
+SONY_SYMLINKS += \
+    $(foreach tgtsoc,$(target_soc), \
+        /data/vendor/tombstones/rfs/tn:$(TARGET_COPY_OUT_VENDOR)/rfs/$(tgtsoc)/tn/ramdumps \
+    )
+endif
 
 include $(SONY_BUILD_SYMLINKS)
 

--- a/hardware/tftp/Android.mk
+++ b/hardware/tftp/Android.mk
@@ -41,7 +41,7 @@ SONY_SYMLINKS := \
 SONY_SYMLINKS += \
     $(foreach tgtsoc,$(target_soc), \
         $(foreach prefix,$(target_prefixes), \
-            /mnt/vendor/persist/rfs/msm/$(prefix):$(TARGET_COPY_OUT_VENDOR)/rfs/msm/$(prefix)/readwrite \
+            /mnt/vendor/persist/rfs/$(tgtsoc)/$(prefix):$(TARGET_COPY_OUT_VENDOR)/rfs/$(tgtsoc)/$(prefix)/readwrite \
         ) \
     )
 

--- a/rootdir/vendor/etc/init/bindmount-misc.rc
+++ b/rootdir/vendor/etc/init/bindmount-misc.rc
@@ -1,4 +1,18 @@
 on post-fs
+    # Libraries
+    mount none /odm/system_ext/lib/libOpenCL_system.so /product/lib/libOpenCL_system.so bind rec
+    mount none /odm/system_ext/lib/libQSEEComAPI_system.so /product/lib/libQSEEComAPI_system.so bind rec
+    mount none /odm/system_ext/lib/libadsprpc_system.so /product/lib/libadsprpc_system.so bind rec
+    mount none /odm/system_ext/lib/libcdsprpc_system.so /product/lib/libcdsprpc_system.so bind rec
+    mount none /odm/system_ext/lib/libmdsprpc_system.so /product/lib/libmdsprpc_system.so bind rec
+    mount none /odm/system_ext/lib/libsdsprpc_system.so /product/lib/libsdsprpc_system.so bind rec
+    mount none /odm/system_ext/lib64/libOpenCL_system.so /product/lib64/libOpenCL_system.so bind rec
+    mount none /odm/system_ext/lib64/libQSEEComAPI_system.so /product/lib64/libQSEEComAPI_system.so bind rec
+    mount none /odm/system_ext/lib64/libadsprpc_system.so /product/lib64/libadsprpc_system.so bind rec
+    mount none /odm/system_ext/lib64/libcdsprpc_system.so /product/lib64/libcdsprpc_system.so bind rec
+    mount none /odm/system_ext/lib64/libmdsprpc_system.so /product/lib64/libmdsprpc_system.so bind rec
+    mount none /odm/system_ext/lib64/libsdsprpc_system.so /product/lib64/libsdsprpc_system.so bind rec
+
     # Frameworks
     mount none /odm/system_ext/framework/com.qti.dpmframework.jar /product/framework/com.qti.dpmframework.jar bind rec
     mount none /odm/system_ext/framework/com.qualcomm.qti.imscmservice-V2.0-java.jar /product/framework/com.qualcomm.qti.imscmservice-V2.0-java.jar bind rec

--- a/vintf/vendor.qti.hardware.camera.postproc.xml
+++ b/vintf/vendor.qti.hardware.camera.postproc.xml
@@ -1,0 +1,7 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>vendor.qti.hardware.camera.postproc</name>
+        <transport>hwbinder</transport>
+        <fqname>@1.0::IPostProcService/camerapostprocservice</fqname>
+    </hal>
+</manifest>


### PR DESCRIPTION
The MPSS readwrite link was not properly updated.
Also, add the 'tn' links, as the new platforms need it.