### PR TITLE
[r-mr1] rootdir: rmt_storage: Enabled based on baseband

### DIFF
--- a/rootdir/vendor/etc/init/rmt_storage.rc
+++ b/rootdir/vendor/etc/init/rmt_storage.rc
@@ -4,3 +4,12 @@ service vendor.rmt_storage /odm/bin/rmt_storage
     user root
     ioprio rt 0
     shutdown critical
+    disabled
+
+# Devices with internal modem
+on property ro.baseband=sdm
+    enable vendor.rmt_storage
+
+# Legacy devices with internal modem
+on property ro.baseband=msm
+    enable vendor.rmt_storage


### PR DESCRIPTION
Fixes confusing logspam for `mdm` targets:
```
E vendor.rmt_storage: Remote storage service is not supported on mdm target
```