### PR TITLE
[T] Remove reliance on deprecated a2dp/hearing_aid system audio modules

### DIFF
--- a/common-packages.mk
+++ b/common-packages.mk
@@ -22,9 +22,7 @@ PRODUCT_PACKAGES += \
 
 # Audio
 PRODUCT_PACKAGES += \
-    audio.a2dp.default \
     audio.bluetooth.default \
-    audio.hearing_aid.default \
     audio.r_submix.default \
     audio.usb.default \
     audioadsprpcd \

--- a/common.mk
+++ b/common.mk
@@ -125,8 +125,6 @@ PRODUCT_COPY_FILES += \
 # Audio Configuration
 PRODUCT_COPY_FILES += \
     $(COMMON_PATH)/rootdir/vendor/etc/audio_effects.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_effects.xml \
-    frameworks/av/services/audiopolicy/config/a2dp_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/a2dp_audio_policy_configuration.xml \
-    frameworks/av/services/audiopolicy/config/a2dp_in_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/a2dp_in_audio_policy_configuration.xml \
     frameworks/av/services/audiopolicy/config/audio_policy_volumes.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_volumes.xml \
     frameworks/av/services/audiopolicy/config/bluetooth_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/bluetooth_audio_policy_configuration.xml \
     frameworks/av/services/audiopolicy/config/default_volume_tables.xml:$(TARGET_COPY_OUT_VENDOR)/etc/default_volume_tables.xml \


### PR DESCRIPTION
Android [finally cut down on vendor access] to the system-only `audio.a2dp.default` and `audio.hearing_aid.default` libhardware modules, which have already been deprecated and replaced with the much more modern HIDL+fqm `audio.bluetooth.default` _vendor_ libhardware module. The modules reside on `/system` where they [can't be loaded anyway when VNDK is enabled]:

    E DevicesFactoryHAL: loadAudioInterface couldn't load audio hw module audio.a2dp (No such file or directory)
    W DevicesFactoryHalHidl: The specified device name is not recognized: "a2dp"
    E AudioFlinger: loadHwModule() error -22 loading module a2dp
    W APM_AudioPolicyManager: could not open HW module a2dp

This policy isn't reachable anyway unless the new Bluetooth Audio HAL is explicitly disabled by setting `persist.bluetooth.bluetooth_audio_hal.disabled` to `true`.

Besides removing this request for libraries that are only installed to `/system` - which isn't compatible with GSI! - delete/exclude any fallback policy files that are pointing to this `a2dp`/`hearing_aid` module (which were previously introduced/retained only to have an easy-out if the Bluetooth Audio HAL acted up, but have fortunately never been used 🎉).

Only `AUDIO_DEVICE_IN_BLUETOOTH_A2DP` is now unsupported, but phones never function as an a2dp sink anyway (this is typically reserved for infotainment systems) and call microphone audio still travels over good-old 8kHz/16kHz HFP SCO via `AUDIO_DEVICE_IN_BLUETOOTH_SCO_HEADSET` (and hopefully LC3 through Bluetooth LE Audio when we enable that soon).

[finally cut down on vendor access]: https://cs.android.com/android/_/android/platform/packages/modules/Bluetooth/+/f261e756b4f10059b6b90847cd208c95adbd8146
[can't be loaded anyway when VNDK is enabled]: https://cs.android.com/android/platform/superproject/+/android-13.0.0_r1:hardware/libhardware/hardware.c;l=187-192

---

Note that this is WIP until the matching platform PRs are submitted, and properly tested on-device - on at least T some services fail to start properly, rendering A2DP to not work at all.
