### PR TITLE
Replace sm8250 with $(KONA)

### DIFF
--- a/hardware/camera/Android.mk
+++ b/hardware/camera/Android.mk
@@ -3,7 +3,7 @@
 
 LOCAL_PATH := $(call my-dir)
 
-ifneq ($(filter sdm845 sm6350 sm8150 sm8250,$(TARGET_BOARD_PLATFORM)),)
+ifneq ($(filter sdm845 sm6350 sm8150 $(KONA),$(TARGET_BOARD_PLATFORM)),)
 
 include $(SONY_CLEAR_VARS)
 LOCAL_MODULE := camera_symlinks

--- a/hardware/qcom/Android.mk
+++ b/hardware/qcom/Android.mk
@@ -3,18 +3,18 @@ ifneq ($(wildcard device/sony/common/hardware/qcom/custom.mk),)
 else
 # Board platforms lists to be used for
 # TARGET_BOARD_PLATFORM specific featurization
-QCOM_BOARD_PLATFORMS += msm8998 sdm660 sdm845 sm6125 sm6350 sm8150 sm8250
+QCOM_BOARD_PLATFORMS += msm8998 sdm660 sdm845 sm6125 sm6350 sm8150 $(KONA)
 
 # Some supported platforms need a different media hal
 # This list selects platforms that should use the latest media hal
 # All other platforms automatically fallback to the legacy hal
-QCOM_NEW_MEDIA_PLATFORM := sdm845 sm6125 sm6350 sm8150 sm8250
+QCOM_NEW_MEDIA_PLATFORM := sdm845 sm6125 sm6350 sm8150 $(KONA)
 
 #List of targets that use video hw
-MSM_VIDC_TARGET_LIST := msm8998 sdm660 sdm845 sm6125 sm6350 sm8150 sm8250
+MSM_VIDC_TARGET_LIST := msm8998 sdm660 sdm845 sm6125 sm6350 sm8150 $(KONA)
 
 #List of targets that use master side content protection
-MASTER_SIDE_CP_TARGET_LIST := msm8998 sdm660 sdm845 sm6125 sm6350 sm8150 sm8250
+MASTER_SIDE_CP_TARGET_LIST := msm8998 sdm660 sdm845 sm6125 sm6350 sm8150 $(KONA)
 
 ifneq ($(filter $(QCOM_NEW_MEDIA_PLATFORM), $(TARGET_BOARD_PLATFORM)),)
 QCOM_MEDIA_ROOT := vendor/qcom/opensource/media/sm8150

--- a/hardware/tftp/Android.mk
+++ b/hardware/tftp/Android.mk
@@ -1,6 +1,6 @@
 LOCAL_PATH := $(call my-dir)
 
-ifneq ($(filter sdm660 msm8998 sdm845 sm6125 sm6350 sm8150 sm8250,$(TARGET_BOARD_PLATFORM)),)
+ifneq ($(filter sdm660 msm8998 sdm845 sm6125 sm6350 sm8150 $(KONA),$(TARGET_BOARD_PLATFORM)),)
 
 include $(SONY_CLEAR_VARS)
 LOCAL_MODULE := tftp_symlinks


### PR DESCRIPTION
Not all custom ROMs use `KONA = sm8250`. For example, the lineage uses `KONA = kona`. It'll cause problems to hard-code `sm8250` everywhere.

This PR replaces all hard-coded sm8250 that is used for detecting `TARGET_BOARD_PLATFORM` to `$(KONA)`.