### PR TITLE
[s-mr1] common: Clean up unnecessarily complex ifneq switches for display

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -15,15 +15,12 @@
 # Common path
 COMMON_PATH := device/sony/common
 
-ifneq ($(filter 4.19, $(SOMC_KERNEL_VERSION)),)
+ifeq ($(SOMC_KERNEL_VERSION), 4.14)
+display_platform := sm8150
+else ifeq ($(SOMC_KERNEL_VERSION), 4.19)
 display_platform := sm8250
 else
 display_platform := sm8350
-endif
-
-# Everything prior to kernel 4.19 uses the sm8150 display HAL
-ifneq ($(filter 4.14, $(SOMC_KERNEL_VERSION)),)
-display_platform := sm8150
 endif
 
 # Enable building packages from device namspaces.


### PR DESCRIPTION
@jerpelea feel free to squash this into 367ae94e ("qcom: add support for sm8305 SOC") which, by the way, has a typo - it's `sm8350` not `sm8305` :wink: 