### PR TITLE
[S] hardware/health: Wait for adsp and `power_supply/battery` before starting health HAL

### DIFF
--- a/hardware/health/android.hardware.health@2.0-service.sony.rc
+++ b/hardware/health/android.hardware.health@2.0-service.sony.rc
@@ -7,10 +7,18 @@ on fs
     chmod 0664 /sys/class/power_supply/bms/charge_full
     chmod 0664 /sys/class/power_supply/bms/cycle_count
 
+# Wait for the battery to come online before starting health
+on property:vendor.qcom.adspup=1
+    wait /sys/class/power_supply/battery
+    enable vendor.health-hal-2-0
+
 service vendor.health-hal-2-0 /vendor/bin/hw/android.hardware.health@2.0-service.sony
-    interface android.hardware.health@2.0::IHealth default
+    # Don't lazy-start this HAL (following line commented out), so that we can coordinate
+    # the start of this service _after_ the battery sysfs entry is available.
+    # interface android.hardware.health@2.0::IHealth default
     class hal
     capabilities WAKE_ALARM
     user system
     group system
     file /dev/kmsg w
+    disabled


### PR DESCRIPTION
On at least our Sagami class of devices the kernel battery driver (including SoMC charger extensions) probes/registers later than the start of our `health` HAL, resulting in it not seeing the battery until a restart.  The power supply arrives as soon as adsp is booted, which is our signal to kick-start the HAL.

Note that we could also have a `wait /sys/class/power_supply/battery` on another `on <xxx>` trigger that starts _later_ than adspstart, but this'll block the entire trigger until a power supply arrives.
