### PR TITLE
[t-mr1] vendor: data: Add configuration for SoC Lahaina

### DIFF
--- a/rootdir/vendor/etc/data/dsi_config.xml
+++ b/rootdir/vendor/etc/data/dsi_config.xml
@@ -276,4 +276,57 @@
        <data type="string"> rmnet_data16 </data>
      </list>
    </listitem>
+
+   <!-- Configuration for lahaina_pt -->
+   <listitem name="lahaina_pt">
+
+     <data name="qos_enabled" type="int"> 1 </data>
+     <data name="rmnet_data_enabled" type="int"> 1 </data>
+     <data name="phys_net_dev" type="string"> rmnet_ipa0 </data>
+     <data name="netmgr_listen_ev_proto" type="int"> 1 </data>
+
+     <data name="single_qmux_channel_enabled" type="int"> 1 </data>
+     <data name="single_qmux_channel_name" type="string"> rmnet0 </data>
+
+     <data name="num_dsi_handles" type="int"> 17 </data>
+     <list name="device_names">
+       <data type="string"> rmnet_data0 </data>
+       <data type="string"> rmnet_data1 </data>
+       <data type="string"> rmnet_data2 </data>
+       <data type="string"> rmnet_data3 </data>
+       <data type="string"> rmnet_data4 </data>
+       <data type="string"> rmnet_data5 </data>
+       <data type="string"> rmnet_data6 </data>
+       <data type="string"> rmnet_data7 </data>
+       <data type="string"> rmnet_data8 </data>
+       <data type="string"> rmnet_data9 </data>
+       <data type="string"> rmnet_data10 </data>
+       <data type="string"> rmnet_data11 </data>
+       <data type="string"> rmnet_data12 </data>
+       <data type="string"> rmnet_data13 </data>
+       <data type="string"> rmnet_data14 </data>
+       <data type="string"> rmnet_data15 </data>
+       <data type="string"> rmnet_data16 </data>
+     </list>
+
+     <list name="control_port_names">
+       <data type="string"> rmnet_data0 </data>
+       <data type="string"> rmnet_data1 </data>
+       <data type="string"> rmnet_data2 </data>
+       <data type="string"> rmnet_data3 </data>
+       <data type="string"> rmnet_data4 </data>
+       <data type="string"> rmnet_data5 </data>
+       <data type="string"> rmnet_data6 </data>
+       <data type="string"> rmnet_data7 </data>
+       <data type="string"> rmnet_data8 </data>
+       <data type="string"> rmnet_data9 </data>
+       <data type="string"> rmnet_data10 </data>
+       <data type="string"> rmnet_data11 </data>
+       <data type="string"> rmnet_data12 </data>
+       <data type="string"> rmnet_data13 </data>
+       <data type="string"> rmnet_data14 </data>
+       <data type="string"> rmnet_data15 </data>
+       <data type="string"> rmnet_data16 </data>
+     </list>
+   </listitem>
 </list>

--- a/rootdir/vendor/etc/data/netmgr_config.xml
+++ b/rootdir/vendor/etc/data/netmgr_config.xml
@@ -764,4 +764,147 @@
       <!-- Number of above reverse data ports inited on bootup -->
       <data name="static_rev_links" type="int"> 4 </data>
    </listitem>
+
+   <!-- lahaina_pt parameters -->
+   <listitem name = "lahaina_pt">
+
+      <data name="qmi_dpm_enabled" type="int"> 1 </data>
+      <data name="use_qmuxd" type="int"> 0 </data>
+      <data name="dpm_retry_timeout" type="int"> 10000 </data>
+      <data name="wda_data_format_enabled" type="int"> 1 </data>
+      <data name="kfc_mode" type="int"> 4 </data>
+      <data name="kfc_qmap" type="int"> 1 </data>
+      <data name="qmi_pc" type="int"> 1 </data>
+      <data name="tcp_ack_prio" type="int"> 1 </data>
+      <data name="netmgr_listen_ev_proto" type="int"> 1 </data>
+
+      <data name="single_qmux_ch_enabled" type="int"> 1 </data>
+      <data name="single_qmux_ch_conn_id_str" type="string"> rmnet0 </data>
+      <data name="single_qmux_ch_name" type="string"> DATA5_CNTL </data>
+      <data name="rmnet_data_enabled" type="int"> 1 </data>
+      <data name="dataformat_agg_dl_pkt" type="int"> 63 </data>
+      <data name="dataformat_agg_dl_size" type="int"> 64844 </data>
+      <data name="dataformat_agg_ul_pkt" type="int"> 32 </data>
+      <data name="dataformat_agg_ul_size" type="int"> 16384 </data>
+      <data name="dataformat_agg_ul_time" type="int"> 1000000 </data>
+      <data name="dataformat_agg_ul_features" type="int"> 1 </data>
+      <data name="dataformat_dl_data_aggregation_protocol" type="int"> 9 </data>
+      <data name="dataformat_ul_data_aggregation_protocol" type="int"> 9 </data>
+      <data name="dataformat_dl_gro_enabled" type="int"> 1 </data>
+      <data name="dataformat_ul_gso_enabled" type="int"> 1 </data>
+      <data name="rsc" type="int"> 2 </data>
+      <data name="rsb" type="int"> 2 </data>
+      <data name="phys_net_dev" type="string"> rmnet_ipa0 </data>
+      <data name="rtm_rmnet_data_enabled" type="int"> 1 </data>
+      <data name="rmnet_offload" type="int"> 1 </data>
+      <data name="rmnet_shs" type="int"> 1 </data>
+      <data name="uplink_priority" type="int"> 1 </data>
+      <data name="iwlan_concurrency" type="int"> 1 </data>
+      <data name="nl_xfrm" type="int"> 1 </data>
+      <data name="netdev_max_backlog" type="int"> 100000 </data>
+      <data name="debug_netdev_max_backlog" type="int"> 1500 </data>
+
+      <data name="disable_tcp_hystart_detect" type="int"> 1 </data>
+      <data name="disable_hystart" type="int"> 1 </data>
+      <data name="initial_ssthresh" type="int"> 1400 </data>
+      <data name="dl_marker_enabled" type="int"> 2 </data>
+      <data name="pnd_rps_mask" type="int"> 2 </data>
+      <data name="vnd_rps_mask" type="int"> 125 </data>
+      <data name="qos_via_idl" type="int"> 1 </data>
+      <data name="max_mtu" type="int"> 9216 </data>
+      <data name="netmgr_recovery_enabled" type="int"> 1 </data>
+      <data name="num_modems" type="int"> 2 </data>
+      <list name="modems_enabled">
+      <data type="int"> 1 </data> <!-- MODEM_MSM -->
+      <data type="int"> 0 </data> <!-- MODEM_MDM -->
+      </list>
+
+      <data name="control_ports_len" type="int"> 17 </data>
+      <list name="control_ports">
+        <data type="string"> rmnet_data0 </data>
+        <data type="string"> rmnet_data1 </data>
+        <data type="string"> rmnet_data2 </data>
+        <data type="string"> rmnet_data3 </data>
+        <data type="string"> rmnet_data4 </data>
+        <data type="string"> rmnet_data5 </data>
+        <data type="string"> rmnet_data6 </data>
+        <data type="string"> rmnet_data7 </data>
+        <data type="string"> rmnet_data8 </data>
+        <data type="string"> rmnet_data9 </data>
+        <data type="string"> rmnet_data10 </data>
+        <data type="string"> rmnet_data11 </data>
+        <data type="string"> rmnet_data12 </data>
+        <data type="string"> rmnet_data13 </data>
+        <data type="string"> rmnet_data14 </data>
+        <data type="string"> rmnet_data15 </data>
+        <data type="string"> rmnet_data16 </data>
+      </list>
+
+      <data name="data_ports_len" type="int"> 17 </data>
+      <list name="data_ports">
+        <data type="string"> rmnet_data0 </data>
+        <data type="string"> rmnet_data1 </data>
+        <data type="string"> rmnet_data2 </data>
+        <data type="string"> rmnet_data3 </data>
+        <data type="string"> rmnet_data4 </data>
+        <data type="string"> rmnet_data5 </data>
+        <data type="string"> rmnet_data6 </data>
+        <data type="string"> rmnet_data7 </data>
+        <data type="string"> rmnet_data8 </data>
+        <data type="string"> rmnet_data9 </data>
+        <data type="string"> rmnet_data10 </data>
+        <data type="string"> rmnet_data11 </data>
+        <data type="string"> rmnet_data12 </data>
+        <data type="string"> rmnet_data13 </data>
+        <data type="string"> rmnet_data14 </data>
+        <data type="string"> rmnet_data15 </data>
+        <data type="string"> rmnet_data16 </data>
+      </list>
+      <!-- Number of above data ports inited on bootup -->
+      <data name="static_fwd_links" type="int"> 6 </data>
+
+      <!-- iWLAN ports -->
+      <data name="iwlan_enable" type="int"> 1 </data>
+      <data name="rev_control_ports_len" type="int"> 16 </data>
+      <list name="rev_control_ports">
+        <data type="string"> r_rmnet_data0 </data>
+        <data type="string"> r_rmnet_data1 </data>
+        <data type="string"> r_rmnet_data2 </data>
+        <data type="string"> r_rmnet_data3 </data>
+        <data type="string"> r_rmnet_data4 </data>
+        <data type="string"> r_rmnet_data5 </data>
+        <data type="string"> r_rmnet_data6 </data>
+        <data type="string"> r_rmnet_data7 </data>
+        <data type="string"> r_rmnet_data8 </data>
+        <data type="string"> r_rmnet_data9 </data>
+        <data type="string"> r_rmnet_data10 </data>
+        <data type="string"> r_rmnet_data11 </data>
+        <data type="string"> r_rmnet_data12 </data>
+        <data type="string"> r_rmnet_data13 </data>
+        <data type="string"> r_rmnet_data14 </data>
+        <data type="string"> r_rmnet_data15 </data>
+      </list>
+
+      <data name="rev_data_ports_len" type="int"> 16 </data>
+      <list name="rev_data_ports">
+        <data type="string"> r_rmnet_data0 </data>
+        <data type="string"> r_rmnet_data1 </data>
+        <data type="string"> r_rmnet_data2 </data>
+        <data type="string"> r_rmnet_data3 </data>
+        <data type="string"> r_rmnet_data4 </data>
+        <data type="string"> r_rmnet_data5 </data>
+        <data type="string"> r_rmnet_data6 </data>
+        <data type="string"> r_rmnet_data7 </data>
+        <data type="string"> r_rmnet_data8 </data>
+        <data type="string"> r_rmnet_data9 </data>
+        <data type="string"> r_rmnet_data10 </data>
+        <data type="string"> r_rmnet_data11 </data>
+        <data type="string"> r_rmnet_data12 </data>
+        <data type="string"> r_rmnet_data13 </data>
+        <data type="string"> r_rmnet_data14 </data>
+        <data type="string"> r_rmnet_data15 </data>
+      </list>
+      <!-- Number of above reverse data ports inited on bootup -->
+      <data name="static_rev_links" type="int"> 4 </data>
+   </listitem>
 </list>


### PR DESCRIPTION
SoC Lahaina with SOC_IDs 415 and 439 use the 'lahaina_pt' configuration.

E QC-NETMGR-LIB: netmgr_main_process_target: unable to load config for target:lahaina_pt