### PR TITLE
[u-mr1] common-treble: Switch NXP NFC HAL to AIDL

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -160,9 +160,6 @@ DEVICE_MATRIX_FILE   += $(COMMON_PATH)/vintf/compatibility_matrix.xml
 # Framework compatibility matrix that contains framework HALs as a vendor extension
 DEVICE_PRODUCT_COMPATIBILITY_MATRIX_FILE += $(COMMON_PATH)/vintf/$(SOMC_KERNEL_VERSION)/framework_compatibility_matrix.xml
 
-# Custom NXP NFC vendor interface
-DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/vendor.nxp.nxpnfc.xml
-
 # SIM secure element, SIM1/SIM2
 ifeq ($(PRODUCT_DEVICE_DS),true)
 DEVICE_MANIFEST_FILE += $(COMMON_PATH)/vintf/android.hardware.secure_element_ds.xml

--- a/common-treble.mk
+++ b/common-treble.mk
@@ -77,7 +77,7 @@ PRODUCT_PACKAGES += \
 
 # NFC packages
 PRODUCT_PACKAGES += \
-    android.hardware.nfc@1.2-service
+    android.hardware.nfc-service.nxp
 
 # GNSS
 PRODUCT_PACKAGES += \

--- a/vintf/4.19/framework_compatibility_matrix.xml
+++ b/vintf/4.19/framework_compatibility_matrix.xml
@@ -71,9 +71,9 @@
             <instance>default</instance>
         </interface>
     </hal>
-    <hal format="hidl">
-        <name>vendor.nxp.nxpnfc</name>
-        <version>1.0</version>
+    <hal format="aidl">
+        <name>vendor.nxp.nxpnfc_aidl</name>
+        <version>1</version>
         <interface>
             <name>INxpNfc</name>
             <instance>default</instance>

--- a/vintf/4.19/manifest.xml
+++ b/vintf/4.19/manifest.xml
@@ -72,15 +72,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.nfc</name>
-        <transport>hwbinder</transport>
-        <version>1.2</version>
-        <interface>
-            <name>INfc</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.power</name>
         <transport>hwbinder</transport>
         <version>1.3</version>

--- a/vintf/5.10/framework_compatibility_matrix.xml
+++ b/vintf/5.10/framework_compatibility_matrix.xml
@@ -136,9 +136,9 @@
             <instance>default</instance>
         </interface>
     </hal>
-    <hal format="hidl">
-        <name>vendor.nxp.nxpnfc</name>
-        <version>1.0</version>
+    <hal format="aidl">
+        <name>vendor.nxp.nxpnfc_aidl</name>
+        <version>1</version>
         <interface>
             <name>INxpNfc</name>
             <instance>default</instance>

--- a/vintf/5.10/manifest.xml
+++ b/vintf/5.10/manifest.xml
@@ -72,15 +72,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.nfc</name>
-        <transport>hwbinder</transport>
-        <version>1.2</version>
-        <interface>
-            <name>INfc</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.power</name>
         <transport>hwbinder</transport>
         <version>1.3</version>

--- a/vintf/5.15/framework_compatibility_matrix.xml
+++ b/vintf/5.15/framework_compatibility_matrix.xml
@@ -144,9 +144,9 @@
             <instance>default</instance>
         </interface>
     </hal>
-    <hal format="hidl">
-        <name>vendor.nxp.nxpnfc</name>
-        <version>1.0</version>
+    <hal format="aidl">
+        <name>vendor.nxp.nxpnfc_aidl</name>
+        <version>1</version>
         <interface>
             <name>INxpNfc</name>
             <instance>default</instance>

--- a/vintf/5.15/manifest.xml
+++ b/vintf/5.15/manifest.xml
@@ -72,15 +72,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.nfc</name>
-        <transport>hwbinder</transport>
-        <version>1.2</version>
-        <interface>
-            <name>INfc</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.power</name>
         <transport>hwbinder</transport>
         <version>1.3</version>

--- a/vintf/5.4/framework_compatibility_matrix.xml
+++ b/vintf/5.4/framework_compatibility_matrix.xml
@@ -152,9 +152,9 @@
             <instance>default</instance>
         </interface>
     </hal>
-    <hal format="hidl">
-        <name>vendor.nxp.nxpnfc</name>
-        <version>1.0</version>
+    <hal format="aidl">
+        <name>vendor.nxp.nxpnfc_aidl</name>
+        <version>1</version>
         <interface>
             <name>INxpNfc</name>
             <instance>default</instance>

--- a/vintf/5.4/manifest.xml
+++ b/vintf/5.4/manifest.xml
@@ -72,15 +72,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.nfc</name>
-        <transport>hwbinder</transport>
-        <version>1.2</version>
-        <interface>
-            <name>INfc</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.power</name>
         <transport>hwbinder</transport>
         <version>1.3</version>

--- a/vintf/vendor.nxp.nxpnfc.xml
+++ b/vintf/vendor.nxp.nxpnfc.xml
@@ -1,7 +1,0 @@
-<manifest version="1.0" type="device">
-    <hal format="hidl">
-        <name>vendor.nxp.nxpnfc</name>
-        <transport>hwbinder</transport>
-        <fqname>@1.0::INxpNfc/default</fqname>
-    </hal>
-</manifest>


### PR DESCRIPTION
The new AIDL HAL covers the entire list of NXP NFC chips,
from PN547C2 to SN300U, meeting all our needs.

It is possible that the Yodo platform will need to fork the
latest version of NXP NFC HAL due to the new dynamic
protection control feature, but all devices from Seine to
Nagara platform are working perfectly.