### PR TITLE
modem-config: Fix path for for Finnish providers Elisa and DNA

### DIFF
--- a/rootdir/vendor/oem/modem-config/S255.1/modem.conf
+++ b/rootdir/vendor/oem/modem-config/S255.1/modem.conf
@@ -1,1 +1,1 @@
-mcfg_sw/generic/euro/telia/vlvw/fin/mcfg_sw.mbn
+mcfg_sw/generic/EU/Elisa/Commercial/FI/mcfg_sw.mbn

--- a/rootdir/vendor/oem/modem-config/S256.1/modem.conf
+++ b/rootdir/vendor/oem/modem-config/S256.1/modem.conf
@@ -1,1 +1,1 @@
-mcfg_sw/generic/euro/elisa/vlvw/fin/mcfg_sw.mbn
+mcfg_sw/generic/EU/Elisa/VLVW/Estonia/mcfg_sw.mbn

--- a/rootdir/vendor/oem/modem-config/S257.1/modem.conf
+++ b/rootdir/vendor/oem/modem-config/S257.1/modem.conf
@@ -1,1 +1,1 @@
-mcfg_sw/generic/euro/dna/vlvw/fin/mcfg_sw.mbn
+mcfg_sw/generic/EU/DNA/VLVW/Finland/mcfg_sw.mbn

--- a/rootdir/vendor/oem/modem-config/S257.2/modem.conf
+++ b/rootdir/vendor/oem/modem-config/S257.2/modem.conf
@@ -1,1 +1,1 @@
-mcfg_sw/generic/euro/dna/vlvw/fin/mcfg_sw.mbn
+mcfg_sw/generic/EU/DNA/VLVW/Finland/mcfg_sw.mbn


### PR DESCRIPTION
Later firmware partitions use a different file layout.