### PR TITLE
[t-mr1] Add support for SM8550 (k5.15) display HAL

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -94,21 +94,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     telephony.lteOnCdmaDevice=0
 
-# debug.sf.latch_unsignaled
-# - This causes SurfaceFlinger to latch
-#   buffers even if their fences haven't signaled
-PRODUCT_PROPERTY_OVERRIDES += \
-    debug.sf.latch_unsignaled=1
-
-# SurfaceFlinger
-# Keep uppercase makevars like TARGET_FORCE_HWC_FOR_VIRTUAL_DISPLAYS
-# in sync, use hardware/interfaces/configstore/1.1/default/surfaceflinger.mk
-# as a reference
-# ConfigStore is being deprecated and sf is moving to props, see
-# frameworks/native/services/surfaceflinger/sysprop/SurfaceFlingerProperties.sysprop
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.surface_flinger.force_hwc_copy_for_virtual_displays=true
-
 # Stagefright
 PRODUCT_PROPERTY_OVERRIDES += \
     media.stagefright.thumbnail.prefer_hw_codecs=true
@@ -235,18 +220,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.sys.wfd.virtual=0
 
-# Display properties
-PRODUCT_PROPERTY_OVERRIDES += \
-    persist.demo.hdmirotationlock=false \
-    persist.sys.sf.color_saturation=1.0 \
-    vendor.display.disable_inline_rotator=1 \
-    vendor.display.enable_null_display=0 \
-    vendor.display.disable_excl_rect=0 \
-    vendor.display.comp_mask=0 \
-    vendor.display.enable_default_color_mode=1 \
-    vendor.display.enable_optimize_refresh=1 \
-    vendor.display.disable_ui_3d_tonemap=1
-
 # Wi-Fi interface name
 PRODUCT_PROPERTY_OVERRIDES += \
     wifi.interface=wlan0
@@ -284,10 +257,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Priv-app permisisons
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.control_privapp_permissions=enforce
-
-# Perform color transform on the client
-PRODUCT_PROPERTY_OVERRIDES += \
-    persist.hwc2.skip_client_color_transform=false
 
 # Avoid Adoptable double encryption
 PRODUCT_PROPERTY_OVERRIDES += \

--- a/common-prop.mk
+++ b/common-prop.mk
@@ -300,8 +300,3 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Look for vulkan.qcom.so instead of vulkan.$(BOARD_TARGET_PLATFORM).so
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.hardware.vulkan=qcom
-
-# Disable Compressed APEX on 4.14 kernel as Android 12 enforces it and our kernel is not compatible (yet)
-ifeq ($(SOMC_KERNEL_VERSION), 4.14)
-OVERRIDE_PRODUCT_COMPRESSED_APEX := false
-endif

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -125,7 +125,7 @@ PRODUCT_PACKAGES += \
 
 # Thermal HAL
 PRODUCT_PACKAGES += \
-    android.hardware.thermal@2.0 \
+    android.hardware.thermal@2.0.vendor \
     android.hardware.thermal@1.0-impl \
     android.hardware.thermal@1.0-service
 

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -3,14 +3,8 @@ PRODUCT_PACKAGES += \
     android.hardware.renderscript@1.0-impl
 
 # Composer
-# Everything prior to kernel 4.19 uses the sm8150 display HAL
-ifeq ($(filter 4.14, $(SOMC_KERNEL_VERSION)),)
 PRODUCT_PACKAGES += \
     vendor.qti.hardware.display.composer-service
-else
-PRODUCT_PACKAGES += \
-    android.hardware.graphics.composer@2.3-service
-endif
 
 # Linked by Adreno/EGL blobs for fallback if 3.0 doesn't exist
 PRODUCT_PACKAGES += \
@@ -126,13 +120,8 @@ PRODUCT_PACKAGES += \
     android.hardware.drm@1.3-service-lazy.clearkey
 
 # Usb HAL
-ifeq ($(filter 4.14, $(SOMC_KERNEL_VERSION)),)
 PRODUCT_PACKAGES += \
     android.hardware.usb@1.2-service-qti
-else
-PRODUCT_PACKAGES += \
-    android.hardware.usb@1.0-service
-endif
 
 # Thermal HAL
 PRODUCT_PACKAGES += \

--- a/common.mk
+++ b/common.mk
@@ -19,8 +19,10 @@ ifneq ($(filter 4.19, $(SOMC_KERNEL_VERSION)),)
 display_platform := sm8250
 else ifneq ($(filter 5.4, $(SOMC_KERNEL_VERSION)),)
 display_platform := sm8350
-else
+else ifneq ($(filter 5.10, $(SOMC_KERNEL_VERSION)),)
 display_platform := sm8450
+else
+display_platform := sm8550
 endif
 
 # Enable building packages from device namspaces.


### PR DESCRIPTION
1. Remove leftover kernel 4.14 barriers. The current minimum supported kernel version is 4.19.
2. Add support for SM8550 display HAL, which will be used for devices running on kernel 5.15.
3. Remove display properties from common, because they are specific for each platform and set of blobs, moreover, some are completely outdated.
