### PR TITLE
[s-mr1] common-treble: Provide android.frameworks.sensorservice@1.0 on vendor

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -57,6 +57,8 @@ PRODUCT_PACKAGES += \
     android.hardware.soundtrigger@2.2-impl
 
 # Camera
+PRODUCT_PACKAGES += \
+    android.frameworks.sensorservice@1.0.vendor
 ifeq ($(TARGET_USES_64BIT_CAMERA),true)
 PRODUCT_PACKAGES += \
     android.hardware.camera.provider@2.4-impl:64 \


### PR DESCRIPTION
Following the commit f19703e ("common-treble: Provide radio, keymaster
and secure_element HAL on vendor"), starting with Android 12 most HAL
libraries are not included in VNDK anymore - they need to be explicitly
pulled in to `/vendor` for odm blobs to be allowed to access them:

    QCamera : <MCI><ERROR> mm_camera_load_shim_lib: 3306: dlopen failed
    with error dlopen failed: library
    "android.frameworks.sensorservice@1.0.so" not found: needed by
    /odm/lib/libmmcamera2_stats_modules.so in namespace (default)

android.frameworks.sensorservice@1.0 is used by at least mm-camera
framework.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>