### PR TITLE
[u-mr1] vintf: Add vendor.qti.hardware.display.config v5 to FCM

### DIFF
--- a/vintf/framework_compatibility_matrix.xml
+++ b/vintf/framework_compatibility_matrix.xml
@@ -164,7 +164,7 @@
     </hal>
     <hal format="aidl">
         <name>vendor.qti.hardware.display.config</name>
-        <version>4</version>
+        <version>4-5</version>
         <interface>
             <name>IDisplayConfig</name>
             <instance>default</instance>


### PR DESCRIPTION
ERROR: files are incompatible: The following instances are in the
device manifest but not specified in framework compatibility matrix:
  vendor.qti.hardware.display.config.IDisplayConfig/default (@5)

Fixes: https://github.com/sonyxperiadev/device-sony-common/issues/931