### PR TITLE
[R/S] common: Don't explicitly disable vendor boot

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -68,10 +68,6 @@ PRODUCT_PACKAGES += \
 # Force building a recovery image: Needed for OTA packaging to work since Q
 PRODUCT_BUILD_RECOVERY_IMAGE := true
 
-# Android R: Disable logic for new vendor_boot
-# Our devices do not support it
-PRODUCT_BUILD_VENDOR_BOOT_IMAGE := false
-
 KERNEL_PATH := kernel/sony/msm-$(SOMC_KERNEL_VERSION)
 # Sanitized prebuilt kernel headers
 -include $(KERNEL_PATH)/common-headers/KernelHeaders.mk


### PR DESCRIPTION
None of our devices set BOARD_BOOT_HEADER_VERSION, which must be at least version 3 for vendor_boot to be enabled by default, as per the AOSP change that this was originally explicitly disabled for: https://r.android.com/1457443 - it'll stay disabled for all our platforms without explicitly setting this to `false`.
Removing this explicit disablement will allow us to enable the feature on newer platforms like Sagami where vendor_boot is required.

Build- and boot-tested on XQ-AU52 (PDX201 DSDS, Seine, Xperia 10 II) running Android 12, and J9110 (Griffin DSDS, Kumano, Xperia 1) running Android 11, no vendor_boot.img is generated and the device functions as normal.

Fixes: f570b264 ("common: Update vendor boot variable")

CC @ix5
