### PR TITLE
[t-mr1] etc: init.common.rc: Restart Health HAL when ADSP ready

### DIFF
--- a/hardware/health/CycleCountBackupRestore.cpp
+++ b/hardware/health/CycleCountBackupRestore.cpp
@@ -35,6 +35,13 @@ namespace health {
 static constexpr int kCCBackupTrigger = 20;
 
 CycleCountBackupRestore::CycleCountBackupRestore() {
+    kPersistCycleFile = "/mnt/vendor/persist/battery/battery_cycle_count";
+    kSysCycleFile = "/sys/class/power_supply/bms/cycle_count";
+
+    if (access(kSysCycleFile.c_str(), F_OK)) {
+        kSysCycleFile = "/sys/class/power_supply/battery/cycle_count";
+    }
+
     persist_cycles = 0;
     sysfs_cycles = 0;
     saved_soc_ = -1;

--- a/hardware/health/CycleCountBackupRestore.h
+++ b/hardware/health/CycleCountBackupRestore.h
@@ -22,9 +22,6 @@ namespace device {
 namespace sony {
 namespace health {
 
-static const std::string kSysCycleFile = "/sys/class/power_supply/bms/cycle_count";
-static const std::string kPersistCycleFile = "/mnt/vendor/persist/battery/battery_cycle_count";
-
 class CycleCountBackupRestore {
    public:
     CycleCountBackupRestore();
@@ -32,6 +29,9 @@ class CycleCountBackupRestore {
     void Backup(int battery_level);
 
    private:
+    std::string kSysCycleFile;
+    std::string kPersistCycleFile;
+
     int persist_cycles;
     int sysfs_cycles;
     int saved_soc_;

--- a/hardware/health/LearnedCapacityBackupRestore.cpp
+++ b/hardware/health/LearnedCapacityBackupRestore.cpp
@@ -40,6 +40,13 @@ static constexpr int kBuffSize = 256;
 static constexpr int kCapConversionFactor = 1000;
 
 LearnedCapacityBackupRestore::LearnedCapacityBackupRestore() {
+    kPersistChargeFullFile = "/mnt/vendor/persist/battery/battery_charge_full";
+    kSysChargeFullFile = "/sys/class/power_supply/bms/charge_full";
+
+    if (access(kSysChargeFullFile.c_str(), F_OK)) {
+        kSysChargeFullFile = "/sys/class/power_supply/battery/charge_full";
+    }
+
     cap_counter = 0;
 }
 

--- a/hardware/health/LearnedCapacityBackupRestore.h
+++ b/hardware/health/LearnedCapacityBackupRestore.h
@@ -22,9 +22,6 @@ namespace device {
 namespace sony {
 namespace health {
 
-static const std::string kSysChargeFullFile = "/sys/class/power_supply/bms/charge_full";
-static const std::string kPersistChargeFullFile = "/mnt/vendor/persist/battery/battery_charge_full";
-
 class LearnedCapacityBackupRestore {
    public:
     LearnedCapacityBackupRestore();
@@ -32,6 +29,9 @@ class LearnedCapacityBackupRestore {
     void Backup();
 
    private:
+    std::string kSysChargeFullFile;
+    std::string kPersistChargeFullFile;
+
     int persist_capacity;
     int sysfs_capacity;
     int cap_counter;

--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -240,6 +240,21 @@ on post-fs-data
 
     chown system /dev/block/bootdevice/by-name
 
+    # Create battery stats dir
+    mkdir /mnt/vendor/persist/battery/ 0700 system system
+
+    # Set permissions for bms
+    chown system system /sys/class/power_supply/bms/charge_full
+    chown system system /sys/class/power_supply/bms/cycle_count
+    chmod 0664 /sys/class/power_supply/bms/charge_full
+    chmod 0664 /sys/class/power_supply/bms/cycle_count
+
+    # Set permissions for battery (used if BMS interface is not present)
+    chown system system /sys/class/power_supply/battery/charge_full
+    chown system system /sys/class/power_supply/battery/cycle_count
+    chmod 0664 /sys/class/power_supply/battery/charge_full
+    chmod 0664 /sys/class/power_supply/battery/cycle_count
+
     setprop vold.post_fs_data_done 1
 
 on early-boot

--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -384,3 +384,10 @@ on property:sys.boot_completed=1
 on property:vendor.sys.listeners.registered=true
     # load IPA FWs
     start vendor.ipastart_sh
+
+# Restart health HAL when ADSP is out of reset.
+# On devices where communication with the battery occurs over GLINK,
+# it is important that Health HAL is (re)launched after ADSP ready.
+on property:vendor.qcom.adspup=1
+    wait /sys/class/power_supply/battery
+    restart health-hal-2-1


### PR DESCRIPTION
Restart Health HAL when ADSP is out of reset.
On devices where communication with the battery occurs over GLINK,
it is important that Health HAL is (re)launched after ADSP ready.

This is reimplementation of https://github.com/sonyxperiadev/device-sony-common/commit/7814953e62a8b4f48e51fe8f3ddebbbca51aebd5 ("hardware/health: Wait for
adsp and power_supply/battery before starting health HAL") which
was removed in https://github.com/sonyxperiadev/device-sony-common/commit/57da52d8d8bfdf02a8506edcb276fe2fe0657172 ("hardware/health: Upgrade to 2.1 via
libhealth2impl").

This brings back the working battery status on platforms such as Sagami, Nagara and Yodo.