### PR TITLE
[R] common-treble: Provide latest radio@1.6 and radio.config@1.3 HAL libs

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -39,8 +39,8 @@ PRODUCT_PACKAGES += \
 # RIL
 # Interface library needed by odm blobs:
 PRODUCT_PACKAGES += \
-    android.hardware.radio@1.4 \
-    android.hardware.radio.config@1.2
+    android.hardware.radio@1.6 \
+    android.hardware.radio.config@1.3
 
 # Audio
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
On Lena we're observing much more recent libraries being used - this is not a problem on Android R where these libraries are available in VNDK, but AOSP stripped them all in Android S [1] where these dependency issues surface.

[1]: https://cs.android.com/android/_/android/platform/hardware/interfaces/+/d610435ac4bb051761b0f016aa6cdf2e884c55b5
