### PR TITLE
[common] [Q/R/master] vintf: Drop gnss interface; already provided by vintf fragment

### DIFF
--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -87,15 +87,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.gnss</name>
-        <transport>hwbinder</transport>
-        <version>2.0</version>
-        <interface>
-            <name>IGnss</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.graphics.composer</name>
         <transport>hwbinder</transport>
         <version>2.3</version>


### PR DESCRIPTION
Both 8.1 and 9.12 branches of the `gps` repository already provide declarations for the `IGnss` interface by a vintf fragment that's included with `android.hardware.gnss@2.0-service-qti`.

---

@jerpelea Are there still plans to rebase R on Q or are we just shelving that for `common`? Seems the last time was at least 3 months ago.