### PR TITLE
[R] common-treble: Drop inexistant composer -impl library dependency

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -9,7 +9,6 @@ PRODUCT_PACKAGES += \
     vendor.qti.hardware.display.composer-service
 else
 PRODUCT_PACKAGES += \
-    android.hardware.graphics.composer@2.3-impl:64 \
     android.hardware.graphics.composer@2.3-service
 endif
 


### PR DESCRIPTION
As mentioned in 28d88a2a ("common-treble: SM8250+ Composer is a binary instead of passthrough HAL") the `-service` is responsible for loading the libhardware module on our SM8150 HAL as well without an SP-HAL `-impl` library available.  Drop this inexistant dependency.
