### PR TITLE
common: hidl: Add prebuilt HIDL interface definition for IModemSwitcher 1.0

### DIFF
--- a/hidl/Android.bp
+++ b/hidl/Android.bp
@@ -1,0 +1,6 @@
+prebuilt_hidl_interfaces {
+    name: "hidl_modemswitcher_interface",
+    interfaces: [
+        "vendor.somc.hardware.modemswitcher@1.0::IModemSwitcher",
+    ],
+}


### PR DESCRIPTION
Should fix the host_init_verifier error we're getting

Signed-off-by: Gagan Malvi <malvigagan@gmail.com>