### PR TITLE
[DNM] [r-mr1] hardware: Add qti-headers intermediary module

### DIFF
--- a/hardware/qti-headers/Android.bp
+++ b/hardware/qti-headers/Android.bp
@@ -1,0 +1,32 @@
+// Select kernel headers based on version
+
+// Use as follows:
+// SOONG_CONFIG_NAMESPACES += qti_kernel_headers
+// SOONG_CONFIG_qti_kernel_headers := version
+// SOONG_CONFIG_qti_kernel_headers_version := 4.14
+
+bootstrap_go_package {
+    name: "soong-qti_kernel_headers_defaults",
+    pkgPath: "device/sony/common/hardware/qti-headers",
+    deps: [
+        "blueprint",
+        "blueprint-pathtools",
+        "soong",
+        "soong-android",
+        "soong-cc",
+    ],
+    srcs: [
+        "kernel_headers.go",
+    ],
+    pluginFor: ["soong_build"],
+}
+
+qti_kernel_headers_defaults {
+    name: "qti_kernel_headers_defaults",
+}
+
+cc_library_headers {
+    name: "qti_kernel_headers",
+    defaults: ["qti_kernel_headers_defaults"],
+    vendor_available: true,
+}

--- a/hardware/qti-headers/README.md
+++ b/hardware/qti-headers/README.md
@@ -1,0 +1,15 @@
+# Kernel headers intermediary module
+
+Selects `qti_kernel_headers` repo based on kernel version so that multiple
+versions can live inside on AOSP tree.
+
+Needs following changes:
+
+```make
+SOONG_CONFIG_NAMESPACES += qti_kernel_headers
+SOONG_CONFIG_qti_kernel_headers := version
+SOONG_CONFIG_qti_kernel_headers_version := 4.14
+```
+
+`common-headers` needs to rename the module name from `qti_kernel_headers` to
+`qti_kernel_headers_4.14` (based on version).

--- a/hardware/qti-headers/kernel_headers.go
+++ b/hardware/qti-headers/kernel_headers.go
@@ -1,0 +1,37 @@
+package qti_kernel_headers
+
+import (
+	"android/soong/android"
+	"android/soong/cc"
+	"fmt"
+)
+
+func init() {
+	// Register our own module type
+	android.RegisterModuleType("qti_kernel_headers_defaults", qtiKernelHeadersDefaultsFactory)
+}
+
+func qtiKernelHeadersDefaultsFactory() android.Module {
+	module := cc.DefaultsFactory()
+
+	// When the module is loaded, execute qtiKernelHeadersDefaults
+	android.AddLoadHook(module, qtiKernelHeadersDefaults)
+
+	return module
+}
+
+func qtiKernelHeadersDefaults(ctx android.LoadHookContext) {
+	version := ctx.Config().VendorConfig("qti_kernel_headers").String("version")
+
+	p := struct {
+		Export_header_lib_headers []string
+		Header_libs []string
+	}{}
+
+    var qtimodule = fmt.Sprintf("qti_kernel_headers_%s", version)
+
+	p.Export_header_lib_headers = []string{qtimodule}
+	p.Header_libs = []string{qtimodule}
+
+	ctx.AppendProperties(&p)
+}


### PR DESCRIPTION
Selects `qti_kernel_headers` repo based on kernel version so that multiple versions can live inside on AOSP tree.

Needs following changes:

```make
SOONG_CONFIG_NAMESPACES += qti_kernel_headers
SOONG_CONFIG_qti_kernel_headers := version
SOONG_CONFIG_qti_kernel_headers_version := 4.14
```

Inisde `common-headers` needs a rename of module name from `qti_kernel_headers` to `qti_kernel_headers_4.14` (based on
version).

This will finally allow multiple kernel versions (and BSPs) to live side-by-side again.