### PR TITLE
[S] clean up USB and set peripheral mode for Sagami

### DIFF
--- a/rootdir/init.recovery.common.rc
+++ b/rootdir/init.recovery.common.rc
@@ -1,28 +1,10 @@
 on init
     # USB setup
-    mkdir /config 0770 shell shell
-    mount configfs none /config
-    mkdir /config/usb_gadget/g1 0770 shell shell
-    mkdir /config/usb_gadget/g1/strings/0x409 0770 shell shell
-    write /config/usb_gadget/g1/strings/0x409/serialnumber ${ro.serialno}
-    write /config/usb_gadget/g1/strings/0x409/manufacturer ${ro.product.manufacturer}
-    write /config/usb_gadget/g1/strings/0x409/product ${ro.product.model}
-    mkdir /config/usb_gadget/g1/functions/ffs.adb
-    write /config/usb_gadget/g1/os_desc/use 1
-    write /config/usb_gadget/g1/os_desc/b_vendor_code 0x1
-    write /config/usb_gadget/g1/os_desc/qw_sign "MSFT100"
-    mkdir /config/usb_gadget/g1/configs/b.1 0770 shell shell
-    mkdir /config/usb_gadget/g1/configs/b.1/strings/0x409 0770 shell shell
-    symlink /config/usb_gadget/g1/configs/b.1 /config/usb_gadget/g1/os_desc/b.1
-    setprop sys.usb.config adb
     setprop sys.usb.configfs 1
 
-on fs      
+on fs
     wait /dev/block/platform/soc/${ro.boot.bootdevice}
     symlink /dev/block/platform/soc/${ro.boot.bootdevice} /dev/block/bootdevice
-
-on property:sys.usb.config=adb
-    start adbd
 
 # Set idVendor as Sony for all USB configurations
 on property:sys.usb.config=*

--- a/rootdir/init.recovery.common.rc
+++ b/rootdir/init.recovery.common.rc
@@ -1,6 +1,7 @@
 on init
     # USB setup
     setprop sys.usb.configfs 1
+    write /sys/class/udc/${sys.usb.controller}/device/../mode peripheral
 
 on fs
     wait /dev/block/platform/soc/${ro.boot.bootdevice}

--- a/rootdir/vendor/etc/init/init.usb.rc
+++ b/rootdir/vendor/etc/init/init.usb.rc
@@ -80,6 +80,7 @@ on boot
     mount functionfs adb /dev/usb-ffs/adb rmode=0770,fmode=0660,uid=2000,gid=2000
     mount functionfs mtp /dev/usb-ffs/mtp rmode=0770,fmode=0660,uid=1024,gid=1024,no_disconnect=1
     mount functionfs ptp /dev/usb-ffs/ptp rmode=0770,fmode=0660,uid=1024,gid=1024,no_disconnect=1
+    write /sys/class/udc/${sys.usb.controller}/device/../mode peripheral
     setprop vendor.sys.usb.configfs 1
 
 # USB compositions


### PR DESCRIPTION
- init.recovery: Only perform USB setup once, and set mode to peripheral
- init.recovery,init.usb: Set UDC mode to peripheral
