### PR TITLE
[r-mr1] priv-permissions-ims.xml: Add newly required permissions

### DIFF
--- a/rootdir/system/system_ext/etc/permissions/privapp-permissions-ims.xml
+++ b/rootdir/system/system_ext/etc/permissions/privapp-permissions-ims.xml
@@ -4,6 +4,9 @@
         <permission name="android.permission.READ_PRECISE_PHONE_STATE"/>
         <permission name="android.permission.INTERACT_ACROSS_USERS"/>
         <permission name="android.permission.SUBSTITUTE_NOTIFICATION_APP_NAME"/>
+        <permission name="android.permission.MODIFY_PHONE_STATE"/>
+        <permission name="android.permission.READ_PRIVILEGED_PHONE_STATE"/>
+        <permission name="android.permission.WRITE_SECURE_SETTINGS"/>
     </privapp-permissions>
     <privapp-permissions  package="com.qti.dpmserviceapp">
         <permission name="android.permission.INTERACT_ACROSS_USERS"/>


### PR DESCRIPTION
After this [commit](https://github.com/PixelExperience-Devices/device_sony_customization/commit/257a449540b616d2cf32af9b6624fb1b8f1b4bb9#diff-c2912b8c99febfbc46b6fef0d31cac8d3d131ee8e3b63617221d4f154a614f3f) we need these 3 new permissions for Pixel Experience to boot again.

Error:
```
        Signature|privileged permissions not in privapp-permissions whitelist:
        org.codeaurora.ims (/system/system_ext/priv-app/ims): android.permission.WRITE_SECURE_SETTINGS,
        org.codeaurora.ims (/system/system_ext/priv-app/ims): android.permission.READ_PRIVILEGED_PHONE_STATE,
        org.codeaurora.ims (/system/system_ext/priv-app/ims): android.permission.MODIFY_PHONE_STATE,
```

Tested-by: Paulbouchara