### PR TITLE
[common] [R] Add blueprint guard (soong_namespace) around all packages

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,1 @@
+soong_namespace {}

--- a/common.mk
+++ b/common.mk
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Common path
+COMMON_PATH := device/sony/common
+
 # Enable building packages from device namspaces.
 # Might be temporary! See:
 # https://android.googlesource.com/platform/build/soong/+/master/README.md#name-resolution
 PRODUCT_SOONG_NAMESPACES += \
+    $(COMMON_PATH) \
     $(PLATFORM_COMMON_PATH) \
     vendor/qcom/opensource/core-utils
-
-# Common path
-COMMON_PATH := device/sony/common
 
 # Build scripts
 SONY_CLEAR_VARS := $(COMMON_PATH)/sony_clear_vars.mk


### PR DESCRIPTION
Place all blueprint-defined packages in `common` (mostly `prebuilt_etc`) under a namespace so that external devices cannot see nor are affected by these targets being defined. For example a device defined outside of Sony cannot redefine a target or copy rule that provides the same file
as our prebuilt packages.

This is pretty much analogous to the build-guard in the top-level Android.mk in this repository.

Build-tested on PDX206.