### PR TITLE
[Q] hardware/adreno: Convert vendor->odm symlink to ro.hardware property

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -303,3 +303,7 @@ endif
 # Reduce cost of scrypt for FBE CE decryption
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.crypto.scrypt_params=15:3:1
+
+# Look for vulkan.qcom.so instead of vulkan.$(BOARD_TARGET_PLATFORM).so
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.hardware.vulkan=qcom

--- a/hardware/adreno/Android.mk
+++ b/hardware/adreno/Android.mk
@@ -18,19 +18,13 @@ library_names := \
     libllvm-glnext.so \
     libllvm-qcom.so \
     librs_adreno.so \
-    librs_adreno_sha1.so \
-    hw/vulkan.qcom.so
+    librs_adreno_sha1.so
 
 # Create symlinks to 32- and 64-bit directories:
 SONY_SYMLINKS := $(foreach lib_dir,lib lib64, \
     $(foreach p,$(library_names), \
         /odm/$(lib_dir)/$p:$(TARGET_COPY_OUT_VENDOR)/$(lib_dir)/$p \
     ) \
-)
-
-# Special exception for vulkan.qcom.so that is also linked as vulkan.$(TARGET_BOARD_PLATFORM).so
-SONY_SYMLINKS += $(foreach lib_dir,lib lib64, \
-    /odm/$(lib_dir)/hw/vulkan.qcom.so:$(TARGET_COPY_OUT_VENDOR)/$(lib_dir)/hw/vulkan.$(TARGET_BOARD_PLATFORM).so \
 )
 
 include $(SONY_BUILD_SYMLINKS)


### PR DESCRIPTION
Fixes https://github.com/sonyxperiadev/bug_tracker/issues/718

Android is continuously clamping down on symlink hacks (see the report in [1]) and for a good reason: they provide a perfectly valid alternative using `ro.hardware.<module name>` to change the platform name of a module that needs to be searched for.  On all our platforms the Vulkan library is called `vulkan.qcom.so` instead of `vulkan.$(TARGET_BOARD_PLATFORM).so` and Android can simply be taught to search for the former instead of the latter by setting `ro.hardware.vulkan=qcom`.

[1]: https://github.com/sonyxperiadev/bug_tracker/issues/718

Signed-off-by: Marijn Suijten <marijn.suijten@somainline.org>
