### PR TITLE
[S] overlay/frameworks-base: Configure fingerprint sensor as Class-3

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -66,6 +66,14 @@
         <item>255</item>  <!-- 4096 -->
     </integer-array>
 
+    <!-- List of biometric sensors on the device, in decreasing strength. Consumed by AuthService
+         when registering authenticators with BiometricService. Format must be ID:Modality:Strength,
+         where: IDs are unique per device, Modality as defined in BiometricAuthenticator.java,
+         and Strength as defined in BiometricManager.java -->
+    <string-array name="config_biometric_sensors" translatable="false" >
+        <item>0:2:15</item> <!-- ID0:Fingerprint:Strong -->
+    </string-array>
+
     <!-- Minimum screen brightness setting allowed by the power manager.
          The user is forbidden from setting the brightness below this level. -->
     <integer name="config_screenBrightnessSettingMinimum">2</integer>


### PR DESCRIPTION
Starting with Android S [1]/[2] biometric sensors must now be explicitly listed in config.xml, complete with its "ID", type and strengh.  Strength 15 here corresponds with a Class-3 secure biometrics device as per [3].

[1]: https://cs.android.com/android/_/android/platform/frameworks/base/+/e8d2d1f9bfa90b9b260f4a5f95caea7518b30ea5
[2]: https://cs.android.com/android/_/android/platform/frameworks/base/+/9cef3631fb8eaecd4ea4583337f160af24237e12
[3]: https://source.android.com/compatibility/android-cdd#7310_biometric_sensors

---

We can theoretically apply this to R already but I don't have the time to test nor do I want to induce any unintended breakage.
