### PR TITLE
[URGENT] [COMMON] [R] rmt_storage: Add missing colon in property triggers to enable service

### DIFF
--- a/rootdir/vendor/etc/init/rmt_storage.rc
+++ b/rootdir/vendor/etc/init/rmt_storage.rc
@@ -7,9 +7,9 @@ service vendor.rmt_storage /odm/bin/rmt_storage
     disabled
 
 # Devices with internal modem
-on property ro.baseband=sdm
+on property:ro.baseband=sdm
     enable vendor.rmt_storage
 
 # Legacy devices with internal modem
-on property ro.baseband=msm
+on property:ro.baseband=msm
     enable vendor.rmt_storage


### PR DESCRIPTION
Closes https://github.com/sonyxperiadev/bug_tracker/issues/679.

https://github.com/sonyxperiadev/bug_tracker/issues/679 reports issues with the modem failing to start. The log is pretty clear on why rmt_storage is not coming up:

    I init    : Parsing file /vendor/etc/init/rmt_storage.rc...
    E init    : /vendor/etc/init/rmt_storage.rc: 10: ParseTriggers() failed: && is the only symbol allowed to concatenate actions
    E init    : /vendor/etc/init/rmt_storage.rc: 14: ParseTriggers() failed: && is the only symbol allowed to concatenate actions

A recent commit disabled rmt_storage for `mdm` basebands by only starting on `sdm` and `msm` basebands, but a colon got lost along the way.

Fixes: 28921cff ("rootdir: rmt_storage: Enabled based on baseband")
