### PR TITLE
[q-mr1] Fix USB composition selector

### DIFF
--- a/rootdir/vendor/etc/init/init.usb.rc
+++ b/rootdir/vendor/etc/init/init.usb.rc
@@ -112,6 +112,9 @@ on property:sys.usb.config=mtp && property:sys.usb.configfs=1
     setprop sys.usb.state ${sys.usb.config}
 
 # USB Mode : adb
+on property:sys.usb.config=adb && property:sys.usb.configfs=1
+    start adbd
+
 on property:sys.usb.ffs.ready=1 && property:sys.usb.config=adb && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "adb"
     rm /config/usb_gadget/g1/configs/b.1/f1
@@ -122,6 +125,9 @@ on property:sys.usb.ffs.ready=1 && property:sys.usb.config=adb && property:sys.u
     setprop sys.usb.state ${sys.usb.config}
 
 # USB Mode : mtp,adb
+on property:sys.usb.config=mtp,adb && property:sys.usb.configfs=1
+    start adbd
+
 on property:sys.usb.ffs.ready=1 && property:sys.usb.config=mtp,adb && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "mtp_adb"
     rm /config/usb_gadget/g1/configs/b.1/f1
@@ -143,6 +149,9 @@ on property:sys.usb.config=rndis && property:sys.usb.configfs=1
     setprop sys.usb.state ${sys.usb.config}
 
 # USB Mode : rndis,adb
+on property:sys.usb.config=rndis,adb && property:sys.usb.configfs=1
+    start adbd
+
 on property:sys.usb.ffs.ready=1 && property:sys.usb.config=rndis,adb && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "rndis_adb"
     rm /config/usb_gadget/g1/configs/b.1/f1
@@ -164,6 +173,9 @@ on property:sys.usb.config=ptp && property:sys.usb.configfs=1
     setprop sys.usb.state ${sys.usb.config}
 
 # USB Mode : ptp,adb
+on property:sys.usb.config=ptp,adb && property:sys.usb.configfs=1
+    start adbd
+
 on property:sys.usb.ffs.ready=1 && property:sys.usb.config=ptp,adb && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "ptp_adb"
     rm /config/usb_gadget/g1/configs/b.1/f1
@@ -185,6 +197,9 @@ on property:sys.usb.config=midi && property:sys.usb.configfs=1
     setprop sys.usb.state ${sys.usb.config}
 
 # USB Mode : midi,adb
+on property:sys.usb.config=midi,adb && property:sys.usb.configfs=1
+    start adbd
+
 on property:sys.usb.ffs.ready=1 && property:sys.usb.config=midi,adb && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "midi_adb"
     rm /config/usb_gadget/g1/configs/b.1/f1

--- a/rootdir/vendor/etc/init/init.usb.rc
+++ b/rootdir/vendor/etc/init/init.usb.rc
@@ -80,7 +80,7 @@ on boot
     mount functionfs adb /dev/usb-ffs/adb rmode=0770,fmode=0660,uid=2000,gid=2000
     mount functionfs mtp /dev/usb-ffs/mtp rmode=0770,fmode=0660,uid=1024,gid=1024,no_disconnect=1
     mount functionfs ptp /dev/usb-ffs/ptp rmode=0770,fmode=0660,uid=1024,gid=1024,no_disconnect=1
-    setprop sys.usb.configfs 1
+    setprop vendor.sys.usb.configfs 1
 
 # USB compositions
 #
@@ -102,7 +102,7 @@ on boot
 #   midi,adb            d
 
 # USB Mode : mtp
-on property:sys.usb.config=mtp && property:sys.usb.configfs=1
+on property:sys.usb.config=mtp && property:vendor.sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "mtp"
     rm /config/usb_gadget/g1/configs/b.1/f1
     rm /config/usb_gadget/g1/configs/b.1/f2
@@ -112,10 +112,10 @@ on property:sys.usb.config=mtp && property:sys.usb.configfs=1
     setprop sys.usb.state ${sys.usb.config}
 
 # USB Mode : adb
-on property:sys.usb.config=adb && property:sys.usb.configfs=1
+on property:sys.usb.config=adb && property:vendor.sys.usb.configfs=1
     start adbd
 
-on property:sys.usb.ffs.ready=1 && property:sys.usb.config=adb && property:sys.usb.configfs=1
+on property:sys.usb.ffs.ready=1 && property:sys.usb.config=adb && property:vendor.sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "adb"
     rm /config/usb_gadget/g1/configs/b.1/f1
     rm /config/usb_gadget/g1/configs/b.1/f2
@@ -125,10 +125,10 @@ on property:sys.usb.ffs.ready=1 && property:sys.usb.config=adb && property:sys.u
     setprop sys.usb.state ${sys.usb.config}
 
 # USB Mode : mtp,adb
-on property:sys.usb.config=mtp,adb && property:sys.usb.configfs=1
+on property:sys.usb.config=mtp,adb && property:vendor.sys.usb.configfs=1
     start adbd
 
-on property:sys.usb.ffs.ready=1 && property:sys.usb.config=mtp,adb && property:sys.usb.configfs=1
+on property:sys.usb.ffs.ready=1 && property:sys.usb.config=mtp,adb && property:vendor.sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "mtp_adb"
     rm /config/usb_gadget/g1/configs/b.1/f1
     rm /config/usb_gadget/g1/configs/b.1/f2
@@ -139,7 +139,7 @@ on property:sys.usb.ffs.ready=1 && property:sys.usb.config=mtp,adb && property:s
     setprop sys.usb.state ${sys.usb.config}
 
 # USB Mode : rndis
-on property:sys.usb.config=rndis && property:sys.usb.configfs=1
+on property:sys.usb.config=rndis && property:vendor.sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "rndis"
     rm /config/usb_gadget/g1/configs/b.1/f1
     rm /config/usb_gadget/g1/configs/b.1/f2
@@ -149,10 +149,10 @@ on property:sys.usb.config=rndis && property:sys.usb.configfs=1
     setprop sys.usb.state ${sys.usb.config}
 
 # USB Mode : rndis,adb
-on property:sys.usb.config=rndis,adb && property:sys.usb.configfs=1
+on property:sys.usb.config=rndis,adb && property:vendor.sys.usb.configfs=1
     start adbd
 
-on property:sys.usb.ffs.ready=1 && property:sys.usb.config=rndis,adb && property:sys.usb.configfs=1
+on property:sys.usb.ffs.ready=1 && property:sys.usb.config=rndis,adb && property:vendor.sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "rndis_adb"
     rm /config/usb_gadget/g1/configs/b.1/f1
     rm /config/usb_gadget/g1/configs/b.1/f2
@@ -163,7 +163,7 @@ on property:sys.usb.ffs.ready=1 && property:sys.usb.config=rndis,adb && property
     setprop sys.usb.state ${sys.usb.config}
 
 # USB Mode : ptp
-on property:sys.usb.config=ptp && property:sys.usb.configfs=1
+on property:sys.usb.config=ptp && property:vendor.sys.usb.configfs=1
     rm /config/usb_gadget/g1/configs/b.1/f1
     rm /config/usb_gadget/g1/configs/b.1/f2
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "ptp"
@@ -173,10 +173,10 @@ on property:sys.usb.config=ptp && property:sys.usb.configfs=1
     setprop sys.usb.state ${sys.usb.config}
 
 # USB Mode : ptp,adb
-on property:sys.usb.config=ptp,adb && property:sys.usb.configfs=1
+on property:sys.usb.config=ptp,adb && property:vendor.sys.usb.configfs=1
     start adbd
 
-on property:sys.usb.ffs.ready=1 && property:sys.usb.config=ptp,adb && property:sys.usb.configfs=1
+on property:sys.usb.ffs.ready=1 && property:sys.usb.config=ptp,adb && property:vendor.sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "ptp_adb"
     rm /config/usb_gadget/g1/configs/b.1/f1
     rm /config/usb_gadget/g1/configs/b.1/f2
@@ -187,7 +187,7 @@ on property:sys.usb.ffs.ready=1 && property:sys.usb.config=ptp,adb && property:s
     setprop sys.usb.state ${sys.usb.config}
 
 # USB Mode : midi
-on property:sys.usb.config=midi && property:sys.usb.configfs=1
+on property:sys.usb.config=midi && property:vendor.sys.usb.configfs=1
     rm /config/usb_gadget/g1/configs/b.1/f1
     rm /config/usb_gadget/g1/configs/b.1/f2
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "midi"
@@ -197,10 +197,10 @@ on property:sys.usb.config=midi && property:sys.usb.configfs=1
     setprop sys.usb.state ${sys.usb.config}
 
 # USB Mode : midi,adb
-on property:sys.usb.config=midi,adb && property:sys.usb.configfs=1
+on property:sys.usb.config=midi,adb && property:vendor.sys.usb.configfs=1
     start adbd
 
-on property:sys.usb.ffs.ready=1 && property:sys.usb.config=midi,adb && property:sys.usb.configfs=1
+on property:sys.usb.ffs.ready=1 && property:sys.usb.config=midi,adb && property:vendor.sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "midi_adb"
     rm /config/usb_gadget/g1/configs/b.1/f1
     rm /config/usb_gadget/g1/configs/b.1/f2

--- a/rootdir/vendor/etc/init/init.usb.rc
+++ b/rootdir/vendor/etc/init/init.usb.rc
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 on charger
     mount configfs none /config
     mkdir /config/usb_gadget/g1 0770 shell shell
@@ -82,21 +83,56 @@ on boot
     setprop sys.usb.configfs 1
 
 # USB compositions
-# Note: PID 0x902X advertises QCOM. Useful for NT based OSes.
+#
+# Following are the triggers to configure various
+# combinations of functions into a USB composition.
+#
+# The PID PREFIX are designed as following
+#
+#   USB mode            PREFIX
+#  ------------------------------
+#   mtp                 0
+#   adb                 3
+#   mtp,adb             5
+#   rndis               7
+#   rndis,adb           8
+#   ptp                 a
+#   ptp,adb             b
+#   midi                c
+#   midi,adb            d
+
+# USB Mode : mtp
 on property:sys.usb.config=mtp && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/functions/mtp.gs0/os_desc/interface.MTP/compatible_id "mtp"
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "mtp"
-    write /config/usb_gadget/g1/os_desc/use 1
+    rm /config/usb_gadget/g1/configs/b.1/f1
+    rm /config/usb_gadget/g1/configs/b.1/f2
     write /config/usb_gadget/g1/idProduct 0x0${ro.usb.pid_suffix}
+    symlink /config/usb_gadget/g1/functions/mtp.gs0 /config/usb_gadget/g1/configs/b.1/f1
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
     setprop sys.usb.state ${sys.usb.config}
 
-on property:sys.usb.config=mtp,adb && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/functions/mtp.gs0/os_desc/interface.MTP/compatible_id "mtp_adb"
+# USB Mode : adb
+on property:sys.usb.ffs.ready=1 && property:sys.usb.config=adb && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "adb"
+    rm /config/usb_gadget/g1/configs/b.1/f1
+    rm /config/usb_gadget/g1/configs/b.1/f2
+    write /config/usb_gadget/g1/idProduct 0x${ro.usb.pid_suffix}
+    symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f1
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
+    setprop sys.usb.state ${sys.usb.config}
+
+# USB Mode : mtp,adb
+on property:sys.usb.ffs.ready=1 && property:sys.usb.config=mtp,adb && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "mtp_adb"
-    write /config/usb_gadget/g1/os_desc/use 1
+    rm /config/usb_gadget/g1/configs/b.1/f1
+    rm /config/usb_gadget/g1/configs/b.1/f2
     write /config/usb_gadget/g1/idProduct 0x5${ro.usb.pid_suffix}
+    symlink /config/usb_gadget/g1/functions/mtp.gs0 /config/usb_gadget/g1/configs/b.1/f1
+    symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f2
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
     setprop sys.usb.state ${sys.usb.config}
 
+# USB Mode : rndis
 on property:sys.usb.config=rndis && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "rndis"
     rm /config/usb_gadget/g1/configs/b.1/f1
@@ -106,6 +142,7 @@ on property:sys.usb.config=rndis && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/UDC ${sys.usb.controller}
     setprop sys.usb.state ${sys.usb.config}
 
+# USB Mode : rndis,adb
 on property:sys.usb.ffs.ready=1 && property:sys.usb.config=rndis,adb && property:sys.usb.configfs=1
     write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "rndis_adb"
     rm /config/usb_gadget/g1/configs/b.1/f1
@@ -116,34 +153,44 @@ on property:sys.usb.ffs.ready=1 && property:sys.usb.config=rndis,adb && property
     write /config/usb_gadget/g1/UDC ${sys.usb.controller}
     setprop sys.usb.state ${sys.usb.config}
 
+# USB Mode : ptp
 on property:sys.usb.config=ptp && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/functions/ptp.gs1/os_desc/interface.MTP/compatible_id "ptp"
-    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "ptp"
-    write /config/usb_gadget/g1/os_desc/use 1
-    write /config/usb_gadget/g1/idProduct 0x9${ro.usb.pid_suffix}
-    setprop sys.usb.state ${sys.usb.config}
-
-on property:sys.usb.config=ptp,adb && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/functions/ptp.gs1/os_desc/interface.MTP/compatible_id "ptp_adb"
-    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "ptp_adb"
-    write /config/usb_gadget/g1/os_desc/use 1
-    write /config/usb_gadget/g1/idProduct 0xA${ro.usb.pid_suffix}
-    setprop sys.usb.state ${sys.usb.config}
-
-on property:sys.usb.config=midi && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/idProduct 0xC${ro.usb.pid_suffix}
-    setprop sys.usb.state ${sys.usb.config}
-
-on property:sys.usb.config=midi,adb && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/idProduct 0xF${ro.usb.pid_suffix}
-    setprop sys.usb.state ${sys.usb.config}
-
-# Completely redeclare ADB for safety purposes
-on property:sys.usb.config=adb && property:sys.usb.configfs=1
-    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "adb"
     rm /config/usb_gadget/g1/configs/b.1/f1
     rm /config/usb_gadget/g1/configs/b.1/f2
-    write /config/usb_gadget/g1/idProduct 0x0${ro.usb.pid_suffix}
-    symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f1
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "ptp"
+    write /config/usb_gadget/g1/idProduct 0xa${ro.usb.pid_suffix}
+    symlink /config/usb_gadget/g1/functions/ptp.gs1 /config/usb_gadget/g1/configs/b.1/f1
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
+    setprop sys.usb.state ${sys.usb.config}
+
+# USB Mode : ptp,adb
+on property:sys.usb.ffs.ready=1 && property:sys.usb.config=ptp,adb && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "ptp_adb"
+    rm /config/usb_gadget/g1/configs/b.1/f1
+    rm /config/usb_gadget/g1/configs/b.1/f2
+    write /config/usb_gadget/g1/idProduct 0xb${ro.usb.pid_suffix}
+    symlink /config/usb_gadget/g1/functions/ptp.gs1 /config/usb_gadget/g1/configs/b.1/f1
+    symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f2
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
+    setprop sys.usb.state ${sys.usb.config}
+
+# USB Mode : midi
+on property:sys.usb.config=midi && property:sys.usb.configfs=1
+    rm /config/usb_gadget/g1/configs/b.1/f1
+    rm /config/usb_gadget/g1/configs/b.1/f2
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "midi"
+    write /config/usb_gadget/g1/idProduct 0xc${ro.usb.pid_suffix}
+    symlink /config/usb_gadget/g1/functions/midi.gs5 /config/usb_gadget/g1/configs/b.1/f1
+    write /config/usb_gadget/g1/UDC ${sys.usb.controller}
+    setprop sys.usb.state ${sys.usb.config}
+
+# USB Mode : midi,adb
+on property:sys.usb.ffs.ready=1 && property:sys.usb.config=midi,adb && property:sys.usb.configfs=1
+    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "midi_adb"
+    rm /config/usb_gadget/g1/configs/b.1/f1
+    rm /config/usb_gadget/g1/configs/b.1/f2
+    write /config/usb_gadget/g1/idProduct 0xd${ro.usb.pid_suffix}
+    symlink /config/usb_gadget/g1/functions/midi.gs5 /config/usb_gadget/g1/configs/b.1/f1
+    symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f2
     write /config/usb_gadget/g1/UDC ${sys.usb.controller}
     setprop sys.usb.state ${sys.usb.config}


### PR DESCRIPTION
sys.usb.configfs from init.usb.rc is triggering generic rules found in
/system/etc/init/hw/init.usb.configfs.rc which leads to the fact that
the values that correspond to the real configuration of the device are
overwritten by the generic (dummy) ones. Because of this, some USB modes
such as USB tethering, cannot be enabled in the USB Preferences menu.
Hence, change the prefix of sys.usb.configfs setting from "sys." to
"vendor." in order to avoid triggering the behavior described above.

The change was successfully tested on Xperia 10+ (Mermaid) device,
MTP, PTP, MIDI and USB tethering modes are enabled successfully and each
of them was recognized by the PC.