### PR TITLE
[u-mr1] common-prop: Set ro.hardware.egl property

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -297,6 +297,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.crypto.scrypt_params=15:3:1
 
+# Look for libGLES_adreno.so instead of libGLES_$(BOARD_TARGET_PLATFORM).so
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.hardware.egl=adreno
+
 # Look for vulkan.qcom.so instead of vulkan.$(BOARD_TARGET_PLATFORM).so
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.hardware.vulkan=qcom


### PR DESCRIPTION
A recent AOSP change[1] has put a hard dependency on ro.hardware.egl or equivalent property being set, otherwise it fails to load EGL libraries successfully:
D libEGL  : Failed to load drivers from property ro.board.platform
            with value sm8450
F libEGL  : couldn't find an OpenGL ES implementation, make sure
            one of persist.graphics.egl, ro.hardware.egl and
            ro.board.platform is set
--------- beginning of crash
F DEBUG   : Cmdline: /system/bin/surfaceflinger
F DEBUG   : pid: 573, tid: 600, name: surfaceflinger  >>> /system/bin/surfaceflinger <<<
F DEBUG   : uid: 1000
F DEBUG   : tagged_addr_ctrl: 0000000000000001 (PR_TAGGED_ADDR_ENABLE)
F DEBUG   : signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr --------
F DEBUG   : Abort message: 'couldn't find an OpenGL ES implementation,
            make sure one of persist.graphics.egl, ro.hardware.egl and
            ro.board.platform is set'

[1] https://android.googlesource.com/platform/frameworks/native/+/8968823ade16061d589c1f9f7562a1de653be2b1