### PR TITLE
[common] [R] hardware/camera: Emit symlinks for sm8250

### DIFF
--- a/hardware/camera/Android.mk
+++ b/hardware/camera/Android.mk
@@ -3,7 +3,7 @@
 
 LOCAL_PATH := $(call my-dir)
 
-ifneq ($(filter sdm845 sm8150,$(TARGET_BOARD_PLATFORM)),)
+ifneq ($(filter sdm845 sm8150 sm8250,$(TARGET_BOARD_PLATFORM)),)
 
 include $(SONY_CLEAR_VARS)
 LOCAL_MODULE := camera_symlinks


### PR DESCRIPTION
Sorry, forgot to submit this yesterday!

---

CamX on Edo needs these symlinks. We should probably come up with a better method of representing this instead of hardcoding SoC names in common.
