### PR TITLE
[v-mr1] common-prop: Add Dalvik heap configuration

### DIFF
--- a/common-prop.mk
+++ b/common-prop.mk
@@ -210,3 +210,8 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Look for vulkan.qcom.so instead of vulkan.$(BOARD_TARGET_PLATFORM).so
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.hardware.vulkan=adreno
+
+# Dalvik heap configuration for compatibility reasons, as
+# certain system components may still use one of the props.
+# Supply until it is supplied by AOSP.
+$(call inherit-product, frameworks/native/build/phone-xhdpi-6144-dalvik-heap.mk)


### PR DESCRIPTION
Even though ART had replaced Dalvik as the primary runtime
many years ago, for compatibility reasons, since some
system components may still rely on these properties, the
last available configuration provided by AOSP for devices
with 6 GB of RAM will be inherited here. This applies to
all our current supported devices, as they all have at
least 6 GB of RAM or more.