### PR TITLE
[v-mr1] etc: init.common.rc: Let the AOSP system decide when to start netd

### DIFF
--- a/rootdir/vendor/etc/init/hw/init.common.rc
+++ b/rootdir/vendor/etc/init/hw/init.common.rc
@@ -129,9 +129,6 @@ on late-fs
     mount_all /vendor/etc/fstab.${ro.hardware} --late
 
 on post-fs-data
-    # We can start netd here before in is launched in common init.rc on zygote-start
-    start netd
-
     # Create directory used by bluetooth subsystem
     mkdir /data/vendor/bluetooth 2770 bluetooth bluetooth
 


### PR DESCRIPTION
A new trigger bpf-progs-loaded was added to AOSP system
core init.rc[1], which ensures that BPF has been mounted,
and the BPF loader initialized, and everything is ready for
the netd service to start. Otherwise, it would start too
early and result in a crash.

[1] https://android.googlesource.com/platform/system/core/+/refs/tags/android-15.0.0_r36/rootdir/init.rc#1083