### PR TITLE
rootdir: Android.mk: Create flags instead of filter

### DIFF
--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -83,7 +83,7 @@ LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 endif
 
-ifneq ($(filter sdm845 sm6125 sm6350 sm8150,$(TARGET_BOARD_PLATFORM)),)
+ifeq ($(TARGET_HAS_CDSP), true)
 include $(CLEAR_VARS)
 LOCAL_MODULE := init.qcom.cdspstart.sh
 LOCAL_MODULE_CLASS := EXECUTABLES
@@ -100,9 +100,9 @@ LOCAL_SRC_FILES := vendor/etc/init/cdsprpcd.rc
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
-endif # TARGET_BOARD_PLATFORM in (sdm845 sm6125 sm6350 sm8150)
+endif
 
-ifneq ($(filter sdm660 msm8998 sdm845 sm8150,$(TARGET_BOARD_PLATFORM)),)
+ifeq ($(TARGET_NEEDS_SSCRPCD), true)
 include $(CLEAR_VARS)
 LOCAL_MODULE := sscrpcd.rc
 LOCAL_MODULE_CLASS := ETC
@@ -110,9 +110,9 @@ LOCAL_SRC_FILES := vendor/etc/init/sscrpcd.rc
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
-endif # TARGET_BOARD_PLATFORM in (sdm660 msm8998 sdm845 sm8150)
+endif
 
-ifneq ($(filter sm6125 sm6350 ,$(TARGET_BOARD_PLATFORM)),)
+ifeq ($(TARGET_NEEDS_HVDCP_OPTI), true)
 include $(CLEAR_VARS)
 LOCAL_MODULE := hvdcp_opti.rc
 LOCAL_MODULE_CLASS := ETC
@@ -120,7 +120,7 @@ LOCAL_SRC_FILES := vendor/etc/init/hvdcp_opti.rc
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
-endif # TARGET_BOARD_PLATFORM in (sm6125)
+endif
 
 ifeq ($(WIFI_DRIVER_BUILT),qca_cld3)
 include $(CLEAR_VARS)

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -83,7 +83,7 @@ LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 endif
 
-ifneq ($(filter sdm845 sm6125 sm8150,$(TARGET_BOARD_PLATFORM)),)
+ifneq ($(filter sdm845 sm6125 sm6350 sm8150,$(TARGET_BOARD_PLATFORM)),)
 include $(CLEAR_VARS)
 LOCAL_MODULE := init.qcom.cdspstart.sh
 LOCAL_MODULE_CLASS := EXECUTABLES
@@ -100,7 +100,7 @@ LOCAL_SRC_FILES := vendor/etc/init/cdsprpcd.rc
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
-endif # TARGET_BOARD_PLATFORM in (sdm845 sm6125 sm8150)
+endif # TARGET_BOARD_PLATFORM in (sdm845 sm6125 sm6350 sm8150)
 
 ifneq ($(filter sdm660 msm8998 sdm845 sm8150,$(TARGET_BOARD_PLATFORM)),)
 include $(CLEAR_VARS)
@@ -112,7 +112,7 @@ LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 endif # TARGET_BOARD_PLATFORM in (sdm660 msm8998 sdm845 sm8150)
 
-ifneq ($(filter sm6125 ,$(TARGET_BOARD_PLATFORM)),)
+ifneq ($(filter sm6125 sm6350 ,$(TARGET_BOARD_PLATFORM)),)
 include $(CLEAR_VARS)
 LOCAL_MODULE := hvdcp_opti.rc
 LOCAL_MODULE_CLASS := ETC


### PR DESCRIPTION
Instead of adding each SoC that needs some module
make the module behind a flag which can be included
in the device tree for the platform.