### PR TITLE
[common] [R] vintf/secure_element: Bump ISecureElement interface to 1.2 

### DIFF
--- a/vintf/android.hardware.secure_element_ds.xml
+++ b/vintf/android.hardware.secure_element_ds.xml
@@ -2,7 +2,7 @@
     <hal format="hidl">
         <name>android.hardware.secure_element</name>
         <transport>hwbinder</transport>
-        <fqname>@1.0::ISecureElement/SIM1</fqname>
-        <fqname>@1.0::ISecureElement/SIM2</fqname>
+        <fqname>@1.2::ISecureElement/SIM1</fqname>
+        <fqname>@1.2::ISecureElement/SIM2</fqname>
     </hal>
 </manifest>

--- a/vintf/android.hardware.secure_element_ss.xml
+++ b/vintf/android.hardware.secure_element_ss.xml
@@ -2,6 +2,6 @@
     <hal format="hidl">
         <name>android.hardware.secure_element</name>
         <transport>hwbinder</transport>
-        <fqname>@1.0::ISecureElement/SIM1</fqname>
+        <fqname>@1.2::ISecureElement/SIM1</fqname>
     </hal>
 </manifest>


### PR DESCRIPTION
New ODM v4 blobs host the ISecureElement interface at 1.2 now, not 1.0:

    I hwservicemanager: getTransport: Cannot find entry android.hardware.secure_element@1.2::ISecureElement/SIM1 in either framework or device manifest.
    E HidlServiceManagement: Service android.hardware.secure_element@1.2::ISecureElement/SIM1 must be in VINTF manifest in order to register/get.
    I hwservicemanager: getTransport: Cannot find entry android.hardware.secure_element@1.2::ISecureElement/SIM2 in either framework or device manifest.
    E HidlServiceManagement: Service android.hardware.secure_element@1.2::ISecureElement/SIM2 must be in VINTF manifest in order to register/get.

Signed-off-by: Marijn Suijten <marijns95@gmail.com>
