### PR TITLE
[S] common-treble: Provide radio, keymaster and secure_element HAL on vendor

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -44,6 +44,10 @@ PRODUCT_PACKAGES += \
     android.hardware.radio.deprecated@1.0.vendor \
     android.hardware.secure_element@1.2.vendor
 
+# netmgrd
+PRODUCT_PACKAGES += \
+    android.system.net.netd@1.1.vendor
+
 # Audio
 PRODUCT_PACKAGES += \
     android.hardware.audio@6.0-impl:32 \

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -39,8 +39,10 @@ PRODUCT_PACKAGES += \
 # RIL
 # Interface library needed by odm blobs:
 PRODUCT_PACKAGES += \
-    android.hardware.radio@1.6 \
-    android.hardware.radio.config@1.3
+    android.hardware.radio@1.6.vendor \
+    android.hardware.radio.config@1.3.vendor \
+    android.hardware.radio.deprecated@1.0.vendor \
+    android.hardware.secure_element@1.2.vendor
 
 # Audio
 PRODUCT_PACKAGES += \
@@ -105,7 +107,8 @@ ifeq ($(TARGET_KEYMASTER_V4),true)
 # Keymaster 4 passthrough service init file
 # (executable is on odm)
 PRODUCT_PACKAGES += \
-    android.hardware.keymaster@4.0-service-qti.rc
+    android.hardware.keymaster@4.0-service-qti.rc \
+    android.hardware.keymaster@4.1.vendor
 else
 # Keymaster 3 passthrough service
 PRODUCT_PACKAGES += \

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -39,8 +39,8 @@ PRODUCT_PACKAGES += \
 # RIL
 # Interface library needed by odm blobs:
 PRODUCT_PACKAGES += \
-    android.hardware.radio@1.4 \
-    android.hardware.radio.config@1.2
+    android.hardware.radio@1.6 \
+    android.hardware.radio.config@1.3
 
 # Audio
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Depends on #867 and rebase of r-mr1 on s-mr1

In [1] Google removed many HIDL HAL libraries from VNDK, causing them to only be installed to the system partition.  This is inaccessible for vendor apps and results in the usual:

	linker  : CANNOT LINK EXECUTABLE "/odm/bin/hw/vendor.somc.hardware.modemswitcher@1.0-service": library "android.hardware.radio.config@1.0.so" not found: needed by /odm/lib64/libril-qc-hal-qmi.so in namespace (default)
	linker  : CANNOT LINK EXECUTABLE "/odm/bin/hw/android.hardware.keymaster@4.0-service-qti": library "android.hardware.keymaster@4.0.so" not found: needed by main executable
	linker  : CANNOT LINK EXECUTABLE "/odm/bin/hw/android.hardware.keymaster@4.0-service-qti": library "android.hardware.keymaster@4.1.so" not found: needed by /odm/lib64/libqtikeymaster4.so in namespace (default)
	linker  : CANNOT LINK EXECUTABLE "/odm/bin/hw/qcrild": library "android.hardware.secure_element@1.1.so" not found: needed by /odm/lib64/libril-qc-hal-qmi.so in namespace (default)
	linker  : CANNOT LINK EXECUTABLE "/odm/bin/hw/qcrild": library "android.hardware.secure_element@1.2.so" not found: needed by /odm/lib64/libril-qc-hal-qmi.so in namespace (default)

These libraries are listed in common-treble because they're used by ODM apps but have no explicit vendor dependency (ie. a binary placed on /vendor) to put them in a vendor-available space.  The default is to include system variants which is why the dependencies have to be suffixed with `.vendor` so that they're shipped in `/vendor` and are available for our ODM blobs even on GSIs.

[1]: https://cs.android.com/android/_/android/platform/hardware/interfaces/+/d610435ac4bb051761b0f016aa6cdf2e884c55b5
