### PR TITLE
[R/S] mediacodec: Update seccomp polic from CAF.

### DIFF
--- a/rootdir/vendor/etc/seccomp_policy/mediacodec.policy
+++ b/rootdir/vendor/etc/seccomp_policy/mediacodec.policy
@@ -1,7 +1,19 @@
 # device specific syscalls
+# extension of services/mediacodec/minijail/seccomp_policy/mediacodec-seccomp-arm.policy
 pselect6: 1
 eventfd2: 1
 sendto: 1
 recvfrom: 1
+_llseek: 1
 sysinfo: 1
 getcwd: 1
+getdents64: 1
+ARM_cacheflush: 1
+inotify_init1: 1
+inotify_add_watch: 1
+inotify_rm_watch: 1
+uname: 1
+ueventd: 1
+timer_create: 1
+timer_settime: 1
+rt_sigtimedwait: 1


### PR DESCRIPTION
Updated from vendor-qcom-opensource-media as of 182649923d3813e2e539a0e36d83b3e70dcfcc4a:
https://github.com/sonyxperiadev/vendor-qcom-opensource-media/tree/182649923d3813e2e539a0e36d83b3e70dcfcc4a