### PR TITLE
common-treble.mk: Build hostapd libraries

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -71,7 +71,8 @@ endif
 
 # Wi-Fi
 PRODUCT_PACKAGES += \
-    android.hardware.wifi@1.0-service
+    android.hardware.wifi@1.0-service \
+    android.hardware.wifi.hostapd@1.0.vendor
 
 # NFC packages
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Since wpa-suppliant is now switched to AIDL, it no longer
builds the HIDL interfaces that the prebuilt software binaries
need.

Build the HIDL interface to make the prebuilt executable happy.