### PR TITLE
[R] common-treble: use GPT-based IBootControl 1.0 HAL for lena

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -223,6 +223,14 @@ ifneq ($(filter edo,$(SOMC_PLATFORM)),)
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.qti.hardware.camera.postproc.xml
 endif
 
+# Only define bootctrl HAL availability on AB platforms:
+ifeq ($(AB_OTA_UPDATER),true)
+# Define HAL 1.0 for platforms reading it from GPT
+ifneq ($(filter lena,$(SOMC_PLATFORM)),)
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.bootctrl_v1.0.xml
+endif
+endif
+
 # New vendor security patch level: https://r.android.com/660840/
 # Used by newer keymaster binaries
 VENDOR_SECURITY_PATCH=$(PLATFORM_SECURITY_PATCH)

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -138,8 +138,16 @@ PRODUCT_PACKAGES += \
 
 # Only define bootctrl HAL availability on AB platforms:
 ifeq ($(AB_OTA_UPDATER),true)
+# Define HAL 1.0 for platforms reading it from GPT
+ifneq ($(filter lena, $(SOMC_PLATFORM)),)
+PRODUCT_PACKAGES += \
+    android.hardware.boot@1.0-impl \
+    android.hardware.boot@1.0-impl.recovery \
+    android.hardware.boot@1.0-service
+else
 PRODUCT_PACKAGES += \
     android.hardware.boot@1.1-impl \
     android.hardware.boot@1.1-impl.recovery \
     android.hardware.boot@1.1-service
+endif
 endif

--- a/vintf/android.hardware.bootctrl_v1.0.xml
+++ b/vintf/android.hardware.bootctrl_v1.0.xml
@@ -1,0 +1,11 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.boot</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IBootControl</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>


### PR DESCRIPTION
IBootControl 1.1 HAL changed the method of storing boot status information. It now uses the `misc` partition, and requires vendors to ship a compatible bootloader to read from it.
1.0 HAL uses GPT partition entries, and devices with such bootloaders should keep the old HAL.