### PR TITLE
[u-mr1] common-treble: Add android.hardware.secure_element-service.nxp

### DIFF
--- a/common-treble.mk
+++ b/common-treble.mk
@@ -23,7 +23,6 @@ PRODUCT_PACKAGES += \
     android.hardware.radio@1.6.vendor \
     android.hardware.radio.config@1.3.vendor \
     android.hardware.radio.deprecated@1.0.vendor \
-    android.hardware.secure_element@1.2.vendor \
     android.hardware.radio.config-V1-ndk.vendor \
     android.hardware.radio.messaging-V1-ndk.vendor \
     android.hardware.radio.modem-V1-ndk.vendor \
@@ -31,6 +30,11 @@ PRODUCT_PACKAGES += \
     android.hardware.radio.sim-V1-ndk.vendor \
     android.hardware.radio.voice-V1-ndk.vendor \
     android.hardware.radio-V1-ndk.vendor
+
+# Secure Element
+PRODUCT_PACKAGES += \
+    android.hardware.secure_element-service.nxp \
+    android.hardware.secure_element@1.2.vendor
 
 # netmgrd
 PRODUCT_PACKAGES += \

--- a/vintf/5.4/framework_compatibility_matrix.xml
+++ b/vintf/5.4/framework_compatibility_matrix.xml
@@ -334,6 +334,14 @@
         </interface>
     </hal>
     <hal format="hidl">
+        <name>vendor.qti.qesdhal</name>
+        <version>1.1</version>
+        <interface>
+            <name>IQesdhal</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+    <hal format="hidl">
         <name>vendor.qti.spu</name>
         <version>1.0</version>
         <interface>


### PR DESCRIPTION
Provide the android.hardware.secure_element-service.nxp service in order to have the
ability to communicate with Secure Element hardware (eUICC, for example).

The eSIM functionality was tested on the Nagara and Columbia platforms using OpenEUICC.
Please note that LPA is mandatory for the eSIM functionality to work, so it will not work on "pure"
AOSP. The OSS alternative for EuiccGoogle is OpenEUICC.

<details>
  <summary>Screenshot</summary>
  <img src="https://github.com/user-attachments/assets/f734d914-30ac-450f-98f2-d78d0bdbd997" width="400">
</details>
