### PR TITLE
vintf: Bump vendor.qti.data.factory::IFactory version to 2.2

### DIFF
--- a/vintf/vendor.hw.dataservices.xml
+++ b/vintf/vendor.hw.dataservices.xml
@@ -7,7 +7,7 @@
     <hal format="hidl">
         <name>vendor.qti.data.factory</name>
         <transport>hwbinder</transport>
-        <fqname>@2.1::IFactory/default</fqname>
+        <fqname>@2.2::IFactory/default</fqname>
     </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.data.latency</name>


### PR DESCRIPTION
* It is required
* E HidlServiceManagement: Service vendor.qti.data.factory@2.2::IFactory/default must be in VINTF manifest in order to register/get.

Signed-off-by: electimon <electimon@gmail.com>