### PR TITLE
[R/S] common-treble: Switch to CAF bootctrl 1.1 HAL

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -139,7 +139,7 @@ PRODUCT_PACKAGES += \
 # Only define bootctrl HAL availability on AB platforms:
 ifeq ($(AB_OTA_UPDATER),true)
 PRODUCT_PACKAGES += \
-    android.hardware.boot@1.1-impl \
-    android.hardware.boot@1.1-impl.recovery \
+    android.hardware.boot@1.1-impl-qti \
+    android.hardware.boot@1.1-impl-qti.recovery \
     android.hardware.boot@1.1-service
 endif


### PR DESCRIPTION
Fixes https://github.com/sonyxperiadev/bug_tracker/issues/740

AOSP switched up the default implementation from GPT flags to the `/misc` partition in the default implementation (`-impl` lib and `libboot_control.so`) for 1.1 [1], which is incorrect on our Qualcomm boards.  As we'd still like to switch to the 1.1 interface for FCM5 compatibility, and would like to drop the legacy libhardware module (see `bootctl.<platform>` in the respective platform directories, and its implementation in `hardware/qcom/bootctrl`) we'll use the updated CAF repository directly.

Note that we still include AOSP's 1.1 passthrough library loader.  As usual, this provides us with the right init .rc and vintf fragment, and allows starting both a 1.0 and 1.1 passthrough (`-impl`) library.  It is this `-impl` library that is custom to QTI and calls into their custom `libboot_control_qti.so`.

[1]: https://github.com/sonyxperiadev/bug_tracker/issues/740#issuecomment-1016325638

---

Tested on Sagami: rebooting to `fastboot` now shows a successful boot:

```
(bootloader) slot-retry-count:a:6
(bootloader) slot-unbootable:a:no
(bootloader) slot-successful:a:yes
```

And setting `bootctl set-slot-as-unbootable` appropriately prohibits boot now.

# TODO

1. [x] Test on R - I only built this on S for now!
2. [ ] Test on all devices listed below;
3. [x] Drop ancient `bootctrl` setup from platform repos, and drop `untrack` it from `hardware/qcom/bootctrl`. I have the changes ready, will PR when there is time again.

### Test on all platforms
- [x] Sagami
- [x] Edo
- [x] Lena
- [x] Tama
- [x] Kumano
- [x] Seine
- [x] Nile
- [x] Ganges

---

CC @sledges @thaodan