### PR TITLE
Use parseint instead of stoi

### DIFF
--- a/hardware/health/CycleCountBackupRestore.cpp
+++ b/hardware/health/CycleCountBackupRestore.cpp
@@ -25,6 +25,7 @@
 #include <android-base/file.h>
 #include <android-base/logging.h>
 #include <android-base/strings.h>
+#include <android-base/parseint.h>
 
 #include "CycleCountBackupRestore.h"
 
@@ -84,12 +85,7 @@ void CycleCountBackupRestore::Read(const std::string &path, int &cycles) {
     }
 
     buffer = ::android::base::Trim(buffer);
-    try {
-        cycles = std::stoi(buffer);
-    } catch (std::out_of_range &e) {
-        LOG(WARNING) << "Battery cycle count in persist storage file is out of bounds: " << path;
-        return;
-    } catch (std::invalid_argument &e) {
+    if (!android::base::ParseInt(buffer.c_str(), &cycles)) {
         LOG(WARNING) << "Data format is wrong in persist storage file: " << path;
         return;
     }

--- a/hardware/health/LearnedCapacityBackupRestore.cpp
+++ b/hardware/health/LearnedCapacityBackupRestore.cpp
@@ -25,6 +25,7 @@
 #include <android-base/file.h>
 #include <android-base/logging.h>
 #include <android-base/strings.h>
+#include <android-base/parseint.h>
 
 #include "LearnedCapacityBackupRestore.h"
 
@@ -74,12 +75,7 @@ void LearnedCapacityBackupRestore::ReadFromPersistStorage() {
     }
 
     buffer = ::android::base::Trim(buffer);
-    try {
-        persist_capacity = std::stoi(buffer);
-    } catch (std::out_of_range &e) {
-        LOG(WARNING) << "Battery capacity in persist storage file is out of bounds: " << buffer;
-        return;
-    } catch (std::invalid_argument &e) {
+    if (!android::base::ParseInt(buffer.c_str(), &persist_capacity)) {
         LOG(WARNING) << "Data format is wrong in the battery capacity persist file: " << buffer;
         return;
     }


### PR DESCRIPTION
For some reason exception handling was not working for stoi-based battery cycles parsing. Replace with ParseInt

The only concern I have is that it can lead to some other exception in static_cast<> used by ParseInt

Related issue: https://github.com/sonyxperiadev/bug_tracker/issues/850