### PR TITLE
[q-mr1] Fix building

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -12,15 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Common path
+COMMON_PATH := device/sony/common
+
+display_platform := sm8150
+
 # Enable building packages from device namspaces.
 # Might be temporary! See:
 # https://android.googlesource.com/platform/build/soong/+/master/README.md#name-resolution
 PRODUCT_SOONG_NAMESPACES += \
     $(PLATFORM_COMMON_PATH) \
-    vendor/qcom/opensource/core-utils
-
-# Common path
-COMMON_PATH := device/sony/common
+    vendor/qcom/opensource/core-utils \
+    vendor/qcom/opensource/display/$(display_platform) \
+    vendor/qcom/opensource/display-commonsys-intf/$(display_platform)
 
 # Build scripts
 SONY_CLEAR_VARS := $(COMMON_PATH)/sony_clear_vars.mk

--- a/hardware/qcom/Android.mk
+++ b/hardware/qcom/Android.mk
@@ -25,7 +25,7 @@ endif
 OMX_VIDEO_PATH := mm-video-v4l2
 
 SRC_CAMERA_HAL_DIR ?= vendor/qcom/opensource/camera
-SRC_DISPLAY_HAL_DIR := vendor/qcom/opensource/display
+SRC_DISPLAY_HAL_DIR := vendor/qcom/opensource/display/sm8150
 SRC_MEDIA_HAL_DIR := $(QCOM_MEDIA_ROOT)
 TARGET_KERNEL_VERSION := $(SOMC_KERNEL_VERSION)
 


### PR DESCRIPTION
Display hal moved into sm8150 dir.

Soong namespace path changed after https://github.com/sonyxperiadev/hardware-qcom-display/commit/fbfe48f6547007449ac7431f20733b79b9c171c3