### PR TITLE
Add modem config files for Turkish providers

### DIFF
--- a/rootdir/vendor/oem/modem-config/S236.1/modem.conf
+++ b/rootdir/vendor/oem/modem-config/S236.1/modem.conf
@@ -1,0 +1,1 @@
+mcfg_sw/generic/euro/turkcell/vlvw/tr/mcfg_sw.mbn

--- a/rootdir/vendor/oem/modem-config/S236.2/modem.conf
+++ b/rootdir/vendor/oem/modem-config/S236.2/modem.conf
@@ -1,0 +1,1 @@
+mcfg_sw/generic/euro/turkcell/vlvw/tr/mcfg_sw.mbn

--- a/rootdir/vendor/oem/modem-config/S237.3/modem.conf
+++ b/rootdir/vendor/oem/modem-config/S237.3/modem.conf
@@ -1,0 +1,1 @@
+mcfg_sw/generic/euro/vodafone/vlvw/tr/mcfg_sw.mbn

--- a/rootdir/vendor/oem/modem-config/S238.1/modem.conf
+++ b/rootdir/vendor/oem/modem-config/S238.1/modem.conf
@@ -1,0 +1,1 @@
+mcfg_sw/generic/euro/turktele/vl/tr/mcfg_sw.mbn

--- a/rootdir/vendor/oem/modem-config/S238.2/modem.conf
+++ b/rootdir/vendor/oem/modem-config/S238.2/modem.conf
@@ -1,0 +1,1 @@
+mcfg_sw/generic/euro/turktele/vl/tr/mcfg_sw.mbn


### PR DESCRIPTION
This adds modem config files for the following providers,

- Turkcell
- Turk Telekom
- Vodafone

Firmware files are extracted from latest stock ROM (52.1.A.3.49) at /vendor/firmware_mnt/image/modem_pr/mcfg/configs