### PR TITLE
[u-mr1] vintf: Add vendor.qti.hardware.camera.aon to FCM

### DIFF
--- a/vintf/framework_compatibility_matrix.xml
+++ b/vintf/framework_compatibility_matrix.xml
@@ -112,6 +112,14 @@
         </interface>
     </hal>
     <hal format="hidl">
+        <name>vendor.qti.hardware.camera.aon</name>
+        <version>1.3</version>
+        <interface>
+            <name>IAONService</name>
+            <instance>aoncameraservice</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
         <name>vendor.qti.hardware.data.connection</name>
         <version>1.1</version>
         <interface>


### PR DESCRIPTION
ERROR: files are incompatible: The following instances are in the
device manifest but not specified in framework compatibility matrix:
  vendor.qti.hardware.camera.aon@1.3::IAONService/aoncameraservice