### PR TITLE
[v-mr1] overlay: Add RilResCommon overlay

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -64,7 +64,16 @@ DEVICE_PACKAGE_OVERLAYS += $(COMMON_PATH)/overlay
 
 PRODUCT_ENFORCE_RRO_TARGETS := *
 
-# Wifi
+# Telephony overlay
+ifeq ($(PRODUCT_DEVICE_DS),true)
+PRODUCT_PACKAGES += \
+    RilResCommon-DS
+else
+PRODUCT_PACKAGES += \
+    RilResCommon-SS
+endif
+
+# Wifi overlay
 PRODUCT_PACKAGES += \
     WifiResCommon
 

--- a/overlay/RilResCommon-DS/Android.bp
+++ b/overlay/RilResCommon-DS/Android.bp
@@ -1,0 +1,5 @@
+runtime_resource_overlay {
+    name: "RilResCommon-DS",
+    sdk_version: "current",
+    vendor: true
+}

--- a/overlay/RilResCommon-DS/AndroidManifest.xml
+++ b/overlay/RilResCommon-DS/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="android.platform.overlay"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <application android:hasCode="false" />
+    <overlay
+      android:targetPackage="android"
+      android:isStatic="true"
+      android:priority="0"/>
+</manifest>

--- a/overlay/RilResCommon-DS/res/values/config.xml
+++ b/overlay/RilResCommon-DS/res/values/config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     SPDX-License-Identifier: Apache-2.0
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Number of physical SIM slots on the device. This includes both eSIM and pSIM slots, and
+         is not necessarily the same as the number of phones/logical modems supported by the device.
+         For example, a multi-sim device can have 2 phones/logical modems, but 3 physical slots,
+         or a single SIM device can have 1 phones/logical modems, but 2 physical slots (one eSIM
+         and one pSIM) -->
+    <integer name="config_num_physical_slots">2</integer>
+</resources>

--- a/overlay/RilResCommon-SS/Android.bp
+++ b/overlay/RilResCommon-SS/Android.bp
@@ -1,0 +1,5 @@
+runtime_resource_overlay {
+    name: "RilResCommon-SS",
+    sdk_version: "current",
+    vendor: true
+}

--- a/overlay/RilResCommon-SS/AndroidManifest.xml
+++ b/overlay/RilResCommon-SS/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="android.platform.overlay"
+    android:versionCode="1"
+    android:versionName="1.0">
+    <application android:hasCode="false" />
+    <overlay
+      android:targetPackage="android"
+      android:isStatic="true"
+      android:priority="0"/>
+</manifest>

--- a/overlay/RilResCommon-SS/res/values/config.xml
+++ b/overlay/RilResCommon-SS/res/values/config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     SPDX-License-Identifier: Apache-2.0
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Number of physical SIM slots on the device. This includes both eSIM and pSIM slots, and
+         is not necessarily the same as the number of phones/logical modems supported by the device.
+         For example, a multi-sim device can have 2 phones/logical modems, but 3 physical slots,
+         or a single SIM device can have 1 phones/logical modems, but 2 physical slots (one eSIM
+         and one pSIM) -->
+    <integer name="config_num_physical_slots">1</integer>
+</resources>


### PR DESCRIPTION
The number of physical SIM slots was previously determined at
runtime[1], but now it must be explicitly specified using the
config_num_physical_slots property. If this value is not set,
the RIL will not initialize at all.

It looks like AOSP has brought back the fallback detection
mechanism in future revisions [2], but it’s better to specify
the value explicitly.

[1] https://android.googlesource.com/platform/frameworks/opt/telephony/+/42e37234cee15c9f3fcfac0532110abfc8843b99
[2] https://android.googlesource.com/platform/frameworks/opt/telephony/+/44e3dbf3d30e89e693f2573500cb80b68fb39492