### PR TITLE
[common] [R/master] Upgrade to gnss 2.1

### DIFF
--- a/common-packages.mk
+++ b/common-packages.mk
@@ -63,9 +63,6 @@ PRODUCT_PACKAGES += \
 
 # GPS
 PRODUCT_PACKAGES += \
-    libloc_core \
-    libgps.utils \
-    liblocation_api \
     libbatching \
     libgeofencing \
     libgnss

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -70,8 +70,8 @@ PRODUCT_PACKAGES += \
 
 # GNSS
 PRODUCT_PACKAGES += \
-    android.hardware.gnss@2.0-impl-qti \
-    android.hardware.gnss@2.0-service-qti
+    android.hardware.gnss@2.1-impl-qti \
+    android.hardware.gnss@2.1-service-qti
 
 # Light
 PRODUCT_PACKAGES += \

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -85,15 +85,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.gnss</name>
-        <transport>hwbinder</transport>
-        <version>2.0</version>
-        <interface>
-            <name>IGnss</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.graphics.composer</name>
         <transport>hwbinder</transport>
         <version>2.3</version>


### PR DESCRIPTION
Depends on https://github.com/sonyxperiadev/hardware-qcom-gps/pull/6 and https://github.com/sonyxperiadev/device-sony-sepolicy/pull/595

9.12 branches support the new functionality introduced with the .1 minor interface release; use it. It is unclear why the `gps` repository still maintains a copy of the 2.0 version of the binary, that interface is still provided by the 2.1 HAL by definition (in fact the HAL also registers interfaces for 1.0 and 1.1).
