### PR TITLE
[t-mr1] Avoid duplicate definition of camera provider

### DIFF
--- a/vintf/android.hardware.camera.provider.xml
+++ b/vintf/android.hardware.camera.provider.xml
@@ -6,6 +6,7 @@
         <interface>
             <name>ICameraProvider</name>
             <instance>legacy/0</instance>
+            <instance>external/0</instance>
         </interface>
     </hal>
 </manifest>

--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -36,15 +36,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.camera.provider</name>
-        <transport>hwbinder</transport>
-        <version>2.5</version>
-        <interface>
-            <name>ICameraProvider</name>
-            <instance>external/0</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.configstore</name>
         <transport>hwbinder</transport>
         <version>1.1</version>

--- a/vintf/vendor.qti.camera.provider.xml
+++ b/vintf/vendor.qti.camera.provider.xml
@@ -7,6 +7,15 @@
         </interface>
     </hal>
     <hal format="hidl">
+        <name>android.hardware.camera.provider</name>
+        <transport>hwbinder</transport>
+        <version>2.5</version>
+        <interface>
+            <name>ICameraProvider</name>
+            <instance>external/0</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
         <name>vendor.qti.hardware.camera.aon</name>
         <transport>hwbinder</transport>
         <version>1.3</version>


### PR DESCRIPTION
For devices without TARGET_USES_QTI_CAMERA, we have generated manifest that defines 

```xml
    <hal format="hidl">
        <name>android.hardware.camera.provider</name>
        <transport>hwbinder</transport>
        <version>2.5</version>
```

twice. Once in vintf/manifest.xml and once in vintf/android.hardware.camera.provider.xml.

This PR keeps the same functionality as before by merging the both definitions in android.hardware.camera.provider.xml and adding a definition in vintf/vendor.qti.camera.provider.xml.

Limited testing so far, fixes compilation issue on nagara.

Fixes: https://github.com/sonyxperiadev/bug_tracker/issues/846