### PR TITLE
[u-mr1] vintf: 5.4: Sync with the v6+ ODM release

### DIFF
--- a/vintf/5.4/android.hardware.radio.config.xml
+++ b/vintf/5.4/android.hardware.radio.config.xml
@@ -2,6 +2,11 @@
     <hal format="hidl">
         <name>android.hardware.radio.config</name>
         <transport>hwbinder</transport>
-        <fqname>@1.1::IRadioConfig/default</fqname>
+        <fqname>@1.3::IRadioConfig/default</fqname>
+    </hal>
+    <hal format="aidl">
+        <name>vendor.qti.hardware.radio.qtiradioconfig</name>
+        <version>2</version>
+        <fqname>IQtiRadioConfig/default</fqname>
     </hal>
 </manifest>

--- a/vintf/5.4/android.hw.qcradio_ds.xml
+++ b/vintf/5.4/android.hw.qcradio_ds.xml
@@ -4,7 +4,7 @@
         <transport>hwbinder</transport>
         <fqname>@1.2::ISap/slot1</fqname>
         <fqname>@1.2::ISap/slot2</fqname>
-        <fqname>@1.5::IRadio/slot1</fqname>
-        <fqname>@1.5::IRadio/slot2</fqname>
+        <fqname>@1.6::IRadio/slot1</fqname>
+        <fqname>@1.6::IRadio/slot2</fqname>
     </hal>
 </manifest>

--- a/vintf/5.4/android.hw.qcradio_ss.xml
+++ b/vintf/5.4/android.hw.qcradio_ss.xml
@@ -3,6 +3,6 @@
         <name>android.hardware.radio</name>
         <transport>hwbinder</transport>
         <fqname>@1.2::ISap/slot1</fqname>
-        <fqname>@1.5::IRadio/slot1</fqname>
+        <fqname>@1.6::IRadio/slot1</fqname>
     </hal>
 </manifest>

--- a/vintf/5.4/framework_compatibility_matrix.xml
+++ b/vintf/5.4/framework_compatibility_matrix.xml
@@ -55,15 +55,6 @@
             <instance>default</instance>
         </interface>
     </hal>
-    <hal format="hidl">
-        <name>android.hardware.radio</name>
-        <version>1.5</version>
-        <interface>
-            <name>IRadio</name>
-            <instance>slot1</instance>
-            <instance>slot2</instance>
-        </interface>
-    </hal>
     <hal format="aidl">
         <name>android.hardware.wifi</name>
         <version>2</version>
@@ -110,14 +101,6 @@
         <interface>
             <name>IUceService</name>
             <instance>com.qualcomm.qti.uceservice</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
-        <name>com.quicinc.cne.api</name>
-        <version>1.1</version>
-        <interface>
-            <name>IApiService</name>
-            <instance>cnd</instance>
         </interface>
     </hal>
     <hal format="hidl">
@@ -237,9 +220,9 @@
             <instance>slot2</instance>
         </interface>
     </hal>
-    <hal format="hidl">
+    <hal format="aidl">
         <name>vendor.qti.hardware.radio.ims</name>
-        <version>1.7</version>
+        <version>12</version>
         <interface>
             <name>IImsRadio</name>
             <instance>imsradio0</instance>
@@ -272,14 +255,31 @@
             <instance>oemhook1</instance>
         </interface>
     </hal>
+    <hal format="aidl">
+        <name>vendor.qti.hardware.radio.qtiradio</name>
+        <version>8</version>
+        <interface>
+            <name>IQtiRadioStable</name>
+            <instance>slot1</instance>
+            <instance>slot2</instance>
+        </interface>
+    </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.qtiradio</name>
         <version>1.0</version>
-        <version>2.7</version>
+        <version>2.6</version>
         <interface>
             <name>IQtiRadio</name>
             <instance>slot1</instance>
             <instance>slot2</instance>
+        </interface>
+    </hal>
+    <hal format="aidl">
+        <name>vendor.qti.hardware.radio.qtiradioconfig</name>
+        <version>2</version>
+        <interface>
+            <name>IQtiRadioConfig</name>
+            <instance>default</instance>
         </interface>
     </hal>
     <hal format="hidl">

--- a/vintf/5.4/vendor.hw.qtiradio_ds.xml
+++ b/vintf/5.4/vendor.hw.qtiradio_ds.xml
@@ -1,10 +1,16 @@
 <manifest version="1.0" type="device">
+    <hal format="aidl">
+        <name>vendor.qti.hardware.radio.qtiradio</name>
+        <version>8</version>
+        <fqname>IQtiRadioStable/slot1</fqname>
+        <fqname>IQtiRadioStable/slot2</fqname>
+    </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.qtiradio</name>
         <transport>hwbinder</transport>
         <fqname>@1.0::IQtiRadio/slot1</fqname>
         <fqname>@1.0::IQtiRadio/slot2</fqname>
-        <fqname>@2.7::IQtiRadio/slot1</fqname>
-        <fqname>@2.7::IQtiRadio/slot2</fqname>
+        <fqname>@2.6::IQtiRadio/slot1</fqname>
+        <fqname>@2.6::IQtiRadio/slot2</fqname>
     </hal>
 </manifest>

--- a/vintf/5.4/vendor.hw.qtiradio_ss.xml
+++ b/vintf/5.4/vendor.hw.qtiradio_ss.xml
@@ -1,8 +1,13 @@
 <manifest version="1.0" type="device">
+    <hal format="aidl">
+        <name>vendor.qti.hardware.radio.qtiradio</name>
+        <version>8</version>
+        <fqname>IQtiRadioStable/slot1</fqname>
+    </hal>
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.qtiradio</name>
         <transport>hwbinder</transport>
         <fqname>@1.0::IQtiRadio/slot1</fqname>
-        <fqname>@2.7::IQtiRadio/slot1</fqname>
+        <fqname>@2.6::IQtiRadio/slot1</fqname>
     </hal>
 </manifest>

--- a/vintf/5.4/vendor.hw.radio.ims.xml
+++ b/vintf/5.4/vendor.hw.radio.ims.xml
@@ -1,8 +1,8 @@
 <manifest version="1.0" type="device">
-    <hal format="hidl">
+    <hal format="aidl">
         <name>vendor.qti.hardware.radio.ims</name>
-        <transport>hwbinder</transport>
-        <fqname>@1.7::IImsRadio/imsradio0</fqname>
-        <fqname>@1.7::IImsRadio/imsradio1</fqname>
+        <version>12</version>
+        <fqname>IImsRadio/imsradio0</fqname>
+        <fqname>IImsRadio/imsradio1</fqname>
     </hal>
 </manifest>


### PR DESCRIPTION
Sync entries with the v6+ ODM release.

`libdsutils` requires a patch to work on Blair targets, otherwise netmgrd won't work.
The library from the v5 release works fine