### PR TITLE
[q-mr1] common: Set qti-headers kernel version via soong

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -53,6 +53,12 @@ KERNEL_PATH := kernel/sony/msm-$(SOMC_KERNEL_VERSION)
 # Sanitized prebuilt kernel headers
 -include $(KERNEL_PATH)/common-headers/KernelHeaders.mk
 
+# Configure qti-headers auxiliary module via soong so that the correct headers
+# under kernel/sony/msm-X.Y/kernel-headers are chosen
+SOONG_CONFIG_NAMESPACES += qti_kernel_headers
+SOONG_CONFIG_qti_kernel_headers := version
+SOONG_CONFIG_qti_kernel_headers_version := $(SOMC_KERNEL_VERSION)
+
 # Codecs Configuration
 PRODUCT_COPY_FILES += \
     frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_audio.xml \


### PR DESCRIPTION
This change will allow multiple kernel versions to live side-by-side in one AOSP tree.

Needs to be accompanied by changes to kernel-headers repos to change module name to `qti_kernel_headers_X.Y` and an auxiliary module to resolve `qti_kernel_headers` to the correct module.