### PR TITLE
common-packages.mk Audio Apex Build Error Fix

### DIFF
--- a/common-packages.mk
+++ b/common-packages.mk
@@ -22,9 +22,7 @@ PRODUCT_PACKAGES += \
 
 # Audio
 PRODUCT_PACKAGES += \
-    audio.a2dp.default \
     audio.bluetooth.default \
-    audio.hearing_aid.default \
     audio.r_submix.default \
     audio.usb.default \
     audioadsprpcd \


### PR DESCRIPTION
I am aware of the git revert on the repo_update.sh but use this instead...
BT Apex Audio Packages got mainlined with Android 13. Fix is right here. Build Failed before with:
```
system/sepolicy/Android.mk:62: warning: BOARD_PLAT_PRIVATE_SEPOLICY_DIR has been deprecated. Use SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS instead. [  0% 1163/160123] build out/NOT_AVAILABLE_FOR_PLATFORM/target/product/pdx215/system/lib64/hw/audio.a2dp.defau FAILED: out/NOT_AVAILABLE_FOR_PLATFORM/target/product/pdx215/system/lib64/hw/audio.a2dp.default.so /bin/bash -c "(echo -e \"\\033[1maudio.a2dp.default: \\033[31merror:\\033[0m\\033[1m\" 'Module is requested to be installed but is not available for platform because it does not have \"//apex_available:platform\" or it depends on other modules that are not available for platform.'  \"\\033[0m\" >&2 ) && (exit 1 )" audio.a2dp.default: error: Module is requested to be installed but is not available for platform because it does not have "//apex_available:platform" or it depends on other modules that are not available for platform.  [  0% 1164/160123] build out/NOT_AVAILABLE_FOR_PLATFORM/target/product/pdx215/system/lib/hw/audio.a2dp.default FAILED: out/NOT_AVAILABLE_FOR_PLATFORM/target/product/pdx215/system/lib/hw/audio.a2dp.default.so /bin/bash -c "(echo -e \"\\033[1maudio.a2dp.default_32: \\033[31merror:\\033[0m\\033[1m\" 'Module is requested to be installed but is not available for platform because it does not have \"//apex_available:platform\" or it depends on other modules that are not available for platform.'  \"\\033[0m\" >&2 ) && (exit 1 )" audio.a2dp.default_32: error: Module is requested to be installed but is not available for platform because it does not have "//apex_available:platform" or it depends on other modules that are not available for platform.  [  0% 1165/160123] build out/NOT_AVAILABLE_FOR_PLATFORM/target/product/pdx215/system/lib64/hw/audio.hearing_ai FAILED: out/NOT_AVAILABLE_FOR_PLATFORM/target/product/pdx215/system/lib64/hw/audio.hearing_aid.default.so /bin/bash -c "(echo -e \"\\033[1maudio.hearing_aid.default: \\033[31merror:\\033[0m\\033[1m\" 'Module is requested to be installed but is not available for platform because it does not have \"//apex_available:platform\" or it depends on other modules that are not available for platform.'  \"\\033[0m\" >&2 ) && (exit 1 )" audio.hearing_aid.default: error: Module is requested to be installed but is not available for platform because it does not have "//apex_available:platform" or it depends on other modules that are not available for platform.  [  0% 1166/160123] build out/NOT_AVAILABLE_FOR_PLATFORM/target/product/pdx215/system/lib/hw/audio.hearing_aid.
FAILED: out/NOT_AVAILABLE_FOR_PLATFORM/target/product/pdx215/system/lib/hw/audio.hearing_aid.default.so
/bin/bash -c "(echo -e \"\\033[1maudio.hearing_aid.default_32: \\033[31merror:\\033[0m\\033[1m\" 'Module is requested to be installed but is not available for platform because it does not have \"//apex_available:platform\" or it depends on other modules that are not available for platform.'  \"\\033[0m\" >&2 ) && (exit 1 )"
audio.hearing_aid.default_32: error: Module is requested to be installed but is not available for platform because it does not have "//apex_available:platform" or it depends on other modules that are not available for platform. 
01:47:48 ninja failed with: exit status 1
```