### PR TITLE
[android-16] common-packages: Provide libjsoncpp on vendor

### DIFF
--- a/common-packages.mk
+++ b/common-packages.mk
@@ -80,6 +80,10 @@ PRODUCT_PACKAGES += \
     libOmxVdecHevc \
     libOmxVenc
 
+# C2 dependencies
+PRODUCT_PACKAGES += \
+    libjsoncpp.vendor
+
 # GPS
 PRODUCT_PACKAGES += \
     batching.conf \
@@ -135,7 +139,7 @@ PRODUCT_PACKAGES += \
 # OSS Time service
 PRODUCT_PACKAGES += \
     timekeep \
-    TimeKeep \
+    TimeKeep
 
 # OSS WIFI and BT MAC tool
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
E vendor.qti.media.c2@1.0-service: QC2HALService:
failed to open libqcodec2_core.so: dlopen failed:
library "libjsoncpp.so" not found: needed by /odm/lib64/libqcodec2_platform.so in namespace (default)