### PR TITLE
hardware: Replace hardcoded `sm6125 sm6350 sm8150` with `$(TRINKET) $(LITO) $(MSMNILE)`

### DIFF
--- a/hardware/camera/Android.mk
+++ b/hardware/camera/Android.mk
@@ -3,7 +3,7 @@
 
 LOCAL_PATH := $(call my-dir)
 
-ifneq ($(filter sdm845 sm6350 sm8150 $(KONA),$(TARGET_BOARD_PLATFORM)),)
+ifneq ($(filter sdm845 $(LITO) $(MSMNILE) $(KONA),$(TARGET_BOARD_PLATFORM)),)
 
 include $(SONY_CLEAR_VARS)
 LOCAL_MODULE := camera_symlinks

--- a/hardware/qcom/Android.mk
+++ b/hardware/qcom/Android.mk
@@ -3,18 +3,18 @@ ifneq ($(wildcard device/sony/common/hardware/qcom/custom.mk),)
 else
 # Board platforms lists to be used for
 # TARGET_BOARD_PLATFORM specific featurization
-QCOM_BOARD_PLATFORMS += msm8998 sdm660 sdm845 sm6125 sm6350 sm8150 $(KONA)
+QCOM_BOARD_PLATFORMS += msm8998 sdm660 sdm845 $(TRINKET) $(LITO) $(MSMNILE) $(KONA)
 
 # Some supported platforms need a different media hal
 # This list selects platforms that should use the latest media hal
 # All other platforms automatically fallback to the legacy hal
-QCOM_NEW_MEDIA_PLATFORM := sdm845 sm6125 sm6350 sm8150 $(KONA)
+QCOM_NEW_MEDIA_PLATFORM := sdm845 $(TRINKET) $(LITO) $(MSMNILE) $(KONA)
 
 #List of targets that use video hw
-MSM_VIDC_TARGET_LIST := msm8998 sdm660 sdm845 sm6125 sm6350 sm8150 $(KONA)
+MSM_VIDC_TARGET_LIST := msm8998 sdm660 sdm845 $(TRINKET) $(LITO) $(MSMNILE) $(KONA)
 
 #List of targets that use master side content protection
-MASTER_SIDE_CP_TARGET_LIST := msm8998 sdm660 sdm845 sm6125 sm6350 sm8150 $(KONA)
+MASTER_SIDE_CP_TARGET_LIST := msm8998 sdm660 sdm845 $(TRINKET) $(LITO) $(MSMNILE) $(KONA)
 
 ifneq ($(filter $(QCOM_NEW_MEDIA_PLATFORM), $(TARGET_BOARD_PLATFORM)),)
 QCOM_MEDIA_ROOT := vendor/qcom/opensource/media/sm8150

--- a/hardware/tftp/Android.mk
+++ b/hardware/tftp/Android.mk
@@ -1,6 +1,6 @@
 LOCAL_PATH := $(call my-dir)
 
-ifneq ($(filter sdm660 msm8998 sdm845 sm6125 sm6350 sm8150 $(KONA),$(TARGET_BOARD_PLATFORM)),)
+ifneq ($(filter sdm660 msm8998 sdm845 $(TRINKET) $(LITO) $(MSMNILE) $(KONA),$(TARGET_BOARD_PLATFORM)),)
 
 include $(SONY_CLEAR_VARS)
 LOCAL_MODULE := tftp_symlinks


### PR DESCRIPTION
These variables are in place to have a custom SoC name for a given SoC project (SODP uses the former "part number", whereas other SODP-based ROMs may opt for the SoC project name), but were only recently adjusted to use the variable name for KONA/sm8250 in a very nondescriptive patch.  Address this for the remaining SoCs with such a variable name.
