### PR TITLE
[u-mr1] common: Do not provide generic audio policy volumes

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -167,7 +167,6 @@ PRODUCT_COPY_FILES += \
 # Audio Configuration
 PRODUCT_COPY_FILES += \
     $(COMMON_PATH)/rootdir/vendor/etc/audio_effects.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_effects.xml \
-    frameworks/av/services/audiopolicy/config/audio_policy_volumes.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_volumes.xml \
     frameworks/av/services/audiopolicy/config/bluetooth_audio_policy_configuration_7_0.xml:$(TARGET_COPY_OUT_VENDOR)/etc/bluetooth_audio_policy_configuration_7_0.xml \
     frameworks/av/services/audiopolicy/config/default_volume_tables.xml:$(TARGET_COPY_OUT_VENDOR)/etc/default_volume_tables.xml \
     frameworks/av/services/audiopolicy/config/r_submix_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/r_submix_audio_policy_configuration.xml \


### PR DESCRIPTION
Audio policy volumes are tuned for each device individually,
so we cannot provide a generic version. On some devices, the
values may differ from the generic version by a few units,
which is completely unnoticeable, while on others, the values
may vary by 1.5-2 times, which could potentially damage the
speaker.