### PR TITLE
enable external camera support on Android 13

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -61,12 +61,12 @@ PRODUCT_PACKAGES += \
     android.frameworks.sensorservice@1.0.vendor
 ifeq ($(TARGET_USES_64BIT_CAMERA),true)
 PRODUCT_PACKAGES += \
-    android.hardware.camera.provider@2.4-impl:64 \
-    android.hardware.camera.provider@2.4-service_64
+    android.hardware.camera.provider@2.5-impl:64 \
+    android.hardware.camera.provider@2.5-service_64
 else
 PRODUCT_PACKAGES += \
-    android.hardware.camera.provider@2.4-impl:32 \
-    android.hardware.camera.provider@2.4-service
+    android.hardware.camera.provider@2.5-impl:32 \
+    android.hardware.camera.provider@2.5-service
 endif
 
 # Wi-Fi

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -69,6 +69,11 @@ PRODUCT_PACKAGES += \
     android.hardware.camera.provider@2.5-service
 endif
 
+# External Camera
+PRODUCT_PACKAGES += \
+    android.hardware.camera.provider@2.5-external \
+    android.hardware.camera.provider@2.5-external-service
+
 # Wi-Fi
 PRODUCT_PACKAGES += \
     android.hardware.wifi@1.0-service \

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -47,7 +47,7 @@
     <hal format="hidl">
         <name>android.hardware.camera.provider</name>
         <transport>hwbinder</transport>
-        <version>2.4</version>
+        <version>2.5</version>
         <interface>
             <name>ICameraProvider</name>
             <instance>legacy/0</instance>

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -51,6 +51,7 @@
         <interface>
             <name>ICameraProvider</name>
             <instance>legacy/0</instance>
+            <instance>external/0</instance>
         </interface>
     </hal>
     <hal format="hidl">


### PR DESCRIPTION
Tested on lena (pdx213) and sagami (pdx215).