### PR TITLE
[t-mr1] Add QTI camera service

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -204,6 +204,13 @@ ifeq ($(TARGET_USES_AUDIOREACH), true)
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.qti.hardware.audio.xml
 endif
 
+# Camera
+ifeq ($(TARGET_USES_QTI_CAMERA),true)
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.qti.camera.provider.xml
+else
+DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.camera.provider.xml
+endif
+
 # New vendor security patch level: https://r.android.com/660840/
 # Used by newer keymaster binaries
 VENDOR_SECURITY_PATCH=$(PLATFORM_SECURITY_PATCH)

--- a/common-init.mk
+++ b/common-init.mk
@@ -78,3 +78,9 @@ ifneq ($(TARGET_USES_ODM_APPS_BINDMOUNT),false)
 PRODUCT_PACKAGES += \
     bindmount-apps.rc
 endif
+
+# QTI camera provider
+ifeq ($(TARGET_USES_QTI_CAMERA),true)
+PRODUCT_PACKAGES += \
+    vendor.qti.camera.provider.rc
+endif

--- a/common-odm-camx.mk
+++ b/common-odm-camx.mk
@@ -98,7 +98,7 @@ PRODUCT_PACKAGES += \
     fdconfigvideo \
     fdconfigvideolite \
     vendor.qti.hardware.camera.aon@1.0-service-impl \
-    vendor.qti.hardware.camera.aom@1.0 \
+    vendor.qti.hardware.camera.aon@1.0 \
     vendor.qti.hardware.camera.postproc@1.0 \
     camera.qcom
 endif

--- a/common-odm-camx.mk
+++ b/common-odm-camx.mk
@@ -98,7 +98,7 @@ PRODUCT_PACKAGES += \
     fdconfigvideo \
     fdconfigvideolite \
     vendor.qti.hardware.camera.aon@1.0-service-impl \
-    vendor.qti.hardware.camera.aon@1.0 \
+    vendor.qti.hardware.camera.aon@1.3 \
     vendor.qti.hardware.camera.postproc@1.0 \
     camera.qcom
 endif

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -46,6 +46,7 @@ PRODUCT_PACKAGES += \
     android.hardware.soundtrigger@2.3-impl
 
 # Camera
+ifneq ($(TARGET_USES_QTI_CAMERA),true)
 ifeq ($(TARGET_USES_64BIT_CAMERA),true)
 PRODUCT_PACKAGES += \
     android.hardware.camera.provider@2.5-impl:64 \
@@ -54,6 +55,7 @@ else
 PRODUCT_PACKAGES += \
     android.hardware.camera.provider@2.5-impl:32 \
     android.hardware.camera.provider@2.5-service
+endif
 endif
 
 # External Camera

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -47,7 +47,6 @@ PRODUCT_PACKAGES += \
 
 # Camera
 PRODUCT_PACKAGES += \
-    vendor.qti.hardware.camera.aon@1.0 \
     android.frameworks.sensorservice@1.0.vendor
 ifeq ($(TARGET_USES_64BIT_CAMERA),true)
 PRODUCT_PACKAGES += \

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -46,8 +46,6 @@ PRODUCT_PACKAGES += \
     android.hardware.soundtrigger@2.3-impl
 
 # Camera
-PRODUCT_PACKAGES += \
-    android.frameworks.sensorservice@1.0.vendor
 ifeq ($(TARGET_USES_64BIT_CAMERA),true)
 PRODUCT_PACKAGES += \
     android.hardware.camera.provider@2.5-impl:64 \
@@ -62,6 +60,10 @@ endif
 PRODUCT_PACKAGES += \
     android.hardware.camera.provider@2.5-external \
     android.hardware.camera.provider@2.5-external-service
+
+# Sensorservice
+PRODUCT_PACKAGES += \
+    android.frameworks.sensorservice@1.0.vendor
 
 # Wi-Fi
 PRODUCT_PACKAGES += \

--- a/rootdir/Android.bp
+++ b/rootdir/Android.bp
@@ -479,3 +479,10 @@ prebuilt_etc {
     sub_dir: "init",
     vendor: true,
 }
+
+prebuilt_etc {
+    name: "vendor.qti.camera.provider.rc",
+    src: "vendor/etc/init/vendor.qti.camera.provider.rc",
+    sub_dir: "init",
+    vendor: true,
+}

--- a/rootdir/vendor/etc/init/vendor.qti.camera.provider.rc
+++ b/rootdir/vendor/etc/init/vendor.qti.camera.provider.rc
@@ -1,0 +1,13 @@
+service vendor.camera-provider /odm/bin/hw/vendor.qti.camera.provider-service_64
+    interface aidl android.hardware.camera.provider.ICameraProvider/vendor_qti/0
+    interface vendor.qti.hardware.camera.postproc@1.0::IPostProcService camerapostprocservice
+    interface vendor.qti.hardware.camera.aon@1.0::IAONService aoncameraservice
+    interface vendor.qti.hardware.camera.aon@1.1::IAONService aoncameraservice
+    interface vendor.qti.hardware.camera.aon@1.2::IAONService aoncameraservice
+    interface vendor.qti.hardware.camera.aon@1.3::IAONService aoncameraservice
+    class hal
+    user cameraserver
+    group camera audio input drmrpc
+    ioprio rt 4
+    capabilities SYS_NICE
+    task_profiles CameraServiceCapacity MaxPerformance

--- a/vintf/android.hardware.camera.provider.xml
+++ b/vintf/android.hardware.camera.provider.xml
@@ -1,0 +1,11 @@
+<manifest version="1.0" type="device">
+    <hal format="hidl">
+        <name>android.hardware.camera.provider</name>
+        <transport>hwbinder</transport>
+        <version>2.5</version>
+        <interface>
+            <name>ICameraProvider</name>
+            <instance>legacy/0</instance>
+        </interface>
+    </hal>
+</manifest>

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -41,7 +41,6 @@
         <version>2.5</version>
         <interface>
             <name>ICameraProvider</name>
-            <instance>legacy/0</instance>
             <instance>external/0</instance>
         </interface>
     </hal>

--- a/vintf/vendor.qti.camera.provider.xml
+++ b/vintf/vendor.qti.camera.provider.xml
@@ -1,0 +1,18 @@
+<manifest version="1.0" type="device">
+    <hal format="aidl">
+        <name>android.hardware.camera.provider</name>
+        <interface>
+            <name>ICameraProvider</name>
+            <instance>vendor_qti/0</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
+        <name>vendor.qti.hardware.camera.aon</name>
+        <transport>hwbinder</transport>
+        <version>1.3</version>
+        <interface>
+            <name>IAONService</name>
+            <instance>aoncameraservice</instance>
+        </interface>
+    </hal>
+</manifest>


### PR DESCRIPTION
Add vendor.qti.camera.provider.rc + vintf.
vendor.qti.hardware.camera.aon typo fix.
Wrap legacy camera provider packages with TARGET_USES_QTI_CAMERA.