### PR TITLE
[T/U] vintf: Drop duplicate `com.qualcomm.qti.dpm.api` definition

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -195,9 +195,6 @@ else
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.secure_element_ss.xml
 endif
 
-# Dynamic Power Management
-DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.qualcomm.qti.dpm.xml
-
 # DSP service
 ifeq ($(TARGET_USES_DSP_SERVICE),true)
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.qti.hardware.dsp.xml

--- a/vintf/vendor.qualcomm.qti.dpm.xml
+++ b/vintf/vendor.qualcomm.qti.dpm.xml
@@ -1,7 +1,0 @@
-<manifest version="1.0" type="device">
-    <hal format="hidl">
-        <name>com.qualcomm.qti.dpm.api</name>
-        <transport>hwbinder</transport>
-        <fqname>@1.0::IdpmQmi/dpmQmiService</fqname>
-    </hal>
-</manifest>


### PR DESCRIPTION
This service was originally added in a5f7f38c ("vintf: Add com.qualcomm.qti.dpm.api::IdpmQmi@1.0") and later had a deprecated `vendor.qti.dpm.api` entry (hosting the same interface) renamed to it in 81835713 ("qcrild.rc: add new ril services") via the `vendor.hw.dataservices.xml` file.  The former commit should have likely renamed it outright, instead of adding a new definition, and Android 14 now rightfully complains that it found a duplicate:

    getDeviceHalManifest: -22 VINTF parse error: Illformed file: /vendor/etc/vintf/manifest.xml: Duplicated manifest.hal entry com.qualcomm.qti.dpm.api: Conflicting FqInstance: @1.0::IdpmQmi/dpmQmiService (from /vendor/etc/vintf/manifest.xml) vs. @1.0::IdpmQmi/dpmQmiService (from /vendor/etc/vintf/manifest.xml). Check whether or not multiple modules providing the same HAL are installed.
