### PR TITLE
[r-mr1] [3/3] common.mk: common-headers soong namespaces

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -21,6 +21,7 @@ COMMON_PATH := device/sony/common
 PRODUCT_SOONG_NAMESPACES += \
     $(COMMON_PATH) \
     $(PLATFORM_COMMON_PATH) \
+    kernel/sony/msm-$(SOMC_KERNEL_VERSION)/common-headers \
     vendor/qcom/opensource/core-utils
 
 # Build scripts


### PR DESCRIPTION
Add a soong namespace for kernel/sony/msm-X.Y/common-headers based on platform kernel version so that different kernels can live side-by-side

See:
https://github.com/sonyxperiadev/device-sony-common-headers/pull/12
https://github.com/sonyxperiadev/device-sony-common-headers/pull/13