### PR TITLE
[t-mr1] CommonConfig: Set BUILD_KERNEL to false by default

### DIFF
--- a/CommonConfig.mk
+++ b/CommonConfig.mk
@@ -133,7 +133,7 @@ WITH_DEXPREOPT_BOOT_IMG_AND_SYSTEM_SERVER_ONLY ?= true
 # May be overriden by KernelConfig.mk if prebuilt kernel present.
 # Can also be turned off in Customization.mk in case it is desired to use a
 # custom ROM's kernel build system, e.g. LineageOS' or PE's.
-BUILD_KERNEL ?= true
+BUILD_KERNEL ?= false
 
 -include $(KERNEL_PATH)/common-kernel/KernelConfig.mk
 


### PR DESCRIPTION
The project uses a prebuilt kernel, so the `BUILD_KERNEL` flag
should be set to false by default. Forks override the flag in
`customization.mk` if necessary, rather than the other way around.

This change should also be applied to the u-mr1 and v-mr1 branches,
which will allow us to update the external Makefiles while maintaining
backward compatibility.