### PR TITLE
Add modem configs for Finnish providers Elisa and DNA

### DIFF
--- a/rootdir/vendor/oem/modem-config/S256.1/modem.conf
+++ b/rootdir/vendor/oem/modem-config/S256.1/modem.conf
@@ -1,0 +1,1 @@
+mcfg_sw/generic/euro/elisa/vlvw/fin/mcfg_sw.mbn

--- a/rootdir/vendor/oem/modem-config/S256.2/modem.conf
+++ b/rootdir/vendor/oem/modem-config/S256.2/modem.conf
@@ -1,0 +1,1 @@
+mcfg_sw/generic/euro/elisa/vlvw/fin/mcfg_sw.mbn

--- a/rootdir/vendor/oem/modem-config/S257.1/modem.conf
+++ b/rootdir/vendor/oem/modem-config/S257.1/modem.conf
@@ -1,0 +1,1 @@
+mcfg_sw/generic/euro/dna/vlvw/fin/mcfg_sw.mbn

--- a/rootdir/vendor/oem/modem-config/S257.2/modem.conf
+++ b/rootdir/vendor/oem/modem-config/S257.2/modem.conf
@@ -1,0 +1,1 @@
+mcfg_sw/generic/euro/dna/vlvw/fin/mcfg_sw.mbn


### PR DESCRIPTION
This adds modem configs for the Finnish Elisa and DNA providers.

The firmware files reside at
/vendor/firmware_mnt/image/modem_pr/mcfg/configs

The IDs are listed at [service_provider_sim_configs.xml](https://github.com/sonyxperiadev/SonyOpenTelephony/blob/master/ModemConfig/res/xml/service_provider_sim_configs.xml#L708) but were missing a modem.conf.
