### PR TITLE
[t-mr1] Inital Audioreach customization

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -231,6 +231,11 @@ else
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.vibrator_v1.0.xml
 endif
 
+# Audioreach audio
+ifeq ($(TARGET_USES_AUDIOREACH), true)
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.qti.hardware.audio.xml
+endif
+
 # New vendor security patch level: https://r.android.com/660840/
 # Used by newer keymaster binaries
 VENDOR_SECURITY_PATCH=$(PLATFORM_SECURITY_PATCH)

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -44,7 +44,7 @@ PRODUCT_PACKAGES += \
 
 # Audio
 PRODUCT_PACKAGES += \
-    android.hardware.audio@6.0-impl:32 \
+    android.hardware.audio@7.1-impl:32 \
     android.hardware.audio.service \
     android.hardware.audio.effect@6.0-impl:32 \
     android.hardware.bluetooth.audio@2.0-impl \

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -48,7 +48,7 @@ PRODUCT_PACKAGES += \
     android.hardware.audio.service \
     android.hardware.audio.effect@7.0-impl:32 \
     android.hardware.bluetooth.audio@2.0-impl \
-    android.hardware.soundtrigger@2.2-impl
+    android.hardware.soundtrigger@2.3-impl
 
 # Camera
 PRODUCT_PACKAGES += \

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -44,9 +44,9 @@ PRODUCT_PACKAGES += \
 
 # Audio
 PRODUCT_PACKAGES += \
-    android.hardware.audio@7.1-impl:32 \
+    android.hardware.audio@7.1-impl \
     android.hardware.audio.service \
-    android.hardware.audio.effect@7.0-impl:32 \
+    android.hardware.audio.effect@7.0-impl \
     android.hardware.bluetooth.audio-impl \
     android.hardware.soundtrigger@2.3-impl
 

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -46,7 +46,7 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     android.hardware.audio@7.1-impl:32 \
     android.hardware.audio.service \
-    android.hardware.audio.effect@6.0-impl:32 \
+    android.hardware.audio.effect@7.0-impl:32 \
     android.hardware.bluetooth.audio@2.0-impl \
     android.hardware.soundtrigger@2.2-impl
 

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -47,7 +47,7 @@ PRODUCT_PACKAGES += \
     android.hardware.audio@7.1-impl:32 \
     android.hardware.audio.service \
     android.hardware.audio.effect@7.0-impl:32 \
-    android.hardware.bluetooth.audio@2.0-impl \
+    android.hardware.bluetooth.audio-impl \
     android.hardware.soundtrigger@2.3-impl
 
 # Camera

--- a/common.mk
+++ b/common.mk
@@ -81,6 +81,11 @@ SOONG_CONFIG_NAMESPACES += qti_kernel_headers
 SOONG_CONFIG_qti_kernel_headers := version
 SOONG_CONFIG_qti_kernel_headers_version := $(SOMC_KERNEL_VERSION)
 
+# Build 64bit audio service
+SOONG_CONFIG_NAMESPACES += android_hardware_audio
+SOONG_CONFIG_android_hardware_audio := run_64bit
+SOONG_CONFIG_android_hardware_audio_run_64bit := true
+
 # Codecs Configuration
 PRODUCT_COPY_FILES += \
     frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_audio.xml \

--- a/common.mk
+++ b/common.mk
@@ -16,12 +16,16 @@
 COMMON_PATH := device/sony/common
 
 ifneq ($(filter 4.19, $(SOMC_KERNEL_VERSION)),)
+audio_platform := primary-hal
 display_platform := sm8250
 else ifneq ($(filter 5.4, $(SOMC_KERNEL_VERSION)),)
+audio_platform := primary-hal
 display_platform := sm8350
 else ifneq ($(filter 5.10, $(SOMC_KERNEL_VERSION)),)
+audio_platform := primary-hal
 display_platform := sm8450
 else
+audio_platform := primary-hal-ar
 display_platform := sm8550
 endif
 
@@ -32,6 +36,7 @@ PRODUCT_SOONG_NAMESPACES += \
     $(COMMON_PATH) \
     $(PLATFORM_COMMON_PATH) \
     vendor/qcom/opensource/core-utils \
+    vendor/qcom/opensource/audio-hal/$(audio_platform) \
     vendor/qcom/opensource/display/$(display_platform) \
     vendor/qcom/opensource/display-commonsys-intf/$(display_platform)
 

--- a/common.mk
+++ b/common.mk
@@ -128,7 +128,7 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     $(COMMON_PATH)/rootdir/vendor/etc/audio_effects.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_effects.xml \
     frameworks/av/services/audiopolicy/config/audio_policy_volumes.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_volumes.xml \
-    frameworks/av/services/audiopolicy/config/bluetooth_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/bluetooth_audio_policy_configuration.xml \
+    frameworks/av/services/audiopolicy/config/bluetooth_audio_policy_configuration_7_0.xml:$(TARGET_COPY_OUT_VENDOR)/etc/bluetooth_audio_policy_configuration_7_0.xml \
     frameworks/av/services/audiopolicy/config/default_volume_tables.xml:$(TARGET_COPY_OUT_VENDOR)/etc/default_volume_tables.xml \
     frameworks/av/services/audiopolicy/config/r_submix_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/r_submix_audio_policy_configuration.xml \
     frameworks/av/services/audiopolicy/config/usb_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/usb_audio_policy_configuration.xml

--- a/hardware/qcom/Android.mk
+++ b/hardware/qcom/Android.mk
@@ -24,9 +24,4 @@ TARGET_KERNEL_VERSION := $(SOMC_KERNEL_VERSION)
 
 include device/sony/common/hardware/qcom/utils.mk
 
-ifeq ($(TARGET_USES_AOSP_AUDIO_HAL),true)
-audio-hal := hardware/qcom/audio
-include $(call all-makefiles-under,$(audio-hal))
-endif
-
 endif

--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -345,6 +345,9 @@ on boot
 
     chown root system /proc/net/ip_conntrack
 
+    # Allow access for AGM to read sound card state
+    chown media audio /sys/kernel/snd_card/card_state
+
     # Set up kernel tracing, but disable it by default
     chmod 0222 /sys/kernel/debug/tracing/trace_marker
     write /sys/kernel/debug/tracing/tracing_on 0

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -11,7 +11,7 @@
     <hal format="hidl">
         <name>android.hardware.audio.effect</name>
         <transport>hwbinder</transport>
-        <version>6.0</version>
+        <version>7.0</version>
         <interface>
             <name>IEffectsFactory</name>
             <instance>default</instance>

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -36,15 +36,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.bluetooth.audio</name>
-        <transport>hwbinder</transport>
-        <version>2.0</version>
-        <interface>
-            <name>IBluetoothAudioProvidersFactory</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.camera.provider</name>
         <transport>hwbinder</transport>
         <version>2.5</version>

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -137,7 +137,7 @@
     <hal format="hidl">
         <name>android.hardware.soundtrigger</name>
         <transport>hwbinder</transport>
-        <version>2.2</version>
+        <version>2.3</version>
         <interface>
             <name>ISoundTriggerHw</name>
             <instance>default</instance>

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -2,7 +2,7 @@
     <hal format="hidl">
         <name>android.hardware.audio</name>
         <transport>hwbinder</transport>
-        <version>6.0</version>
+        <version>7.1</version>
         <interface>
             <name>IDevicesFactory</name>
             <instance>default</instance>

--- a/vintf/vendor.qti.hardware.audio.xml
+++ b/vintf/vendor.qti.hardware.audio.xml
@@ -1,0 +1,21 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>vendor.qti.hardware.AGMIPC</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IAGM</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>vendor.qti.hardware.pal</name>
+        <transport>hwbinder</transport>
+        <version>1.0</version>
+        <interface>
+            <name>IPAL</name>
+            <instance>default</instance>
+            </interface>
+        <fqname>@1.0::IPAL/default</fqname>
+    </hal>
+</manifest>


### PR DESCRIPTION
Implement changes required for Audioreach audio subsystem.

1. Bump audio implementation to 7.1 (All current supported platforms should receive audio
policy updates in accordance with[1])
2. Bump audio effect implementation to 7.0.
3. Bump soundtrigger implementation to 2.3.
4. Switch to 64bit audio service.

Changes tested on at least one device from each supported platform except Lena.

[1] https://source.android.com/docs/core/audio/hidl-implement#xml-schema-hal7