### PR TITLE
init: qcrild.rc : Add vendor prefix to ril-daemon

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -44,6 +44,10 @@ PRODUCT_PACKAGES += \
     android.hardware.radio.deprecated@1.0.vendor \
     android.hardware.secure_element@1.2.vendor
 
+# netmgrd
+PRODUCT_PACKAGES += \
+    android.system.net.netd@1.1.vendor
+
 # Audio
 PRODUCT_PACKAGES += \
     android.hardware.audio@6.0-impl:32 \

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -121,6 +121,10 @@ PRODUCT_PACKAGES += \
     android.hardware.keymaster@3.0-service
 endif
 
+# SPU
+PRODUCT_PACKAGES += \
+    android.hardware.authsecret@1.0.vendor
+
 # DRM
 PRODUCT_PACKAGES += \
     android.hardware.drm@1.0-impl \

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -57,6 +57,8 @@ PRODUCT_PACKAGES += \
     android.hardware.soundtrigger@2.2-impl
 
 # Camera
+PRODUCT_PACKAGES += \
+    android.frameworks.sensorservice@1.0.vendor
 ifeq ($(TARGET_USES_64BIT_CAMERA),true)
 PRODUCT_PACKAGES += \
     android.hardware.camera.provider@2.4-impl:64 \

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -39,8 +39,10 @@ PRODUCT_PACKAGES += \
 # RIL
 # Interface library needed by odm blobs:
 PRODUCT_PACKAGES += \
-    android.hardware.radio@1.6 \
-    android.hardware.radio.config@1.3
+    android.hardware.radio@1.6.vendor \
+    android.hardware.radio.config@1.3.vendor \
+    android.hardware.radio.deprecated@1.0.vendor \
+    android.hardware.secure_element@1.2.vendor
 
 # Audio
 PRODUCT_PACKAGES += \
@@ -105,7 +107,8 @@ ifeq ($(TARGET_KEYMASTER_V4),true)
 # Keymaster 4 passthrough service init file
 # (executable is on odm)
 PRODUCT_PACKAGES += \
-    android.hardware.keymaster@4.0-service-qti.rc
+    android.hardware.keymaster@4.0-service-qti.rc \
+    android.hardware.keymaster@4.1.vendor
 else
 # Keymaster 3 passthrough service
 PRODUCT_PACKAGES += \

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -74,6 +74,16 @@
         <item>0:2:15</item> <!-- ID0:Fingerprint:Strong -->
     </string-array>
 
+    <!-- Control the behavior when the user long presses the power button.
+            0 - Nothing
+            1 - Global actions menu
+            2 - Power off (with confirmation)
+            3 - Power off (without confirmation)
+            4 - Go to voice assist
+            5 - Go to assistant (Settings.Secure.ASSISTANT)
+    -->
+    <integer name="config_longPressOnPowerBehavior">1</integer>
+
     <!-- Minimum screen brightness setting allowed by the power manager.
          The user is forbidden from setting the brightness below this level. -->
     <integer name="config_screenBrightnessSettingMinimum">2</integer>

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -66,6 +66,14 @@
         <item>255</item>  <!-- 4096 -->
     </integer-array>
 
+    <!-- List of biometric sensors on the device, in decreasing strength. Consumed by AuthService
+         when registering authenticators with BiometricService. Format must be ID:Modality:Strength,
+         where: IDs are unique per device, Modality as defined in BiometricAuthenticator.java,
+         and Strength as defined in BiometricManager.java -->
+    <string-array name="config_biometric_sensors" translatable="false" >
+        <item>0:2:15</item> <!-- ID0:Fingerprint:Strong -->
+    </string-array>
+
     <!-- Minimum screen brightness setting allowed by the power manager.
          The user is forbidden from setting the brightness below this level. -->
     <integer name="config_screenBrightnessSettingMinimum">2</integer>

--- a/rootdir/vendor/etc/init/qcrild.rc
+++ b/rootdir/vendor/etc/init/qcrild.rc
@@ -6,5 +6,5 @@ service vendor.qcrild /odm/bin/hw/qcrild
     capabilities BLOCK_SUSPEND NET_ADMIN NET_RAW
 
 on property:vendor.rild.libpath=/odm/lib64/libril-qc-hal-qmi.so
-    stop ril-daemon
+    stop vendor.ril-daemon
     enable vendor.qcrild


### PR DESCRIPTION
qcrild.rc is attempting to stop ril-daemon which doesnt exist (https://github.com/sonyxperiadev/device-sony-common/blob/s-mr1/rootdir/vendor/etc/init/qcrild.rc#L9) and errors out with the below message.

"init: Command 'stop ril-daemon' action=vendor.rild.libpath=/odm/lib64/libril-qc-hal-qmi.so (/vendor/etc/init/qcrild.rc:9) took 0ms and failed: service ril-daemon not found."

Instead we have vendor.ril-daemon service starting in the background.

"init: starting service 'vendor.ril-daemon'..."

Add the vendor prefix to ril-daemon.

Fixes the buggy sim detection on S.