### PR TITLE
[R] VINTF: Remove duplicates, Bump versions

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -179,11 +179,9 @@ DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.qualcomm.qti.dpm.xml
 
 ifeq ($(PRODUCT_DEVICE_DS),true)
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hw.qcradio_ds.xml
-DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.hw.qcradio_ds.xml
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.hw.radio_ds.xml
 else
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hw.qcradio_ss.xml
-DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.hw.qcradio_ss.xml
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.hw.radio_ss.xml
 endif
 

--- a/vintf/android.hw.qcradio_ds.xml
+++ b/vintf/android.hw.qcradio_ds.xml
@@ -4,7 +4,7 @@
         <transport>hwbinder</transport>
         <fqname>@1.2::ISap/slot1</fqname>
         <fqname>@1.2::ISap/slot2</fqname>
-        <fqname>@1.4::IRadio/slot1</fqname>
-        <fqname>@1.4::IRadio/slot2</fqname>
+        <fqname>@1.5::IRadio/slot1</fqname>
+        <fqname>@1.5::IRadio/slot2</fqname>
     </hal>
 </manifest>

--- a/vintf/android.hw.qcradio_ss.xml
+++ b/vintf/android.hw.qcradio_ss.xml
@@ -3,6 +3,6 @@
         <name>android.hardware.radio</name>
         <transport>hwbinder</transport>
         <fqname>@1.2::ISap/slot1</fqname>
-        <fqname>@1.4::IRadio/slot1</fqname>
+        <fqname>@1.5::IRadio/slot1</fqname>
     </hal>
 </manifest>

--- a/vintf/vendor.hw.qcradio_ds.xml
+++ b/vintf/vendor.hw.qcradio_ds.xml
@@ -1,9 +1,0 @@
-<manifest version="1.0" type="device">
-    <!-- Hidl service for 5G network apis -->
-    <hal format="hidl">
-        <name>vendor.qti.hardware.radio.qtiradio</name>
-        <transport>hwbinder</transport>
-        <fqname>@2.3::IQtiRadio/slot1</fqname>
-        <fqname>@2.3::IQtiRadio/slot2</fqname>
-    </hal>
-</manifest>

--- a/vintf/vendor.hw.qcradio_ss.xml
+++ b/vintf/vendor.hw.qcradio_ss.xml
@@ -1,8 +1,0 @@
-<manifest version="1.0" type="device">
-    <!-- Hidl service for 5G network apis -->
-    <hal format="hidl">
-        <name>vendor.qti.hardware.radio.qtiradio</name>
-        <transport>hwbinder</transport>
-        <fqname>@2.3::IQtiRadio/slot1</fqname>
-    </hal>
-</manifest>

--- a/vintf/vendor.hw.radio_ds.xml
+++ b/vintf/vendor.hw.radio_ds.xml
@@ -28,8 +28,8 @@
         <transport>hwbinder</transport>
         <fqname>@1.0::IQtiRadio/slot1</fqname>
         <fqname>@1.0::IQtiRadio/slot2</fqname>
-        <fqname>@2.3::IQtiRadio/slot1</fqname>
-        <fqname>@2.3::IQtiRadio/slot2</fqname>
+        <fqname>@2.4::IQtiRadio/slot1</fqname>
+        <fqname>@2.4::IQtiRadio/slot2</fqname>
     </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.data.connection</name>

--- a/vintf/vendor.hw.radio_ds.xml
+++ b/vintf/vendor.hw.radio_ds.xml
@@ -8,8 +8,8 @@
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.ims</name>
         <transport>hwbinder</transport>
-        <fqname>@1.5::IImsRadio/imsradio0</fqname>
-        <fqname>@1.5::IImsRadio/imsradio1</fqname>
+        <fqname>@1.6::IImsRadio/imsradio0</fqname>
+        <fqname>@1.6::IImsRadio/imsradio1</fqname>
     </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.lpa</name>

--- a/vintf/vendor.hw.radio_ss.xml
+++ b/vintf/vendor.hw.radio_ss.xml
@@ -7,7 +7,7 @@
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.ims</name>
         <transport>hwbinder</transport>
-        <fqname>@1.5::IImsRadio/imsradio0</fqname>
+        <fqname>@1.6::IImsRadio/imsradio0</fqname>
     </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.lpa</name>

--- a/vintf/vendor.hw.radio_ss.xml
+++ b/vintf/vendor.hw.radio_ss.xml
@@ -23,7 +23,7 @@
         <name>vendor.qti.hardware.radio.qtiradio</name>
         <transport>hwbinder</transport>
         <fqname>@1.0::IQtiRadio/slot1</fqname>
-        <fqname>@2.3::IQtiRadio/slot1</fqname>
+        <fqname>@2.4::IQtiRadio/slot1</fqname>
     </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.data.connection</name>


### PR DESCRIPTION
In the new ODM V4 blobs services host higher version then we specify.
Bump the version of the services (Check commits for logs)

While at it remove unwanted duplication.