### PR TITLE
[u-mr1] AudioReach on 5.10 targets

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -22,7 +22,7 @@ else ifneq ($(filter 5.4, $(SOMC_KERNEL_VERSION)),)
 audio_platform := primary-hal
 display_platform := sm8350
 else ifneq ($(filter 5.10, $(SOMC_KERNEL_VERSION)),)
-audio_platform := primary-hal
+audio_platform := primary-hal-ar
 display_platform := sm8450
 else
 audio_platform := primary-hal-ar

--- a/common.mk
+++ b/common.mk
@@ -16,17 +16,19 @@
 COMMON_PATH := device/sony/common
 
 ifneq ($(filter 4.19, $(SOMC_KERNEL_VERSION)),)
-audio_platform := primary-hal
 display_platform := sm8250
 else ifneq ($(filter 5.4, $(SOMC_KERNEL_VERSION)),)
-audio_platform := primary-hal
 display_platform := sm8350
 else ifneq ($(filter 5.10, $(SOMC_KERNEL_VERSION)),)
-audio_platform := primary-hal-ar
 display_platform := sm8450
 else
-audio_platform := primary-hal-ar
 display_platform := sm8550
+endif
+
+ifeq ($(TARGET_USES_AUDIOREACH),true)
+audio_platform := primary-hal-ar
+else
+audio_platform := primary-hal
 endif
 
 # Enable building packages from device namspaces.


### PR DESCRIPTION
- common: Switch 5.10 kernel targets to AudioReach
All targets released with 5.10 kernel use AudioReach
framework by default.

- common: Protect audio HAL selection with TARGET_USES_AUDIOREACH
Some platforms (Murray and Zambezi in our case) that are
ported from older kernel version are forced to use legacy
audio HAL due to the incompatibility of the ADSP firmware
with AudioReach. Because of this reason, the audio HAL must
be detected regardless of the kernel version.