### PR TITLE
[s-mr1] vintf: Move fingerprint entry to its own project

### DIFF
--- a/vintf/manifest.xml
+++ b/vintf/manifest.xml
@@ -18,15 +18,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.biometrics.fingerprint</name>
-        <transport>hwbinder</transport>
-        <version>2.1</version>
-        <interface>
-            <name>IBiometricsFingerprint</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.bluetooth</name>
         <transport>hwbinder</transport>
         <version>1.0</version>


### PR DESCRIPTION
Move the FPC HAL to its own project VINTF fragment. This
will allow us to avoid duplicating code and, for example,
exclude the FPC module from the build using a single flag.

The change from [FPC PR](https://github.com/sonyxperiadev/vendor-sony-oss-fingerprint/pull/78) has been applied to the master branch,
which is used starting from the `s-mr1` branch. For `s-mr1` and `t-mr1`,
I submitted this separate pull request. Since the VINTF structure has
changed significantly starting with the `u-mr1` branch, the patch is
simply incompatible.