### PR TITLE
[u-mr1] vendor: data: Add configuration for SoC Parrot

### DIFF
--- a/rootdir/vendor/etc/data/dsi_config.xml
+++ b/rootdir/vendor/etc/data/dsi_config.xml
@@ -386,6 +386,61 @@
      </list>
    </listitem>
 
+   <!-- Configuration for parrot -->
+   <listitem name="parrot">
+
+     <data name="qos_enabled" type="int"> 1 </data>
+     <data name="rmnet_data_enabled" type="int"> 1 </data>
+     <data name="phys_net_dev" type="string"> rmnet_ipa0 </data>
+     <data name="netmgr_listen_ev_proto" type="int"> 1 </data>
+     <data name="sscm3" type="int"> 1 </data>
+
+     <data name="single_qmux_channel_enabled" type="int"> 1 </data>
+     <data name="single_qmux_channel_name" type="string"> rmnet0 </data>
+
+     <data name="oemprxy_enabled" type="int"> 0 </data>
+
+     <data name="num_dsi_handles" type="int"> 17 </data>
+     <list name="device_names">
+       <data type="string"> rmnet_data0 </data>
+       <data type="string"> rmnet_data1 </data>
+       <data type="string"> rmnet_data2 </data>
+       <data type="string"> rmnet_data3 </data>
+       <data type="string"> rmnet_data4 </data>
+       <data type="string"> rmnet_data5 </data>
+       <data type="string"> rmnet_data6 </data>
+       <data type="string"> rmnet_data7 </data>
+       <data type="string"> rmnet_data8 </data>
+       <data type="string"> rmnet_data9 </data>
+       <data type="string"> rmnet_data10 </data>
+       <data type="string"> rmnet_data11 </data>
+       <data type="string"> rmnet_data12 </data>
+       <data type="string"> rmnet_data13 </data>
+       <data type="string"> rmnet_data14 </data>
+       <data type="string"> rmnet_data15 </data>
+       <data type="string"> rmnet_data16 </data>
+     </list>
+     <list name="control_port_names">
+       <data type="string"> rmnet_data0 </data>
+       <data type="string"> rmnet_data1 </data>
+       <data type="string"> rmnet_data2 </data>
+       <data type="string"> rmnet_data3 </data>
+       <data type="string"> rmnet_data4 </data>
+       <data type="string"> rmnet_data5 </data>
+       <data type="string"> rmnet_data6 </data>
+       <data type="string"> rmnet_data7 </data>
+       <data type="string"> rmnet_data8 </data>
+       <data type="string"> rmnet_data9 </data>
+       <data type="string"> rmnet_data10 </data>
+       <data type="string"> rmnet_data11 </data>
+       <data type="string"> rmnet_data12 </data>
+       <data type="string"> rmnet_data13 </data>
+       <data type="string"> rmnet_data14 </data>
+       <data type="string"> rmnet_data15 </data>
+       <data type="string"> rmnet_data16 </data>
+     </list>
+   </listitem>
+
    <!-- Configuration for kailua -->
    <listitem name="kailua">
 

--- a/rootdir/vendor/etc/data/netmgr_config.xml
+++ b/rootdir/vendor/etc/data/netmgr_config.xml
@@ -1150,6 +1150,222 @@
       </list>
    </listitem>
 
+   <!-- parrot parameters -->
+   <listitem name = "parrot">
+
+      <data name="qmi_dpm_enabled" type="int"> 1 </data>
+      <data name="use_qmuxd" type="int"> 0 </data>
+      <data name="dpm_retry_timeout" type="int"> 10000 </data>
+      <data name="wda_data_format_enabled" type="int"> 1 </data>
+      <data name="kfc_mode" type="int"> 4 </data>
+      <data name="kfc_qmap" type="int"> 1 </data>
+      <data name="qmi_pc" type="int"> 1 </data>
+      <data name="dfc_ps_ext" type="int"> 1 </data>
+      <data name="tcp_ack_prio" type="int"> 1 </data>
+      <data name="netmgr_listen_ev_proto" type="int"> 1 </data>
+      <data name="sscm3" type="int"> 1 </data>
+
+      <data name="single_qmux_ch_enabled" type="int"> 1 </data>
+      <data name="single_qmux_ch_conn_id_str" type="string"> rmnet0 </data>
+      <data name="single_qmux_ch_name" type="string"> DATA5_CNTL </data>
+      <data name="rmnet_data_enabled" type="int"> 1 </data>
+      <data name="dataformat_agg_dl_pkt" type="int"> 63 </data>
+      <data name="dataformat_agg_dl_size" type="int"> 64844 </data>
+      <data name="dataformat_agg_ul_pkt" type="int"> 32 </data>
+      <data name="dataformat_agg_ul_size" type="int"> 16384 </data>
+      <data name="dataformat_agg_ul_time" type="int"> 1000000 </data>
+      <data name="dataformat_agg_ul_features" type="int"> 0 </data>
+      <data name="dataformat_dl_data_aggregation_protocol" type="int"> 9 </data>
+      <data name="dataformat_ul_data_aggregation_protocol" type="int"> 9 </data>
+      <data name="dataformat_dl_gro_enabled" type="int"> 1 </data>
+      <data name="dataformat_ul_gso_enabled" type="int"> 1 </data>
+      <data name="rsc" type="int"> 2 </data>
+      <data name="rsb" type="int"> 2 </data>
+      <data name="phys_net_dev" type="string"> rmnet_ipa0 </data>
+      <data name="rtm_rmnet_data_enabled" type="int"> 1 </data>
+      <data name="rmnet_offload" type="int"> 1 </data>
+      <data name="rmnet_shs" type="int"> 1 </data>
+      <data name="uplink_priority" type="int"> 1 </data>
+      <data name="iwlan_concurrency" type="int"> 1 </data>
+      <data name="nl_xfrm" type="int"> 1 </data>
+      <data name="netdev_max_backlog" type="int"> 100000 </data>
+      <data name="debug_netdev_max_backlog" type="int"> 1500 </data>
+      <data name="disable_tcp_hystart_detect" type="int"> 1 </data>
+      <data name="disable_hystart" type="int"> 1 </data>
+      <data name="initial_ssthresh" type="int"> 1400 </data>
+      <data name="dl_marker_enabled" type="int"> 2 </data>
+      <data name="pnd_rps_mask" type="int"> 2 </data>
+      <data name="vnd_rps_mask" type="int"> 125 </data>
+      <data name="qos_via_idl" type="int"> 1 </data>
+      <data name="max_mtu" type="int"> 9216 </data>
+      <data name="netmgr_recovery_enabled" type="int"> 1 </data>
+      <data name="num_modems" type="int"> 2 </data>
+      <list name="modems_enabled">
+      <data type="int"> 1 </data> <!-- MODEM_MSM -->
+      <data type="int"> 0 </data> <!-- MODEM_MDM -->
+      </list>
+
+      <data name="control_ports_len" type="int"> 17 </data>
+      <list name="control_ports">
+        <data type="string"> rmnet_data0 </data>
+        <data type="string"> rmnet_data1 </data>
+        <data type="string"> rmnet_data2 </data>
+        <data type="string"> rmnet_data3 </data>
+        <data type="string"> rmnet_data4 </data>
+        <data type="string"> rmnet_data5 </data>
+        <data type="string"> rmnet_data6 </data>
+        <data type="string"> rmnet_data7 </data>
+        <data type="string"> rmnet_data8 </data>
+        <data type="string"> rmnet_data9 </data>
+        <data type="string"> rmnet_data10 </data>
+        <data type="string"> rmnet_data11 </data>
+        <data type="string"> rmnet_data12 </data>
+        <data type="string"> rmnet_data13 </data>
+        <data type="string"> rmnet_data14 </data>
+        <data type="string"> rmnet_data15 </data>
+        <data type="string"> rmnet_data16 </data>
+      </list>
+
+      <data name="data_ports_len" type="int"> 17 </data>
+      <list name="data_ports">
+        <data type="string"> rmnet_data0 </data>
+        <data type="string"> rmnet_data1 </data>
+        <data type="string"> rmnet_data2 </data>
+        <data type="string"> rmnet_data3 </data>
+        <data type="string"> rmnet_data4 </data>
+        <data type="string"> rmnet_data5 </data>
+        <data type="string"> rmnet_data6 </data>
+        <data type="string"> rmnet_data7 </data>
+        <data type="string"> rmnet_data8 </data>
+        <data type="string"> rmnet_data9 </data>
+        <data type="string"> rmnet_data10 </data>
+        <data type="string"> rmnet_data11 </data>
+        <data type="string"> rmnet_data12 </data>
+        <data type="string"> rmnet_data13 </data>
+        <data type="string"> rmnet_data14 </data>
+        <data type="string"> rmnet_data15 </data>
+        <data type="string"> rmnet_data16 </data>
+      </list>
+      <!-- Number of above data ports inited on bootup -->
+      <data name="static_fwd_links" type="int"> 6 </data>
+
+      <data name="oemprxy_enabled" type="int"> 0 </data>
+      <data name="iwlan_enable" type="int"> 3 </data>
+
+      <!-- iWLAN ports -->
+      <data name="rev_control_ports_len" type="int"> 16 </data>
+      <list name="rev_control_ports">
+        <data type="string"> r_rmnet_data0 </data>
+        <data type="string"> r_rmnet_data1 </data>
+        <data type="string"> r_rmnet_data2 </data>
+        <data type="string"> r_rmnet_data3 </data>
+        <data type="string"> r_rmnet_data4 </data>
+        <data type="string"> r_rmnet_data5 </data>
+        <data type="string"> r_rmnet_data6 </data>
+        <data type="string"> r_rmnet_data7 </data>
+        <data type="string"> r_rmnet_data8 </data>
+        <data type="string"> r_rmnet_data9 </data>
+        <data type="string"> r_rmnet_data10 </data>
+        <data type="string"> r_rmnet_data11 </data>
+        <data type="string"> r_rmnet_data12 </data>
+        <data type="string"> r_rmnet_data13 </data>
+        <data type="string"> r_rmnet_data14 </data>
+        <data type="string"> r_rmnet_data15 </data>
+      </list>
+
+      <data name="rev_data_ports_len" type="int"> 16 </data>
+      <list name="rev_data_ports">
+        <data type="string"> r_rmnet_data0 </data>
+        <data type="string"> r_rmnet_data1 </data>
+        <data type="string"> r_rmnet_data2 </data>
+        <data type="string"> r_rmnet_data3 </data>
+        <data type="string"> r_rmnet_data4 </data>
+        <data type="string"> r_rmnet_data5 </data>
+        <data type="string"> r_rmnet_data6 </data>
+        <data type="string"> r_rmnet_data7 </data>
+        <data type="string"> r_rmnet_data8 </data>
+        <data type="string"> r_rmnet_data9 </data>
+        <data type="string"> r_rmnet_data10 </data>
+        <data type="string"> r_rmnet_data11 </data>
+        <data type="string"> r_rmnet_data12 </data>
+        <data type="string"> r_rmnet_data13 </data>
+        <data type="string"> r_rmnet_data14 </data>
+        <data type="string"> r_rmnet_data15 </data>
+      </list>
+      <!-- Number of above reverse data ports inited on bootup -->
+      <data name="static_rev_links" type="int"> 4 </data>
+      <data name="ep_config_ext_ioctl_v2" type="int"> 1 </data>
+      <!--
+      Please note, the order of the egress/ingress EPs below are as they
+      will be populated and sent to HW, so please ensure that ordering of EP's
+      is deliverately chosen.
+      -->
+      <data name="egress_ep_configs_len" type="int"> 2 </data>
+      <list name="egress_ep_configs">
+         <!-- Egress Default -->
+         <list name="ep_config">
+            <data name="egress_ep_type" type="int"> 0 </data>
+            <data name="pipe_setup_success" type="int"> 1 </data>
+            <data name="cs_offload_en" type="int"> 1 </data>
+            <data name="agg_en" type="int"> 1 </data>
+            <data name="ulso_en" type="int"> 1 </data>
+            <data name="ipid_min_max_idx" type="int"> 0 </data>
+            <data name="int_modt" type="int"> 16 </data>
+            <data name="int_modc" type="int"> 20 </data>
+         </list>
+         <!-- Egress Low Latency Control -->
+         <list name="ep_config">
+            <data name="egress_ep_type" type="int"> 1 </data>
+            <data name="pipe_setup_success" type="int"> 1 </data>
+            <data name="cs_offload_en" type="int"> 1 </data>
+            <data name="agg_en" type="int"> 0 </data>
+            <data name="ulso_en" type="int"> 0 </data>
+            <data name="ipid_min_max_idx" type="int"> 0 </data>
+            <data name="int_modt" type="int"> 16 </data>
+            <data name="int_modc" type="int"> 1 </data>
+         </list>
+      </list>
+      <data name="ingress_ep_configs_len" type="int"> 3 </data>
+      <list name="ingress_ep_configs">
+         <!-- Ingress Coalescing -->
+         <list name="ep_config">
+            <data name="ingress_ep_type" type="int"> 0 </data>
+            <data name="pipe_setup_success" type="int"> 1 </data>
+            <data name="cs_offload_en" type="int"> 1 </data>
+            <data name="buff_size" type="int"> 32768 </data>
+            <data name="agg_byte_limit" type="int"> 64844 </data>
+            <data name="agg_time_limit" type="int"> 500 </data>
+            <data name="agg_pkt_limit" type="int"> 63 </data>
+            <data name="int_modt" type="int"> 16 </data>
+            <data name="int_modc" type="int"> 20 </data>
+         </list>
+         <!-- Ingress Default -->
+         <list name="ep_config">
+            <data name="ingress_ep_type" type="int"> 1 </data>
+            <data name="pipe_setup_success" type="int"> 1 </data>
+            <data name="cs_offload_en" type="int"> 1 </data>
+            <data name="buff_size" type="int"> 32768 </data>
+            <data name="agg_byte_limit" type="int"> 64844 </data>
+            <data name="agg_time_limit" type="int"> 500 </data>
+            <data name="agg_pkt_limit" type="int"> 63 </data>
+            <data name="int_modt" type="int"> 16 </data>
+            <data name="int_modc" type="int"> 20 </data>
+         </list>
+         <!-- Ingress Low Latency Control -->
+         <list name="ep_config">
+            <data name="ingress_ep_type" type="int"> 2 </data>
+            <data name="pipe_setup_success" type="int"> 1 </data>
+            <data name="cs_offload_en" type="int"> 1 </data>
+            <data name="buff_size" type="int"> 4096 </data>
+            <data name="agg_byte_limit" type="int"> 0 </data>
+            <data name="agg_time_limit" type="int"> 0 </data>
+            <data name="agg_pkt_limit" type="int"> 0 </data>
+            <data name="int_modt" type="int"> 16 </data>
+            <data name="int_modc" type="int"> 1 </data>
+         </list>
+      </list>
+   </listitem>
+
    <!-- kailua parameters -->
    <listitem name = "kailua">
 


### PR DESCRIPTION
Add data configuration for SoC Parrot.

Placed before Kailua instead of at the end of the list
to maintain the chronological order of the SoC release.