### PR TITLE
[s-mr1] overlay: base: Set default value of config_longPressOnPowerBehavior

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -74,6 +74,16 @@
         <item>0:2:15</item> <!-- ID0:Fingerprint:Strong -->
     </string-array>
 
+    <!-- Control the behavior when the user long presses the power button.
+            0 - Nothing
+            1 - Global actions menu
+            2 - Power off (with confirmation)
+            3 - Power off (without confirmation)
+            4 - Go to voice assist
+            5 - Go to assistant (Settings.Secure.ASSISTANT)
+    -->
+    <integer name="config_longPressOnPowerBehavior">1</integer>
+
     <!-- Minimum screen brightness setting allowed by the power manager.
          The user is forbidden from setting the brightness below this level. -->
     <integer name="config_screenBrightnessSettingMinimum">2</integer>


### PR DESCRIPTION
Set default behavior when the user long presses the power button.
This allows to call the power menu with a long press of the power
button. If the default value is set to 5 (Go to assistant), the fallback
to the old behavior will not work when "Hold for Assistant" is disabled.

Reference:
https://android.googlesource.com/platform/packages/apps/Settings/+/34cbca502bdfd6e0e5fff836bb9b0a3abf6811ea

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>