### PR TITLE
[master] Add support for QTI USB HAL

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -126,15 +126,9 @@ PRODUCT_PACKAGES += \
     android.hardware.drm@1.0-service-lazy \
     android.hardware.drm@1.3-service-lazy.clearkey
 
-ifneq ($(BOARD_USE_LEGACY_USB),true)
 # Usb HAL
 PRODUCT_PACKAGES += \
     android.hardware.usb@1.0-service
-else
-# Simple Usb HAL
-PRODUCT_PACKAGES += \
-    android.hardware.usb@1.0-service.basic
-endif
 
 # Thermal HAL
 PRODUCT_PACKAGES += \

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -127,8 +127,13 @@ PRODUCT_PACKAGES += \
     android.hardware.drm@1.3-service-lazy.clearkey
 
 # Usb HAL
+ifeq ($(filter 4.14, $(SOMC_KERNEL_VERSION)),)
+PRODUCT_PACKAGES += \
+    android.hardware.usb@1.2-service-qti
+else
 PRODUCT_PACKAGES += \
     android.hardware.usb@1.0-service
+endif
 
 # Thermal HAL
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Add android.hardware.usb@1.2-service-qti HAL for devices
running on 4.19 kernel.

This version of the USB HAL is not intended to be used
on targets with kernels older than 4.19 (since it relies on
Type-C Class to be enabled).