### PR TITLE
hardware/adreno: Add back vendor->odm symlink for `vulkan.qcom.so`

### DIFF
--- a/hardware/adreno/Android.mk
+++ b/hardware/adreno/Android.mk
@@ -18,7 +18,8 @@ library_names := \
     libllvm-glnext.so \
     libllvm-qcom.so \
     librs_adreno.so \
-    librs_adreno_sha1.so
+    librs_adreno_sha1.so \
+    hw/vulkan.qcom.so
 
 # Create symlinks to 32- and 64-bit directories:
 SONY_SYMLINKS := $(foreach lib_dir,lib lib64, \


### PR DESCRIPTION
Commit 0aecc439 ("hardware/adreno: Convert vendor->odm symlink to ro.hardware property") cleaned up the Vulkan Adreno blob links by using `ro.hardware.vulkan=qcom` to search for a qcom-vendored blob instead of one specifically named after the current board.  However, this also dropped the symlink from vendor to odm which is necessary for Android to find the module.  Android loads this hardware module from the sphal namespace [1] which is allowed to load from both /odm/${LIB} and /vendor/${LIB}, but is only searching in the hw/ subdirectory of /vendor/${LIB} [2].

Directly symlinking from /odm/${LIB} into /odm/${LIB}/hw is possible however since sphal _is_ instructed to _search_ there, but this requires and odm change and a new release; instead restore the previous symlink from /vendor's hw/ subfolder into /odm's hw/ subfolder.

[1]: https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/native/vulkan/libvulkan/driver.cpp;l=182
[2]: https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:system/linkerconfig/contents/namespace/sphal.cc;l=41-44

Fixes: 0aecc439 ("hardware/adreno: Convert vendor->odm symlink to ro.hardware property")
Signed-off-by: Marijn Suijten <marijns95@gmail.com>
