### PR TITLE
Revert "init: qcrild.rc : Add vendor prefix to ril-daemon"

### DIFF
--- a/rootdir/vendor/etc/init/qcrild.rc
+++ b/rootdir/vendor/etc/init/qcrild.rc
@@ -6,5 +6,5 @@ service vendor.qcrild /odm/bin/hw/qcrild
     capabilities BLOCK_SUSPEND NET_ADMIN NET_RAW
 
 on property:vendor.rild.libpath=/odm/lib64/libril-qc-hal-qmi.so
-    stop vendor.ril-daemon
+    stop ril-daemon
     enable vendor.qcrild


### PR DESCRIPTION
On R the service is still called "ril-daemon".

This fixes random SIM detection https://github.com/sonyxperiadev/bug_tracker/issues/736.

This reverts commit 30b54ba54619cc17bfc8bfd7a56d8e235579431a.