### PR TITLE
Add modem config for French provider Free mobile

### DIFF
--- a/rootdir/vendor/oem/modem-config/S8683.1/modem.conf
+++ b/rootdir/vendor/oem/modem-config/S8683.1/modem.conf
@@ -1,0 +1,1 @@
+mcfg_sw/generic/common/default/vl/global/mcfg_sw.mbn


### PR DESCRIPTION
The modem is recognised as:
```
$ getprop persist.vendor.somc.cust.modem0
S8683.1
```

The PR is using the generic modem configuration file. I've tested it on SailifshOS (4.6.0) with an Xperia 10ii and:
- VoLTE service register,
- incoming calls are handled on 4G, as for outgoing calls,
- SMS reception is working (SMS emission not tested yet).