### PR TITLE
[u-mr1] Fix RIL for Nagara platform

### DIFF
--- a/vintf/5.15/android.hardware.radio.config.xml
+++ b/vintf/5.15/android.hardware.radio.config.xml
@@ -2,6 +2,11 @@
     <hal format="hidl">
         <name>android.hardware.radio.config</name>
         <transport>hwbinder</transport>
-        <fqname>@1.1::IRadioConfig/default</fqname>
+        <fqname>@1.3::IRadioConfig/default</fqname>
     </hal>
+    <hal format="aidl">
+         <name>vendor.qti.hardware.radio.qtiradioconfig</name>
+         <version>2</version>
+         <fqname>IQtiRadioConfig/default</fqname>
+     </hal>
 </manifest>

--- a/vintf/5.15/android.hw.qcradio_ds.xml
+++ b/vintf/5.15/android.hw.qcradio_ds.xml
@@ -4,7 +4,7 @@
         <transport>hwbinder</transport>
         <fqname>@1.2::ISap/slot1</fqname>
         <fqname>@1.2::ISap/slot2</fqname>
-        <fqname>@1.5::IRadio/slot1</fqname>
-        <fqname>@1.5::IRadio/slot2</fqname>
+        <fqname>@1.6::IRadio/slot1</fqname>
+        <fqname>@1.6::IRadio/slot2</fqname>
     </hal>
 </manifest>

--- a/vintf/5.15/framework_compatibility_matrix.xml
+++ b/vintf/5.15/framework_compatibility_matrix.xml
@@ -49,7 +49,7 @@
     </hal>
     <hal format="hidl">
         <name>android.hardware.radio</name>
-        <version>1.5</version>
+        <version>1.6</version>
         <interface>
             <name>IRadio</name>
             <instance>slot1</instance>
@@ -58,7 +58,7 @@
     </hal>
     <hal format="hidl">
         <name>android.hardware.radio.config</name>
-        <version>1.1</version>
+        <version>1.3</version>
         <interface>
             <name>IRadioConfig</name>
             <instance>default</instance>
@@ -179,7 +179,7 @@
     </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.data.iwlan</name>
-        <version>1.0</version>
+        <version>1.1</version>
         <interface>
             <name>IIWlan</name>
             <instance>slot1</instance>
@@ -259,9 +259,9 @@
             <instance>slot2</instance>
         </interface>
     </hal>
-    <hal format="hidl">
+    <hal format="aidl">
         <name>vendor.qti.hardware.radio.ims</name>
-        <version>1.7</version>
+        <version>12</version>
         <interface>
             <name>IImsRadio</name>
             <instance>imsradio0</instance>
@@ -278,7 +278,7 @@
     </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.lpa</name>
-        <version>1.1-2</version>
+        <version>1.2</version>
         <interface>
             <name>IUimLpa</name>
             <instance>UimLpa0</instance>
@@ -296,7 +296,7 @@
     </hal>
     <hal format="aidl">
         <name>vendor.qti.hardware.radio.qtiradio</name>
-        <version>4</version>
+        <version>8</version>
         <interface>
             <name>IQtiRadioStable</name>
             <instance>slot1</instance>
@@ -306,13 +306,21 @@
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.qtiradio</name>
         <version>1.0</version>
-        <version>2.7</version>
+        <version>2.6</version>
         <interface>
             <name>IQtiRadio</name>
             <instance>slot1</instance>
             <instance>slot2</instance>
         </interface>
     </hal>
+    <hal format="aidl">
+         <name>vendor.qti.hardware.radio.qtiradioconfig</name>
+         <version>2</version>
+         <interface>
+             <name>IQtiRadioConfig</name>
+             <instance>default</instance>
+         </interface>
+     </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.uim</name>
         <version>1.2</version>
@@ -370,14 +378,6 @@
         <version>1.1</version>
         <interface>
             <name>IQesdhal</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
-        <name>vendor.qti.spu</name>
-        <version>1.0</version>
-        <interface>
-            <name>ISPUManager</name>
             <instance>default</instance>
         </interface>
     </hal>

--- a/vintf/5.15/vendor.hw.qtiradio_ds.xml
+++ b/vintf/5.15/vendor.hw.qtiradio_ds.xml
@@ -1,8 +1,16 @@
 <manifest version="1.0" type="device">
     <hal format="aidl">
         <name>vendor.qti.hardware.radio.qtiradio</name>
-        <version>4</version>
+        <version>8</version>
         <fqname>IQtiRadioStable/slot1</fqname>
         <fqname>IQtiRadioStable/slot2</fqname>
     </hal>
+    <hal format="hidl">
+         <name>vendor.qti.hardware.radio.qtiradio</name>
+         <transport>hwbinder</transport>
+         <fqname>@1.0::IQtiRadio/slot1</fqname>
+         <fqname>@1.0::IQtiRadio/slot2</fqname>
+         <fqname>@2.6::IQtiRadio/slot1</fqname>
+         <fqname>@2.6::IQtiRadio/slot2</fqname>
+     </hal>
 </manifest>

--- a/vintf/5.15/vendor.hw.qtiradio_ss.xml
+++ b/vintf/5.15/vendor.hw.qtiradio_ss.xml
@@ -1,7 +1,13 @@
 <manifest version="1.0" type="device">
     <hal format="aidl">
         <name>vendor.qti.hardware.radio.qtiradio</name>
-        <version>4</version>
+        <version>8</version>
         <fqname>IQtiRadioStable/slot1</fqname>
     </hal>
+    <hal format="hidl">
+         <name>vendor.qti.hardware.radio.qtiradio</name>
+         <transport>hwbinder</transport>
+         <fqname>@1.0::IQtiRadio/slot1</fqname>
+         <fqname>@2.6::IQtiRadio/slot1</fqname>
+     </hal>
 </manifest>

--- a/vintf/5.15/vendor.hw.radio.ims.xml
+++ b/vintf/5.15/vendor.hw.radio.ims.xml
@@ -1,8 +1,8 @@
 <manifest version="1.0" type="device">
-    <hal format="hidl">
+    <hal format="aidl">
         <name>vendor.qti.hardware.radio.ims</name>
-        <transport>hwbinder</transport>
-        <fqname>@1.7::IImsRadio/imsradio0</fqname>
-        <fqname>@1.7::IImsRadio/imsradio1</fqname>
+        <version>12</version>
+        <fqname>IImsRadio/imsradio0</fqname>
+        <fqname>IImsRadio/imsradio1</fqname>
     </hal>
 </manifest>

--- a/vintf/5.15/vendor.hw.radio_ds.xml
+++ b/vintf/5.15/vendor.hw.radio_ds.xml
@@ -8,8 +8,8 @@
     <hal format="hidl">
         <name>vendor.qti.hardware.data.iwlan</name>
         <transport>hwbinder</transport>
-        <fqname>@1.0::IIWlan/slot1</fqname>
-        <fqname>@1.0::IIWlan/slot2</fqname>
+        <fqname>@1.1::IIWlan/slot1</fqname>
+        <fqname>@1.1::IIWlan/slot2</fqname>
     </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.am</name>
@@ -20,26 +20,14 @@
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.lpa</name>
         <transport>hwbinder</transport>
-        <fqname>@1.1::IUimLpa/UimLpa0</fqname>
-        <fqname>@1.1::IUimLpa/UimLpa1</fqname>
+        <fqname>@1.2::IUimLpa/UimLpa0</fqname>
+        <fqname>@1.2::IUimLpa/UimLpa1</fqname>
     </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.qcrilhook</name>
         <transport>hwbinder</transport>
         <fqname>@1.0::IQtiOemHook/oemhook0</fqname>
         <fqname>@1.0::IQtiOemHook/oemhook1</fqname>
-    </hal>
-    <hal format="hidl">
-        <name>vendor.qti.hardware.radio.qtiradio</name>
-        <transport>hwbinder</transport>
-        <fqname>@1.0::IQtiRadio/slot1</fqname>
-        <fqname>@1.0::IQtiRadio/slot2</fqname>
-    </hal>
-    <hal format="hidl">
-        <name>vendor.qti.hardware.radio.qtiradio</name>
-        <transport>hwbinder</transport>
-        <fqname>@2.7::IQtiRadio/slot1</fqname>
-        <fqname>@2.7::IQtiRadio/slot2</fqname>
     </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.uim</name>

--- a/vintf/5.15/vendor.hw.radio_ss.xml
+++ b/vintf/5.15/vendor.hw.radio_ss.xml
@@ -25,16 +25,6 @@
         <fqname>@1.0::IQtiOemHook/oemhook0</fqname>
     </hal>
     <hal format="hidl">
-        <name>vendor.qti.hardware.radio.qtiradio</name>
-        <transport>hwbinder</transport>
-        <fqname>@1.0::IQtiRadio/slot1</fqname>
-    </hal>
-    <hal format="hidl">
-        <name>vendor.qti.hardware.radio.qtiradio</name>
-        <transport>hwbinder</transport>
-        <fqname>@2.6::IQtiRadio/slot1</fqname>
-    </hal>
-    <hal format="hidl">
         <name>vendor.qti.hardware.radio.uim</name>
         <transport>hwbinder</transport>
         <fqname>@1.2::IUim/Uim0</fqname>


### PR DESCRIPTION
Sync entries with the latest ODM release and OSS configuration.

The configuration is compatible with upcoming ODM and fixes RIL on the Nagara platform,
unfortunately it is probably incompatible with the Yodo platform. In the future we will return
to this when Yodo gets the necessary blobs and the Nagara platform synchronizes with them
since it was ported to the same kernel version.

Fixes: https://github.com/sonyxperiadev/bug_tracker/issues/847, fixes: https://github.com/sonyxperiadev/bug_tracker/issues/860